### PR TITLE
MUI V5: Generalize base class for DatePicker (4/n)

### DIFF
--- a/packages/component-driver-mui-v5/src/components/datepicker/DatePickerDriverBase.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/DatePickerDriverBase.ts
@@ -1,0 +1,62 @@
+import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import {
+  ComponentDriver,
+  IComponentDriverOption,
+  IInputDriver,
+  Interactor,
+  PartLocator,
+  ScenePart,
+  byTagName,
+} from '@atomic-testing/core';
+import { DatePickerCharacteristic } from './types';
+
+const parts = {
+  dateInput: {
+    locator: byTagName('input'),
+    driver: HTMLTextInputDriver,
+  },
+} satisfies ScenePart;
+
+export abstract class DesktopDatePickerDriverBase
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<Date | null>
+{
+  constructor(
+    locator: PartLocator,
+    interactor: Interactor,
+    protected characteristic: DatePickerCharacteristic,
+    option?: Partial<IComponentDriverOption>,
+  ) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  async setValue(value: Date | null): Promise<boolean> {
+    await this.enforcePartExistence('dateInput');
+    let textToEnter = '';
+    if (value != null) {
+      const format = await this.getFormat();
+      textToEnter = this.characteristic.valueToTextEntry(value, format);
+    }
+    await this.interactor.enterText(this.parts.dateInput.locator, textToEnter);
+
+    return true;
+  }
+
+  async getValue(): Promise<Date | null> {
+    await this.enforcePartExistence('dateInput');
+    const value = await this.interactor.getInputValue(this.parts.dateInput.locator);
+    if (value != null) {
+      const format = await this.getFormat();
+      return this.characteristic.textEntryToValue(value, format);
+    }
+    return null;
+  }
+
+  async getFormat(defaultFormat: string = this.characteristic.defaultFormat): Promise<string> {
+    const placeHolder = await this.parts.dateInput.getAttribute('placeholder');
+    return placeHolder ?? defaultFormat;
+  }
+}

--- a/packages/component-driver-mui-v5/src/components/datepicker/DesktopDatePickerDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/DesktopDatePickerDriver.ts
@@ -1,55 +1,16 @@
-import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
-import {
-  ComponentDriver,
-  IComponentDriverOption,
-  IInputDriver,
-  Interactor,
-  PartLocator,
-  ScenePart,
-  byTagName,
-} from '@atomic-testing/core';
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+import { DesktopDatePickerDriverBase } from './DatePickerDriverBase';
 import { dateToTextEntry, textEntryToDate } from './dateUtil';
+import { DatePickerCharacteristic } from './types';
 
-const parts = {
-  dateInput: {
-    locator: byTagName('input'),
-    driver: HTMLTextInputDriver,
-  },
-} satisfies ScenePart;
-
-export class DesktopDatePickerDriver extends ComponentDriver<typeof parts> implements IInputDriver<Date | null> {
+export class DesktopDatePickerDriver extends DesktopDatePickerDriverBase {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
-    super(locator, interactor, {
-      ...option,
-      parts,
-    });
-  }
-
-  async setValue(value: Date | null): Promise<boolean> {
-    await this.enforcePartExistence('dateInput');
-    let textToEnter = '';
-    if (value != null) {
-      const format = await this.getFormat();
-      textToEnter = dateToTextEntry(value, format);
-    }
-    await this.interactor.enterText(this.parts.dateInput.locator, textToEnter);
-
-    return true;
-  }
-
-  async getValue(): Promise<Date | null> {
-    await this.enforcePartExistence('dateInput');
-    const value = await this.interactor.getInputValue(this.parts.dateInput.locator);
-    if (value != null) {
-      const format = await this.getFormat();
-      return textEntryToDate(value, format);
-    }
-    return null;
-  }
-
-  async getFormat(defaultFormat: string = 'mm/dd/yyyy'): Promise<string> {
-    const placeHolder = await this.parts.dateInput.getAttribute('placeholder');
-    return placeHolder ?? defaultFormat;
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: dateToTextEntry,
+      textEntryToValue: textEntryToDate,
+      defaultFormat: 'mm/dd/yyyy',
+    };
+    super(locator, interactor, characteristic, option);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v5/src/components/datepicker/TimePickerDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/TimePickerDriver.ts
@@ -1,55 +1,16 @@
-import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
-import {
-  ComponentDriver,
-  IComponentDriverOption,
-  IInputDriver,
-  Interactor,
-  PartLocator,
-  ScenePart,
-  byTagName,
-} from '@atomic-testing/core';
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+import { DesktopDatePickerDriverBase } from './DatePickerDriverBase';
 import { textEntryToTime, timeToTextEntry } from './dateUtil';
+import { DatePickerCharacteristic } from './types';
 
-const parts = {
-  dateInput: {
-    locator: byTagName('input'),
-    driver: HTMLTextInputDriver,
-  },
-} satisfies ScenePart;
-
-export class TimePickerDriver extends ComponentDriver<typeof parts> implements IInputDriver<Date | null> {
+export class TimePickerDriver extends DesktopDatePickerDriverBase {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
-    super(locator, interactor, {
-      ...option,
-      parts,
-    });
-  }
-
-  async setValue(value: Date | null): Promise<boolean> {
-    await this.enforcePartExistence('dateInput');
-    let textToEnter = '';
-    if (value != null) {
-      const format = await this.getFormat();
-      textToEnter = timeToTextEntry(value, format);
-    }
-    await this.interactor.enterText(this.parts.dateInput.locator, textToEnter);
-
-    return true;
-  }
-
-  async getValue(): Promise<Date | null> {
-    await this.enforcePartExistence('dateInput');
-    const value = await this.interactor.getInputValue(this.parts.dateInput.locator);
-    if (value != null) {
-      const format = await this.getFormat();
-      return textEntryToTime(value, format);
-    }
-    return null;
-  }
-
-  async getFormat(defaultFormat: string = 'hh:mm (a|pm)'): Promise<string> {
-    const placeHolder = await this.parts.dateInput.getAttribute('placeholder');
-    return placeHolder ?? defaultFormat;
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: timeToTextEntry,
+      textEntryToValue: textEntryToTime,
+      defaultFormat: 'hh:mm (a|pm)',
+    };
+    super(locator, interactor, characteristic, option);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v5/src/components/datepicker/dateUtil.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/dateUtil.ts
@@ -21,7 +21,10 @@ export function dateToTextEntry(date: Date, format: string): string {
   return monthPart + datePart + yearPart;
 }
 
-export function textEntryToDate(text: string, format: string): Date {
+export function textEntryToDate(text: string, format: string): Date | null {
+  if (text.length < 6) {
+    return null;
+  }
   return new Date(text);
 }
 
@@ -30,7 +33,10 @@ export function timeToTextEntry(date: Date, format: string): string {
   return dayjs(date).format('hhmmA');
 }
 
-export function textEntryToTime(text: string, format: string): Date {
+export function textEntryToTime(text: string, format: string): Date | null {
+  if (text.length < 3) {
+    return null;
+  }
   const datePart = dayjs().format('YYYY-MM-DD');
   return new Date(`${datePart} ${text}`);
 }

--- a/packages/component-driver-mui-v5/src/components/datepicker/types.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/types.ts
@@ -1,0 +1,8 @@
+export interface DatePickerCharacteristic {
+  valueToTextEntry: (value: Date, format: string) => string;
+  textEntryToValue: (text: string, format: string) => Date | null;
+  /**
+   * Format hint displayed in the input field
+   */
+  defaultFormat: string;
+}


### PR DESCRIPTION
MUI V5: Generalize base class for DatePicker (4/n)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/166).
* #168
* #167
* __->__ #166