### PR TITLE
Fix comment typo in core package

### DIFF
--- a/packages/core/src/drivers/ComponentDriver.ts
+++ b/packages/core/src/drivers/ComponentDriver.ts
@@ -197,8 +197,8 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
   /**
    * Whether the component is visible.  Visibility is defined
    * that the component does not have the CSS property `display: none`,
-   * `visibility: hidden`, or `opacity: 0`.  However this does not
-   * check wether the component is within the viewport.
+  * `visibility: hidden`, or `opacity: 0`.  However this does not
+  * check whether the component is within the viewport.
    *
    * @returns true if the component is visible, false otherwise
    */

--- a/packages/core/src/partTypes.ts
+++ b/packages/core/src/partTypes.ts
@@ -126,7 +126,7 @@ export interface IComponentDriver<T extends ScenePart = {}> {
    * Whether the component is visible.  Visibility is defined
    * that the component does not have the CSS property `display: none`,
    * `visibility: hidden`, or `opacity: 0`.  However this does not
-   * check wether the component is within the viewport.
+   * check whether the component is within the viewport.
    *
    * @returns true if the component is visible, false otherwise
    */


### PR DESCRIPTION
## Summary
- correct a typo in visibility comments of `ComponentDriver` and `partTypes`

## Testing
- `pnpm run check:lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm --filter @atomic-testing/core test` *(fails: command not found: jest)*

------
https://chatgpt.com/codex/tasks/task_b_683b4cc68080832ba32bd3cabddd8c43