### PR TITLE
fix: Change URL of the website to include www

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://atomic-testing.dev',
+  url: 'https://www.atomic-testing.dev',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',


### PR DESCRIPTION
fix: Change URL of the website to include www

Include www so it works with search engine Algolia.

See: https://discourse.algolia.com/t/crawler-skipping-my-website-for-reason-domain-not-allowed/19347
