### PR TITLE
chore: Migrate to use act from testing-library

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",
-    "@atomic-testing/dom-core": "workspace:*"
+    "@atomic-testing/dom-core": "workspace:*",
+    "@testing-library/react": "^16.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.9",
@@ -41,6 +42,7 @@
   },
   "peerDependencies": {
     "@testing-library/dom": ">=9.2.0",
+    "@testing-library/react": ">=16.2.0",
     "@testing-library/user-event": ">=14.0.0",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"

--- a/packages/react/src/createTestEngine.ts
+++ b/packages/react/src/createTestEngine.ts
@@ -1,6 +1,6 @@
 import { byAttribute, ScenePart, TestEngine } from '@atomic-testing/core';
+import { act } from '@testing-library/react';
 import { createRoot } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
 
 import { ReactInteractor } from './ReactInteractor';
 import { IReactTestEngineOption } from './types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         version: 29.7.0
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.26.9))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9))(@swc/core@1.3.53)(@types/babel__core@7.20.0)(eslint@8.52.0)(react@18.2.0)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.13.9)(typescript@5.8.2))(type-fest@2.19.0)(typescript@5.8.2)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.21.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.21.0))(@swc/core@1.3.53)(@types/babel__core@7.20.0)(eslint@8.52.0)(react@18.2.0)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.13.9)(typescript@5.8.2))(type-fest@2.19.0)(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -756,6 +756,9 @@ importers:
       '@testing-library/dom':
         specifier: '>=9.2.0'
         version: 9.2.0
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.2.0(@testing-library/dom@9.2.0)(@types/react-dom@18.2.18)(@types/react@18.2.45)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/user-event':
         specifier: '>=14.0.0'
         version: 14.4.3(@testing-library/dom@9.2.0)
@@ -3207,6 +3210,21 @@ packages:
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
+
+  '@testing-library/react@16.2.0':
+    resolution: {integrity: sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@testing-library/user-event@14.4.3':
     resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
@@ -11893,6 +11911,16 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
+  '@testing-library/react@16.2.0(@testing-library/dom@9.2.0)(@types/react-dom@18.2.18)(@types/react@18.2.45)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.26.9
+      '@testing-library/dom': 9.2.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.45
+      '@types/react-dom': 18.2.18
+
   '@testing-library/user-event@14.4.3(@testing-library/dom@9.2.0)':
     dependencies:
       '@testing-library/dom': 9.2.0
@@ -13984,7 +14012,7 @@ snapshots:
 
   eslint-plugin-jsx-a11y@6.7.1(eslint@8.52.0):
     dependencies:
-      '@babel/runtime': 7.24.1
+      '@babel/runtime': 7.26.9
       aria-query: 5.1.3
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -18298,7 +18326,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.12.0)
       '@babel/core': 7.21.4
       '@babel/preset-env': 7.20.2(@babel/core@7.21.4)
-      '@babel/runtime': 7.24.1
+      '@babel/runtime': 7.26.9
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.21.4)(@types/babel__core@7.20.0)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)


### PR DESCRIPTION

act() is deprecated in React in favor of that from testing-library/react
