### PR TITLE
fix: getListItemIterator causes typescript issue when using a Driver with inner parts declaration

### DIFF
--- a/packages/core/src/drivers/listHelper.ts
+++ b/packages/core/src/drivers/listHelper.ts
@@ -34,7 +34,7 @@ export async function getListItemByIndex<T extends ComponentDriver>(
  * @param itemLocatorBase The locator of the list item without the index, the locator should already compound the host locator if needed
  * @param driverClass The driver class of the list item
  */
-export async function* getListItemIterator<T extends ComponentDriver>(
+export async function* getListItemIterator<T extends ComponentDriver<any>>(
   host: ComponentDriver<any>,
   itemLocatorBase: PartLocator,
   driverClass: ComponentDriverClass<T>,

--- a/packages/core/src/partTypes.ts
+++ b/packages/core/src/partTypes.ts
@@ -8,10 +8,10 @@ import { PartLocator } from './locators/PartLocator';
 
 export type PartName<T extends ScenePart> = keyof T;
 
-export type ComponentDriverClass<T extends ComponentDriver<P>, P extends ScenePart = {}> = new (
+export type ComponentDriverClass<T extends ComponentDriver<any>> = new (
   locator: PartLocator,
   interactor: Interactor,
-  option?: Partial<IComponentDriverOption<P>>,
+  option?: Partial<IComponentDriverOption<any>>,
 ) => T;
 
 export interface ComponentPartDefinition<T extends ScenePart> {
@@ -23,11 +23,10 @@ export interface ComponentPartDefinition<T extends ScenePart> {
   /**
    * The class of driver which is used to interact with the element
    */
-  driver: typeof ComponentDriver<T> | ComponentDriverClass<ComponentDriver<T>, T>;
+  driver: {
+    new (locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption<T>>): ComponentDriver<T>;
+  };
 
-  /**
-   * Option for the driver
-   */
   option?: Partial<IComponentDriverOption<T>>;
 }
 


### PR DESCRIPTION
fix: getListItemIterator causes typescript issue when using a Driver with inner parts declaration

Summary:
When getListItemIterator is used with drivers with inner parts such as CheckboxDriver, TypeScript error TS2345 (type incompatibility) occurs.  This PR fixes it by relaxing some type restriction.
