### PR TITLE
fix: (core) Properly escape attribute values

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  roots: ['<rootDir>/src'],
+  displayName: 'core',
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "node ../../scripts/postBuild.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "Tianzhen Lin <tangent@usa.net>",
   "keywords": [],

--- a/packages/core/src/locators/byAttribute.ts
+++ b/packages/core/src/locators/byAttribute.ts
@@ -1,4 +1,4 @@
-import { escapeId, escapeName, escapeValue } from '../utils/escapeUtil';
+import { escapeName, escapeValue } from '../utils/escapeUtil';
 import { CssLocator } from './CssLocator';
 import { LocatorRelativePosition } from './LocatorRelativePosition';
 
@@ -14,7 +14,7 @@ export function byAttribute(
   value: string,
   relativeTo: LocatorRelativePosition = LocatorRelativePosition.Descendent,
 ): CssLocator {
-  const selector = name === 'id' ? `#${escapeId(value)}` : `[${escapeName(name)}="${escapeValue(value)}"]`;
+  const selector = name === 'id' ? `#${escapeValue(value)}` : `[${escapeName(name)}="${escapeValue(value)}"]`;
   return new CssLocator(selector, {
     relative: relativeTo,
     source: {

--- a/packages/core/src/utils/__tests__/escapeUtil.test.ts
+++ b/packages/core/src/utils/__tests__/escapeUtil.test.ts
@@ -1,0 +1,15 @@
+import { escapeValue } from '../escapeUtil';
+
+describe('escapeValue', () => {
+  test('should escape special characters such as #', () => {
+    expect(escapeValue('color-0-#000000')).toBe('color-0-\\#000000');
+  });
+
+  test('should escape special characters such as :', () => {
+    expect(escapeValue(':r0:-listbox')).toBe('\\:r0\\:-listbox');
+  });
+
+  test('should not escape value without special character', () => {
+    expect(escapeValue('abc')).toBe('abc');
+  });
+});

--- a/packages/core/src/utils/escapeUtil.ts
+++ b/packages/core/src/utils/escapeUtil.ts
@@ -1,15 +1,67 @@
+const cssEscapes = new Map([
+  ['!', '\\!'],
+  ['"', '\\"'],
+  ['#', '\\#'],
+  ['$', '\\$'],
+  ['%', '\\%'],
+  ['&', '\\&'],
+  ["'", "\\'"],
+  ['(', '\\('],
+  [')', '\\)'],
+  ['*', '\\*'],
+  ['+', '\\+'],
+  [',', '\\,'],
+  ['.', '\\.'],
+  ['/', '\\/'],
+  [':', '\\:'],
+  [';', '\\;'],
+  ['<', '\\<'],
+  ['=', '\\='],
+  ['>', '\\>'],
+  ['?', '\\?'],
+  ['@', '\\@'],
+  ['[', '\\['],
+  ['\\', '\\\\'],
+  [']', '\\]'],
+  ['^', '\\^'],
+  ['`', '\\`'],
+  ['{', '\\{'],
+  ['|', '\\|'],
+  ['}', '\\}'],
+  ['~', '\\~'],
+  [' ', '\\ '],
+]);
+
 export function escapeName(name: string): string {
   return encodeURIComponent(name);
 }
 
+const escapeCache = new Map();
+
+/**
+ * Escaping based on the CSS spec: https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+ * Backslashes, spaces, and non-identifier characters (e.g., ! " # $ % & ' ( ) * + , . / : ; < = > ? @ [ ] ^ ` { | } ~) are escaped.
+ * @param value
+ * @returns
+ */
 export function escapeValue(value: string): string {
-  return encodeURIComponent(value);
+  if (escapeCache.has(value)) {
+    return escapeCache.get(value);
+  }
+
+  let escapedValue = '';
+  for (const character of value) {
+    if (cssEscapes.has(character)) {
+      escapedValue += cssEscapes.get(character);
+      continue;
+    }
+    escapedValue += character;
+  }
+
+  escapeCache.set(value, escapedValue);
+  return escapedValue;
 }
 
 export function escapeCssClassName(name: string): string {
   return name;
-}
-
-export function escapeId(id: string): string {
-  return id.split(':').join('\\:');
 }


### PR DESCRIPTION
fix: (core) Properly escape attribute values


Fix when constructing CSS selector, attribute values are not properly escaped
