### PR TITLE
Fix comment referencing MissingPartError

### DIFF
--- a/packages/core/src/drivers/ComponentDriver.ts
+++ b/packages/core/src/drivers/ComponentDriver.ts
@@ -92,7 +92,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
   }
 
   /**
-   * Check the specified parts' existences, and throw MissPartError if any of the part is found not existence.
+   * Check the specified parts' existences, and throw MissingPartError if any of the part is found not existence.
    * Existence is defined by the part's existence in the DOM regardless of its visibility on the screen
    * @param partName Single or array of the names of the parts to be enforced
    */


### PR DESCRIPTION
## Summary
- fix the documentation above `enforcePartExistence` to reference `MissingPartError`

## Testing
- `pnpm --filter @atomic-testing/core test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b4cdd68bc832bb8f2d886b1bc10b8