### PR TITLE
Add getListItemIterator

### DIFF
--- a/packages/component-driver-html/src/components/HTMLSelectDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLSelectDriver.ts
@@ -27,24 +27,16 @@ export class HTMLSelectDriver extends ComponentDriver<{}> implements IInputDrive
     return true;
   }
 
-  async getOptionByIndex(index: number): Promise<HTMLOptionDriver | null> {
-    const itemLocatorBase = locatorUtil.append(this.locator, optionLocator);
-    return driverHelper.getListItemByIndex(this, itemLocatorBase, index, HTMLOptionDriver);
-  }
-
   async getValuesByLabels(labels: readonly string[]): Promise<readonly string[]> {
     const labelSet = new Set(labels);
-    let index = 0;
-    let item: HTMLOptionDriver | null = await this.getOptionByIndex(index);
     const values: string[] = [];
-    while (item != null) {
+    const itemLocatorBase = locatorUtil.append(this.locator, optionLocator);
+    for await (let item of driverHelper.getListItemIterator(this, itemLocatorBase, HTMLOptionDriver)) {
       const label = await item.label();
       const value = await item.value();
       if (label != null && labelSet.has(label) && value != null) {
         values.push(value);
       }
-      index++;
-      item = await this.getOptionByIndex(index);
     }
     return values;
   }

--- a/packages/component-driver-mui-v5/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/MenuDriver.ts
@@ -41,20 +41,12 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
     return LocatorRelativePosition.Same;
   }
 
-  async getMenuItemByIndex(index: number): Promise<MenuItemDriver | null> {
-    return driverHelper.getListItemByIndex(this, menuItemLocator, index, MenuItemDriver);
-  }
-
   async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {
-    let index = 0;
-    let item: MenuItemDriver | null = await this.getMenuItemByIndex(index);
-    while (item != null) {
+    for await (let item of driverHelper.getListItemIterator(this, menuItemLocator, MenuItemDriver)) {
       const itemLabel = await item.label();
       if (itemLabel === label) {
         return item;
       }
-      index++;
-      item = await this.getMenuItemByIndex(index);
     }
     return null;
   }

--- a/packages/component-driver-mui-v5/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/SelectDriver.ts
@@ -5,21 +5,21 @@ import {
   HTMLTextInputDriver,
 } from '@atomic-testing/component-driver-html';
 import {
-  byAttribute,
-  byRole,
-  byTagName,
   ComponentDriver,
-  driverHelper,
   IComponentDriverOption,
   IInputDriver,
   Interactor,
   LocatorChain,
   LocatorRelativePosition,
   LocatorType,
-  locatorUtil,
   Nullable,
   ScenePart,
   ScenePartDriver,
+  byAttribute,
+  byRole,
+  byTagName,
+  driverHelper,
+  locatorUtil,
 } from '@atomic-testing/core';
 
 import { MenuItemNotFoundError } from '../errors/MenuItemNotFoundError';
@@ -100,20 +100,12 @@ export class SelectDriver extends ComponentDriver<SelectScenePart> implements II
     return success;
   }
 
-  async getOptionByIndex(index: number): Promise<MenuItemDriver | null> {
-    return driverHelper.getListItemByIndex(this, optionLocator, index, MenuItemDriver);
-  }
-
   async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {
-    let index = 0;
-    let item: MenuItemDriver | null = await this.getOptionByIndex(index);
-    while (item != null) {
+    for await (let item of driverHelper.getListItemIterator(this, optionLocator, MenuItemDriver)) {
       const itemLabel = await item.label();
       if (itemLabel === label) {
         return item;
       }
-      index++;
-      item = await this.getOptionByIndex(index);
     }
     return null;
   }

--- a/packages/core/src/drivers/driverHelper.ts
+++ b/packages/core/src/drivers/driverHelper.ts
@@ -11,11 +11,12 @@ type ComponentDriverClass<T extends ComponentDriver> = new (
 ) => T;
 
 /**
- *
+ * Get list item driver within host by index.  List item is an indefinite number of items under the same host
+ * with similar characteristics defined by the itemLocatorBase.
  * @param host The component the list item is under
  * @param itemLocatorBase The locator of the list item without the index, the locator should already compound the host locator if needed
- * @param index
- * @param driverClass
+ * @param index The index of the list item
+ * @param driverClass The driver class of the list item
  * @returns
  */
 export async function getListItemByIndex<T extends ComponentDriver>(
@@ -35,4 +36,25 @@ export async function getListItemByIndex<T extends ComponentDriver>(
     return new driverClass(itemLocator, host.interactor, host.commutableOption);
   }
   return null;
+}
+
+/**
+ * Get an iterator of list item driver.
+ * List item is an indefinite number of items under the same host
+ * @param host The component the list item is under
+ * @param itemLocatorBase The locator of the list item without the index, the locator should already compound the host locator if needed
+ * @param driverClass The driver class of the list item
+ */
+export async function* getListItemIterator<T extends ComponentDriver>(
+  host: ComponentDriver<any>,
+  itemLocatorBase: LocatorChain | PartLocatorType,
+  driverClass: ComponentDriverClass<T>,
+): AsyncGenerator<T, void, unknown> {
+  let index = 0;
+  let item: T | null = await getListItemByIndex(host, itemLocatorBase, index, driverClass);
+  while (item != null) {
+    yield item;
+    index++;
+    item = await getListItemByIndex(host, itemLocatorBase, index, driverClass);
+  }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #142
* #141
* __->__ #140

Without iterator, iterating through list item often resort to the following boilerplate code

```TypeScript
let index = 0;
let item = await getListItemAtIdex( host, locator, index, FooDriver );
while (item != null) {
  // do work
  item++;
  item = await getListItemAtIdex( host, locator, index, FooDriver );
}
```

With iterator, the above is reduced to a simple for...of loop with improved readability

```TypeScript
for await (let item of getListItemIterator(host, locator, FooDriver) {
  // do work
}
```