### PR TITLE
Add test for unsupported date input type

### DIFF
--- a/packages/core/src/utils/__tests__/dateUtil.test.ts
+++ b/packages/core/src/utils/__tests__/dateUtil.test.ts
@@ -57,4 +57,10 @@ describe('validateHtmlDateInput', () => {
   ])('type: %s with value %s should validated as %p', (type, input, expected) => {
     expect(validateHtmlDateInput(type, input).valid).toBe(expected);
   });
+
+  test('should throw an error for unsupported type', () => {
+    expect(() => validateHtmlDateInput('month', '2021-01')).toThrowError(
+      'Unsupported date type: month',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend `validateHtmlDateInput` tests to check error handling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `packages/core` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b4cdf7be4832b804ee5c58fbb0a99