### PR TITLE
MUI V5: DatetimePicker Driver (5/n)

### DIFF
--- a/packages/component-driver-mui-v5-test/src/examples/datatimepicker/BasicDataTimePicker.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/datatimepicker/BasicDataTimePicker.examples.tsx
@@ -1,4 +1,5 @@
 import {
+  DateTimePickerDriver,
   DesktopDatePickerDriver,
   MobileDatePickerDriver,
   TimePickerDriver,
@@ -78,6 +79,10 @@ export const basicDatePickerExampleScenePart = {
     locator: byDataTestId('time-picker'),
     driver: TimePickerDriver,
   },
+  dateTimePicker: {
+    locator: byDataTestId('date-time-picker'),
+    driver: DateTimePickerDriver,
+  },
 } satisfies ScenePart;
 
 /**
@@ -122,7 +127,7 @@ export const basicDatePickerTestSuite: TestSuiteInfo<typeof basicDatePickerExamp
 
     describe('MobileDatePickerDriver', () => {
       test('Driver should set date correctly', async () => {
-        const date = new Date('2019/09/21');
+        const date = new Date('2018/09/21');
         await testEngine.parts.mobilePicker.setValue(date);
         const retrieved = await testEngine.parts.mobilePicker.getValue();
         assertEqual(retrieved?.toDateString(), date.toDateString());
@@ -131,7 +136,16 @@ export const basicDatePickerTestSuite: TestSuiteInfo<typeof basicDatePickerExamp
 
     describe('TimePickerDriver', () => {
       test('Driver should set time correctly', async () => {
-        const date = new Date('2019/09/21 00:18');
+        const date = new Date('2018/09/21 00:18');
+        await testEngine.parts.timePicker.setValue(date);
+        const retrieved = await testEngine.parts.timePicker.getValue();
+        assertEqual(retrieved?.toTimeString(), date.toTimeString());
+      });
+    });
+
+    describe('DateTimePickerDriver', () => {
+      test('Driver should set date/time correctly', async () => {
+        const date = new Date('2018/09/21 00:18');
         await testEngine.parts.timePicker.setValue(date);
         const retrieved = await testEngine.parts.timePicker.getValue();
         assertEqual(retrieved?.toTimeString(), date.toTimeString());

--- a/packages/component-driver-mui-v5/src/components/datepicker/DateTimePickerDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/DateTimePickerDriver.ts
@@ -1,0 +1,19 @@
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+import { DesktopDatePickerDriverBase } from './DatePickerDriverBase';
+import { dateTimeToTextEntry, textEntryToDateTime } from './dateUtil';
+import { DatePickerCharacteristic } from './types';
+
+export class DateTimePickerDriver extends DesktopDatePickerDriverBase {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: dateTimeToTextEntry,
+      textEntryToValue: textEntryToDateTime,
+      defaultFormat: 'mm/dd/yyyy hh:mm (a|pm)',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  get driverName(): string {
+    return 'MuiV5DateTimePicker';
+  }
+}

--- a/packages/component-driver-mui-v5/src/components/datepicker/dateUtil.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/dateUtil.ts
@@ -41,6 +41,18 @@ export function textEntryToTime(text: string, format: string): Date | null {
   return new Date(`${datePart} ${text}`);
 }
 
+export function dateTimeToTextEntry(date: Date, format: string): string {
+  return dayjs(date).format('YYYYMMDDhhmmA');
+}
+
+export function textEntryToDateTime(text: string, format: string): Date | null {
+  // assume YYYY/MM/DD hh:mm for now
+  if (text.length < 12) {
+    return null;
+  }
+  return new Date(text);
+}
+
 /**
  * Return numeric text with padding zero's to guarantee the number of digits
  * @param number

--- a/packages/component-driver-mui-v5/src/components/datepicker/index.ts
+++ b/packages/component-driver-mui-v5/src/components/datepicker/index.ts
@@ -1,5 +1,7 @@
+export * from './DateTimePickerDriver';
 export * from './DesktopDatePickerDriver';
 export * from './MobileDatePickerDialogDriver';
 export * from './MobileDatePickerDriver';
 export * from './TimePickerDriver';
 export * as dateUtil from './dateUtil';
+export * from './types';


### PR DESCRIPTION
MUI V5: DatetimePicker Driver (5/n)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/167).
* #168
* __->__ #167