### PR TITLE
Extend click event to support position

### DIFF
--- a/packages/component-driver-html-test/__tests__/MouseEvent.dom.test.ts
+++ b/packages/component-driver-html-test/__tests__/MouseEvent.dom.test.ts
@@ -1,10 +1,21 @@
 import { jestTestAdapter } from '@atomic-testing/jest';
 import { createTestEngine } from '@atomic-testing/react';
 import { testRunner } from '@atomic-testing/test-runner';
-import { hoverMouseEventExample, hoverMouseEventExampleTestSuite } from '../src/examples';
+import {
+  clickLocationMouseEventExample,
+  clickLocationMouseEventExampleTestSuite,
+  hoverMouseEventExample,
+  hoverMouseEventExampleTestSuite,
+} from '../src/examples';
 
 testRunner(hoverMouseEventExampleTestSuite, jestTestAdapter, {
   getTestEngine: (scenePart: typeof hoverMouseEventExample.scene) => {
     return createTestEngine(hoverMouseEventExample.ui, scenePart);
+  },
+});
+
+testRunner(clickLocationMouseEventExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof clickLocationMouseEventExample.scene) => {
+    return createTestEngine(clickLocationMouseEventExample.ui, scenePart);
   },
 });

--- a/packages/component-driver-html-test/__tests__/MouseEvent.e2e.test.ts
+++ b/packages/component-driver-html-test/__tests__/MouseEvent.e2e.test.ts
@@ -1,5 +1,6 @@
 import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
 import { testRunner } from '@atomic-testing/test-runner';
-import { hoverMouseEventExampleTestSuite } from '../src/examples';
+import { clickLocationMouseEventExampleTestSuite, hoverMouseEventExampleTestSuite } from '../src/examples';
 
 testRunner(hoverMouseEventExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());
+testRunner(clickLocationMouseEventExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/packages/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
+++ b/packages/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
@@ -1,0 +1,91 @@
+import { HTMLButtonDriver, HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import React, { useCallback } from 'react';
+
+export const ClickLocationMouseEventExample = () => {
+  const [clickX, setClickX] = React.useState<number | null>(null);
+  const [clickY, setClickY] = React.useState<number | null>(null);
+
+  const onClick = useCallback((evt: React.MouseEvent<HTMLDivElement>) => {
+    const rect = evt.currentTarget.getBoundingClientRect();
+    var x = evt.clientX - rect.left; //x position within the element.
+    var y = evt.clientY - rect.top; //y position within the element.
+    setClickX(x);
+    setClickY(y);
+  }, []);
+
+  return (
+    <React.Fragment>
+      <div
+        style={{ cursor: 'crosshair', backgroundColor: '#0099ff', width: '20rem', height: '12rem' }}
+        data-testid="click-target"
+        onClick={onClick}
+      ></div>
+      <p>
+        Click on <span data-testid="position-x">{clickX}</span>, <span data-testid="position-y">{clickY}</span>
+      </p>
+    </React.Fragment>
+  );
+};
+
+export const clickLocationMouseEventExampleScenePart = {
+  target: {
+    locator: byDataTestId('click-target'),
+    driver: HTMLButtonDriver,
+  },
+  xDisplay: {
+    locator: byDataTestId('position-x'),
+    driver: HTMLElementDriver,
+  },
+  yDisplay: {
+    locator: byDataTestId('position-y'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const clickLocationMouseEventExample: IExampleUnit<typeof clickLocationMouseEventExampleScenePart, JSX.Element> =
+  {
+    title: 'Click location',
+    scene: clickLocationMouseEventExampleScenePart,
+    ui: <ClickLocationMouseEventExample />,
+  };
+
+export const clickLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof clickLocationMouseEventExample.scene> = {
+  title: 'Mouse event: Click',
+  url: '/mouse-event',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${clickLocationMouseEventExample.title}`, () => {
+      let testEngine: TestEngine<typeof clickLocationMouseEventExample.scene>;
+
+      // Use the following beforeEach to work around the issue of Playwright's page being undefined
+      // @ts-ignore
+      beforeEach(function ({ page }) {
+        // @ts-ignore
+        testEngine = getTestEngine(clickLocationMouseEventExample.scene, { page });
+        if (typeof arguments[0] === 'function') {
+          arguments[0]();
+        }
+      });
+
+      afterEach(async () => {
+        await testEngine.cleanUp();
+      });
+
+      test('Click on somewhere in the target should display the correct coordinates', async () => {
+        await testEngine.parts.target.click({
+          position: {
+            x: 10,
+            y: 5,
+          },
+        });
+        const xDisplay = await testEngine.parts.xDisplay.getText();
+        const yDisplay = await testEngine.parts.yDisplay.getText();
+
+        // The coordinates are rounded because e2e tests are not pixel perfect
+        assertEqual(Math.round(parseFloat(xDisplay ?? '')), 10);
+        assertEqual(Math.round(parseFloat(yDisplay ?? '')), 5);
+      });
+    });
+  },
+};

--- a/packages/component-driver-html-test/src/examples/mouseEvent/index.ts
+++ b/packages/component-driver-html-test/src/examples/mouseEvent/index.ts
@@ -1,6 +1,15 @@
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { clickLocationMouseEventExample, clickLocationMouseEventExampleTestSuite } from './ClickLocation.examples';
 import { hoverMouseEventExample, hoverMouseEventExampleTestSuite } from './Hover.examples';
 
-export { hoverMouseEventExample, hoverMouseEventExampleTestSuite };
+export {
+  clickLocationMouseEventExample,
+  clickLocationMouseEventExampleTestSuite,
+  hoverMouseEventExample,
+  hoverMouseEventExampleTestSuite,
+};
 
-export const mouseEventExamples = [hoverMouseEventExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+export const mouseEventExamples = [hoverMouseEventExample, clickLocationMouseEventExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5/src/components/ListItemDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ListItemDriver.ts
@@ -25,7 +25,7 @@ export class ListItemDriver extends ComponentDriver {
       const label = await this.label();
       throw new MenuItemDisabledError(label ?? '', this);
     }
-    await this.interactor.click(this.locator, { bubble: true });
+    await this.interactor.click(this.locator);
   }
 
   get driverName(): string {

--- a/packages/core/src/geometry/Point.ts
+++ b/packages/core/src/geometry/Point.ts
@@ -1,0 +1,4 @@
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/packages/core/src/geometry/index.ts
+++ b/packages/core/src/geometry/index.ts
@@ -1,0 +1,1 @@
+export * from './Point';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type { Nullable, Optional } from './dataTypes';
 export * from './drivers';
 export * from './errors';
 export * from './example/types';
+export * from './geometry';
 export * from './interactor';
 export * from './locators/';
 export type {

--- a/packages/core/src/interactor/ClickOption.ts
+++ b/packages/core/src/interactor/ClickOption.ts
@@ -1,1 +1,10 @@
-export interface ClickOption {}
+import { Point } from '../geometry';
+
+export interface ClickOption {
+  /**
+   * A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of
+   * the element.
+   * Note that in end to end tests such as Playwright, mouse interaction location is not always pixel perfect.
+   */
+  position?: Point;
+}

--- a/packages/dom-core/src/fakeEvents/FakeMouseEvent.ts
+++ b/packages/dom-core/src/fakeEvents/FakeMouseEvent.ts
@@ -1,0 +1,13 @@
+/**
+ * Fake mouse event for testing.
+ * @see https://github.com/testing-library/react-testing-library/issues/268
+ */
+export class FakeMouseEvent extends MouseEvent {
+  constructor(type: string, overrides: Partial<MouseEvent> = {}) {
+    super(type, overrides);
+    Object.assign(this, {
+      pageX: overrides.pageX ?? 0,
+      pageY: overrides.pageY ?? 0,
+    });
+  }
+}

--- a/packages/dom-core/src/fakeEvents/index.ts
+++ b/packages/dom-core/src/fakeEvents/index.ts
@@ -1,0 +1,1 @@
+export * from './FakeMouseEvent';

--- a/packages/dom-core/src/index.ts
+++ b/packages/dom-core/src/index.ts
@@ -1,1 +1,2 @@
 export { DOMInteractor } from './DOMInteractor';
+export * from './fakeEvents';

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -73,7 +73,7 @@ export class PlaywrightInteractor implements Interactor {
 
   async click(locator: PartLocator, option?: ClickOption): Promise<void> {
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    await this.page.locator(cssLocator).click();
+    await this.page.locator(cssLocator).click({ position: option?.position });
   }
 
   async hover(locator: PartLocator): Promise<void> {

--- a/packages/react/src/ReactInteractor.ts
+++ b/packages/react/src/ReactInteractor.ts
@@ -1,9 +1,9 @@
-import { ClickOption, Interactor, PartLocator } from '@atomic-testing/core';
+import { ClickOption, EnterTextOption, Interactor, PartLocator } from '@atomic-testing/core';
 import { DOMInteractor } from '@atomic-testing/dom-core';
 import { act } from 'react-dom/test-utils';
 
 export class ReactInteractor extends DOMInteractor {
-  override async enterText(locator: PartLocator, text: string, option?: Partial<ClickOption>): Promise<void> {
+  override async enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void> {
     await act(async () => {
       await super.enterText(locator, text, option);
     });


### PR DESCRIPTION
Extend click event to support position

Enable mouse click event to support location where the mouse clicks.
