### PR TITLE
Fix waitUntil timing in core utils

### DIFF
--- a/packages/core/src/utils/__tests__/timingUtil.test.ts
+++ b/packages/core/src/utils/__tests__/timingUtil.test.ts
@@ -1,0 +1,16 @@
+import { waitUntil } from '../timingUtil';
+
+describe('waitUntil', () => {
+  test('should respect timeout when condition is never met', async () => {
+    const start = Date.now();
+    const result = await waitUntil({
+      probeFn: () => false,
+      terminateCondition: true,
+      timeoutMs: 100,
+    });
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    // allow some buffer for timers but ensure it does not wait excessively
+    expect(elapsed).toBeLessThan(200);
+  });
+});

--- a/packages/core/src/utils/timingUtil.ts
+++ b/packages/core/src/utils/timingUtil.ts
@@ -67,10 +67,10 @@ export async function waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
     }
 
     const nextStart = Math.round(elapsed / intervalMs) * intervalMs;
-    if (nextStart - startMs >= timeoutMs) {
+    if (nextStart >= timeoutMs) {
       return val;
     }
-    await wait(nextStart);
+    await wait(nextStart - elapsed);
   }
 
   return val!;


### PR DESCRIPTION
## Summary
- fix waitUntil interval logic
- add test for waitUntil timeout

## Testing
- `pnpm --filter "@atomic-testing/core" test` *(fails: command not found: jest)*

------
https://chatgpt.com/codex/tasks/task_b_683b4cd73cc8832ba59c318ad3edfb1e