### PR TITLE
fix: Some driver constructor should use partial option type

### DIFF
--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "HTML component driver for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/component-driver-html/src/components/HTMLHiddenInputDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLHiddenInputDriver.ts
@@ -1,7 +1,7 @@
 import { ComponentDriver, IComponentDriverOption, IInputDriver, Interactor, PartLocator } from '@atomic-testing/core';
 
 export class HTMLHiddenInputDriver extends ComponentDriver<{}> implements IInputDriver<string | null> {
-  constructor(locator: PartLocator, interactor: Interactor, option?: IComponentDriverOption) {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: {},

--- a/packages/component-driver-html/src/components/HTMLTextInputDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLTextInputDriver.ts
@@ -1,7 +1,7 @@
 import { ComponentDriver, IComponentDriverOption, IInputDriver, Interactor, PartLocator } from '@atomic-testing/core';
 
 export class HTMLTextInputDriver extends ComponentDriver<{}> implements IInputDriver<string | null> {
-  constructor(locator: PartLocator, interactor: Interactor, option?: IComponentDriverOption) {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: {},

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v5",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Atomic Testing Component driver to help drive Material UI v5 components",
   "main": "dist/index.js",
   "files": [

--- a/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
@@ -25,7 +25,7 @@ export class CheckboxDriver
   extends ComponentDriver<CheckboxScenePart>
   implements IFormFieldDriver<string | null>, IToggleDriver
 {
-  constructor(locator: PartLocator, interactor: Interactor, option?: IComponentDriverOption) {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: checkboxPart,

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Core library for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/src/drivers/ListComponentDriver.ts
+++ b/packages/core/src/drivers/ListComponentDriver.ts
@@ -6,7 +6,7 @@ import { ComponentDriver } from './ComponentDriver';
 import * as listHelper from './listHelper';
 
 export interface ListComponentDriverSpecificOption<ItemT extends ComponentDriver> {
-  itemClass: new (locator: PartLocator, interactor: Interactor, option?: IComponentDriverOption) => ItemT;
+  itemClass: new (locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) => ItemT;
   itemLocator: PartLocator;
 }
 

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Core engine for HTML DOM testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/jest",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Jest adapter for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Atomic Testing Playwright Adapter",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/test-runner",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
fix: Some driver constructor should use partial option type

Summary:
Some drivers such as CheckboxDriver incorrectly expects full `IComponentDriverOption` type instead of partial, this causes incompatiblity when using with ListHelper.
