### PR TITLE
feat: Add createRenderedTestEngine for React

### DIFF
--- a/packages/component-driver-html-test/src/examples/checkbox/SingleCheckbox.examples.tsx
+++ b/packages/component-driver-html-test/src/examples/checkbox/SingleCheckbox.examples.tsx
@@ -56,9 +56,9 @@ export const singleCheckboxTestSuite: TestSuiteInfo<typeof singleCheckboxExample
           const val = await testEngine.parts.toggle.isSelected();
           assertEqual(val, false);
         });
-        test('value should be null because it is not checked', async () => {
+        test('value should be 1 regardless of its checked state', async () => {
           const val = await testEngine.parts.toggle.getValue();
-          assertEqual(val, null);
+          assertEqual(val, '1');
         });
       });
 

--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "HTML component driver for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/component-driver-html/src/components/HTMLCheckboxDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLCheckboxDriver.ts
@@ -2,11 +2,6 @@ import { ComponentDriver, IFormFieldDriver, IToggleDriver } from '@atomic-testin
 
 export class HTMLCheckboxDriver extends ComponentDriver<{}> implements IFormFieldDriver<string | null>, IToggleDriver {
   async getValue(): Promise<string | null> {
-    const isChecked = await this.interactor.isChecked(this.locator);
-    if (!isChecked) {
-      return null;
-    }
-
     const value = await this.interactor.getAttribute(this.locator, 'value');
     return value ?? null;
   }

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v5",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Atomic Testing Component driver to help drive Material UI v5 components",
   "main": "dist/index.js",
   "files": [

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Core library for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Core engine for HTML DOM testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/jest",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Jest adapter for atomic-testing",
   "main": "dist/index.js",
   "files": [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Atomic Testing Playwright Adapter",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/src/createLegacyTestEngine.ts
+++ b/packages/react/src/createLegacyTestEngine.ts
@@ -1,12 +1,21 @@
-import { ScenePart, TestEngine } from '@atomic-testing/core';
+import { ScenePart, TestEngine, byAttribute } from '@atomic-testing/core';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 
 import { ReactInteractor } from './ReactInteractor';
 import { IReactTestEngineOption } from './types';
 
+let _rootId = 0;
+function getNextRootElementId() {
+  return `${_rootId++}`;
+}
+
+const rootElementAttributeName = 'data-atomic-testing-react-legacy';
+
 /**
  * Create test engine for React 17 or before, for React 18 or later, use createTestEngine
+ * This function takes a react node and render it into a container element.  For rendered
+ * components, use createRenderedLegacyTestEngine
  * @param node The React node to render
  * @param partDefinitions The scene part definitions
  * @param option
@@ -19,6 +28,8 @@ export function createLegacyTestEngine<T extends ScenePart>(
 ): TestEngine<T> {
   const rootEl = option?.rootElement ?? document.body;
   const container = rootEl.appendChild(document.createElement('div'));
+  const rootId = getNextRootElementId();
+  container.setAttribute(rootElementAttributeName, rootId);
 
   act(() => {
     ReactDOM.render(node, container);
@@ -30,7 +41,41 @@ export function createLegacyTestEngine<T extends ScenePart>(
   };
 
   const engine = new TestEngine(
-    [],
+    byAttribute(rootElementAttributeName, rootId),
+    new ReactInteractor(),
+    {
+      parts: partDefinitions,
+    },
+    cleanup,
+  );
+
+  return engine;
+}
+
+/**
+ * Create test engine for React 17 or before, for React 18 or later, use createRenderedTestEngine
+ * This function takes an html element purportedly rendered by React and create a test engine for it, it
+ * can be useful in environment such as Storybook where Storybook renders the component and the test
+ * @param rootElement The React node to render
+ * @param partDefinitions The scene part definitions
+ * @param option
+ * @returns The test engine
+ */
+export function createRenderedLegacyTestEngine<T extends ScenePart>(
+  rootElement: HTMLElement,
+  partDefinitions: T,
+  _option?: Readonly<Partial<IReactTestEngineOption>>,
+): TestEngine<T> {
+  const rootId = getNextRootElementId();
+  rootElement.setAttribute(rootElementAttributeName, rootId);
+
+  const cleanup = () => {
+    rootElement.removeAttribute(rootElementAttributeName);
+    return Promise.resolve();
+  };
+
+  const engine = new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
     new ReactInteractor(),
     {
       parts: partDefinitions,

--- a/packages/react/src/createTestEngine.ts
+++ b/packages/react/src/createTestEngine.ts
@@ -1,12 +1,21 @@
-import { ScenePart, TestEngine } from '@atomic-testing/core';
+import { ScenePart, TestEngine, byAttribute } from '@atomic-testing/core';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 
 import { ReactInteractor } from './ReactInteractor';
 import { IReactTestEngineOption } from './types';
 
+let _rootId = 0;
+function getNextRootElementId() {
+  return `${_rootId++}`;
+}
+
+const rootElementAttributeName = 'data-atomic-testing-react';
+
 /**
  * Create test engine for React 18 or later, for React 17 or before, use createLegacyTestEngine
+ * This function takes a react node and render it into a container element.  For rendered
+ * components, use createRenderedTestEngine
  * @param node The React node to render
  * @param partDefinitions The scene part definitions
  * @param option
@@ -21,6 +30,8 @@ export function createTestEngine<T extends ScenePart>(
   const container = rootEl.appendChild(document.createElement('div'));
 
   const root = createRoot(container);
+  const rootId = getNextRootElementId();
+  container.setAttribute(rootElementAttributeName, rootId);
   act(() => root.render(node));
 
   const cleanup = () => {
@@ -30,7 +41,41 @@ export function createTestEngine<T extends ScenePart>(
   };
 
   const engine = new TestEngine(
-    [],
+    byAttribute(rootElementAttributeName, rootId),
+    new ReactInteractor(),
+    {
+      parts: partDefinitions,
+    },
+    cleanup,
+  );
+
+  return engine;
+}
+
+/**
+ * Create test engine for React 18 or later, for React 17 or before, use createRenderedLegacyTestEngine
+ * This function takes an html element purportedly rendered by React and create a test engine for it, it
+ * can be useful in environment such as Storybook where Storybook renders the component and the test
+ * @param rootElement The React node to render
+ * @param partDefinitions The scene part definitions
+ * @param option
+ * @returns The test engine
+ */
+export function createRenderedTestEngine<T extends ScenePart>(
+  rootElement: HTMLElement,
+  partDefinitions: T,
+  _option?: Readonly<Partial<IReactTestEngineOption>>,
+): TestEngine<T> {
+  const rootId = getNextRootElementId();
+  rootElement.setAttribute(rootElementAttributeName, rootId);
+
+  const cleanup = () => {
+    rootElement.removeAttribute(rootElementAttributeName);
+    return Promise.resolve();
+  };
+
+  const engine = new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
     new ReactInteractor(),
     {
       parts: partDefinitions,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,3 @@
-export { createLegacyTestEngine } from './createLegacyTestEngine';
-export { createTestEngine } from './createTestEngine';
+export { createLegacyTestEngine, createRenderedLegacyTestEngine } from './createLegacyTestEngine';
+export { createRenderedTestEngine, createTestEngine } from './createTestEngine';
 export type { IReactTestEngineOption } from './types';

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/test-runner",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
feat: Add createRenderedTestEngine for React

Summary:
* Add createRenderedTestEngine for React for use case where React rendering was handled by host container such as Storybook, and a test engine for React is still needed to take advantage of integraiton with React rendering lifecycle.
* Fix check getValue which returns null on unchecked checkbox, which can be counterintuitive.
