### PR TITLE
Fix waitUntil timing logic

### DIFF
--- a/packages/core/src/utils/__tests__/timingUtil.test.ts
+++ b/packages/core/src/utils/__tests__/timingUtil.test.ts
@@ -1,0 +1,25 @@
+import { waitUntil } from '../timingUtil';
+
+describe('waitUntil', () => {
+  test('resolves when condition met', async () => {
+    let counter = 0;
+    const result = await waitUntil({
+      probeFn: () => ++counter,
+      terminateCondition: 3,
+      timeoutMs: 500,
+    });
+    expect(result).toBe(3);
+  });
+
+  test('returns last value on timeout', async () => {
+    const start = Date.now();
+    const result = await waitUntil({
+      probeFn: () => 0,
+      terminateCondition: 1,
+      timeoutMs: 100,
+    });
+    const duration = Date.now() - start;
+    expect(result).toBe(0);
+    expect(duration).toBeGreaterThanOrEqual(100);
+  });
+});

--- a/packages/core/src/utils/timingUtil.ts
+++ b/packages/core/src/utils/timingUtil.ts
@@ -44,10 +44,9 @@ export async function waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
       : currentValue => terminateCondition === currentValue;
 
   const startMs = Date.now();
-  const shouldContinue = true;
   let val: T;
 
-  while (shouldContinue) {
+  while (Date.now() - startMs < timeoutMs) {
     val = await probeFn();
     const hasMetEqCheck = eqCheck(val);
     if (debug) {
@@ -59,18 +58,7 @@ export async function waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
       return val;
     }
 
-    const currentTime = Date.now();
-    const elapsed = currentTime - startMs;
-
-    if (elapsed >= timeoutMs) {
-      return val;
-    }
-
-    const nextStart = Math.round(elapsed / intervalMs) * intervalMs;
-    if (nextStart - startMs >= timeoutMs) {
-      return val;
-    }
-    await wait(nextStart);
+    await wait(intervalMs);
   }
 
   return val!;


### PR DESCRIPTION
## Summary
- fix waitUntil loop logic so it waits a fixed interval
- add tests for waitUntil

## Testing
- `npx jest` *(fails: request to https://registry.npmjs.org/jest failed)*

------
https://chatgpt.com/codex/tasks/task_b_683b4a769d28832bb7656bc58654a19e