### PR TITLE
Make dayjs dependency instead of peerDependency

### DIFF
--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",
-    "@atomic-testing/component-driver-html": "workspace:*"
+    "@atomic-testing/component-driver-html": "workspace:*",
+    "dayjs": "^1.11.10"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.2.0",
@@ -42,8 +43,5 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.0",
     "typescript": "^5.0.2"
-  },
-  "peerDependencies": {
-    "dayjs": ">=1.10.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       dayjs:
-        specifier: '>=1.10.0'
-        version: 1.11.7
+        specifier: ^1.11.10
+        version: 1.11.10
     devDependencies:
       '@testing-library/dom':
         specifier: ^9.2.0
@@ -6152,6 +6152,10 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
+  /dayjs@1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+    dev: false
+
   /dayjs@1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
     dev: false
@@ -7254,7 +7258,7 @@ packages:
     engines: {node: '>=8.3.0'}
     dependencies:
       archiver: 5.3.1
-      dayjs: 1.11.7
+      dayjs: 1.11.10
       fast-csv: 4.3.6
       jszip: 3.10.1
       readable-stream: 3.6.2


### PR DESCRIPTION
Make dayjs dependency instead of peerDependency

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/173).
* #174
* __->__ #173