### PR TITLE
fix: Make type concat more explicit

### DIFF
--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "HTML component driver for atomic-testing",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/component-driver-mui-v5",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Atomic Testing Component driver to help drive Material UI v5 components",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Core library for atomic-testing",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/core/src/locators/CssLocator.ts
+++ b/packages/core/src/locators/CssLocator.ts
@@ -3,7 +3,7 @@ import { CssLocatorSource } from './CssLocatorSource';
 import { LocatorComplexity } from './LocatorComplexity';
 import { LocatorRelativePosition } from './LocatorRelativePosition';
 import { LocatorType } from './LocatorType';
-import { PartLocator } from './PartLocator';
+import { CssLocatorChain, PartLocator } from './PartLocator';
 
 export interface CssLocatorInitializer {
   relative: LocatorRelativePosition;
@@ -39,8 +39,11 @@ export class CssLocator {
 
   chain(...locatorsToAppend: PartLocator[]): PartLocator {
     const baseLocator: CssLocator[] = [this];
-    const toAppend: CssLocator[] = locatorsToAppend.reduce((acc: CssLocator[], locator) => {
-      return acc.concat(locator);
+    const toAppend: CssLocator[] = locatorsToAppend.reduce((acc: CssLocator[], locator: PartLocator) => {
+      if (locator instanceof CssLocator) {
+        return acc.concat(locator);
+      }
+      return acc.concat(...(locator as CssLocatorChain));
     }, [] as CssLocator[]);
 
     return baseLocator.concat(toAppend);

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -16,9 +16,12 @@ export function toChain(locator: PartLocator): CssLocatorChain {
 
 export function append(locatorBase: PartLocator, ...locatorsToAppend: PartLocator[]): PartLocator {
   const baseLocator: CssLocatorChain = toChain(locatorBase);
-  const toAppend: CssLocatorChain = locatorsToAppend.reduce((acc: CssLocatorChain, locator) => {
-    return acc.concat(locator);
-  }, [] as CssLocatorChain);
+  const toAppend: CssLocator[] = locatorsToAppend.reduce((acc: CssLocator[], locator: PartLocator) => {
+    if (locator instanceof CssLocator) {
+      return acc.concat(locator);
+    }
+    return acc.concat(...(locator as CssLocatorChain));
+  }, [] as CssLocator[]);
 
   return baseLocator.concat(toAppend);
 }

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Core engine for HTML DOM testing",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/jest",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Jest adapter for atomic-testing",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Atomic Testing Playwright Adapter",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/react",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@atomic-testing/test-runner",
-  "version": "0.46.3",
+  "version": "0.46.5",
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
fix: Make type concat more explicit

Summary:
Fix CSSLocator and PartLocator operations which sometimes can cause some TypeScript compilation fail.
