### PR TITLE
MUIV5: Change some drivers' base class to ComponentDriver

### DIFF
--- a/packages/component-driver-mui-v5/src/components/AccordionDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/AccordionDriver.ts
@@ -2,8 +2,8 @@ import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
 import {
   byCssClass,
   byRole,
-  ContainerDriver,
-  IContainerDriverOption,
+  ComponentDriver,
+  IComponentDriverOption,
   Interactor,
   PartLocator,
   ScenePart,
@@ -32,12 +32,11 @@ export const parts = {
  * Driver for Material UI v5 Accordion component.
  * @see https://mui.com/material-ui/react-accordion/
  */
-export class AccordionDriver<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {
-  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
+export class AccordionDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: parts,
-      content: (option?.content ?? {}) as ContentT,
     });
   }
 

--- a/packages/component-driver-mui-v5/src/components/BadgeDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/BadgeDriver.ts
@@ -1,8 +1,8 @@
 import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
 import {
   byCssClass,
-  ContainerDriver,
-  IContainerDriverOption,
+  ComponentDriver,
+  IComponentDriverOption,
   Interactor,
   PartLocator,
   ScenePart,
@@ -19,12 +19,11 @@ export const parts = {
  * Driver for Material UI v5 Badge component.
  * @see https://mui.com/material-ui/react-badge/
  */
-export class BadgeDriver<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {
-  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
+export class BadgeDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: parts,
-      content: (option?.content ?? {}) as ContentT,
     });
   }
 

--- a/packages/component-driver-mui-v5/src/components/ChipDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ChipDriver.ts
@@ -2,8 +2,8 @@ import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
 import {
   byCssClass,
   byDataTestId,
-  ContainerDriver,
-  IContainerDriverOption,
+  ComponentDriver,
+  IComponentDriverOption,
   Interactor,
   PartLocator,
   ScenePart,
@@ -24,12 +24,11 @@ export const parts = {
  * Driver for Material UI v5 Chip component.
  * @see https://mui.com/material-ui/react-chip/
  */
-export class ChipDriver<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {
-  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
+export class ChipDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: parts,
-      content: (option?.content ?? {}) as ContentT,
     });
   }
 


### PR DESCRIPTION
MUIV5: Change some drivers' base class to ComponentDriver

Some drivers incorrectly inherits ContainerDriver, which is unnecessary, ComponentDriver should be a sufficient base class.
