### PR TITLE
Add getting-started tutorial

### DIFF
--- a/docs/docs/advanced-concepts/build-component-driver.mdx
+++ b/docs/docs/advanced-concepts/build-component-driver.mdx
@@ -5,4 +5,63 @@ sidebar_position: 1
 
 # Build Component Driver
 
-Coming soon
+Component drivers encapsulate the logic for interacting with a UI component. While many drivers are provided out of the box, you can build your own for custom widgets.
+
+## Basic structure
+
+A driver extends `ComponentDriver` and implements any interfaces that describe its capabilities. The `constructor` receives a locator, an interactor and optional configuration.
+
+```ts title="SimpleButtonDriver.ts"
+import { ComponentDriver, IClickableDriver } from '@atomic-testing/core';
+
+export class SimpleButtonDriver extends ComponentDriver implements IClickableDriver {
+  click(): Promise<void> {
+    return this.interactor.click(this.locator);
+  }
+
+  get driverName(): string {
+    return 'SimpleButtonDriver';
+  }
+}
+```
+
+## Why use drivers?
+
+Drivers abstract away the DOM details of complex components. Instead of manipulating HTML in tests, you interact with high level methods (`next()`, `setValue()`, etc.). Drivers can expose child parts so you can compose them into larger units and reuse them across tests.
+
+For example, the signup form in the example project is implemented with a `CredentialFormDriver` that wraps four MUI text fields and a navigation component. Tests only call `setValue()` and `next()` on this driver, keeping the assertions focused on behavior rather than DOM markup.
+
+By composing multiple drivers you can model entire workflows with minimal test code.
+
+### Composing drivers
+
+The `LoginFormDriver` below demonstrates composing text field and button drivers to abstract the entire login form.
+
+```ts title="LoginFormDriver.ts"
+import { ButtonDriver, TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { ComponentDriver, Locator, Interactor, byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const loginFormParts = {
+  username: { locator: byDataTestId('username'), driver: TextFieldDriver },
+  password: { locator: byDataTestId('password'), driver: TextFieldDriver },
+  submit: { locator: byDataTestId('submit'), driver: ButtonDriver },
+} satisfies ScenePart;
+
+export class LoginFormDriver extends ComponentDriver<typeof loginFormParts> {
+  constructor(locator: Locator, interactor: Interactor) {
+    super(locator, interactor, { parts: loginFormParts });
+  }
+
+  async login(credentials: { username: string; password: string }): Promise<void> {
+    await this.parts.username.setValue(credentials.username);
+    await this.parts.password.setValue(credentials.password);
+    await this.parts.submit.click();
+  }
+
+  get driverName(): string {
+    return 'LoginFormDriver';
+  }
+}
+```
+
+This driver can itself be used as a part inside a larger `AuthenticatedAppDriver`, keeping individual tests concise.

--- a/docs/docs/getting-started-tutorial.mdx
+++ b/docs/docs/getting-started-tutorial.mdx
@@ -1,0 +1,166 @@
+---
+id: tutorial
+title: 'Step-by-Step Tutorial'
+sidebar_position: 5
+---
+
+This tutorial walks you through the `example-mui-signup-form` found in the `examples` folder. It demonstrates how to run the example application and introduces the basic **Atomic Testing** APIs for writing tests.
+
+## 1. Install dependencies
+
+From the repository root run:
+
+```bash
+pnpm install
+```
+
+The example project has its own dependencies so install them as well:
+
+```bash
+cd examples/example-mui-signup-form
+pnpm install
+```
+
+## 2. Start the example application
+
+Run the app locally to see the signup form in action:
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:5371](http://localhost:5371) in your browser to interact with the multi‑step form.
+
+## 3. Run the component tests
+
+Unit tests for each form step live under their respective `__tests__` directories. Execute them with:
+
+```bash
+pnpm test:dom
+```
+
+## 4. Run the end‑to‑end test
+
+The example also includes an end‑to‑end scenario located in `e2e/success.spec.ts`. Launch it in Chrome with:
+
+```bash
+pnpm test:e2e:chrome
+```
+
+Add the `--ui` flag to open Playwright in UI mode if you want to watch the interactions.
+
+## 5. Explore Storybook (optional)
+
+Some components contain Storybook stories with interaction tests. To view them, run:
+
+```bash
+pnpm storybook
+```
+
+## 6. Write your first Atomic test
+
+The signup form example includes unit tests written with **Atomic Testing**. The steps below outline the main pieces required to create a test.
+
+### Declare `data-testid`
+
+Assign the `data-testid` attribute on components that you need to interact with. This example shows the markup for the credential form:
+
+```tsx title="CredentialForm.tsx"
+<form data-testid={DataTestId.form}>
+  <TextField data-testid={DataTestId.emailInput} label='Email' />
+  <TextField data-testid={DataTestId.passwordInput} label='Password' />
+  <WizardButton data-testid={DataTestId.navigation} onNextStep={onNextStep} />
+</form>
+```
+
+### Define a ScenePart
+
+Create a ScenePart describing how to locate each component and which driver to use:
+
+```ts title="credentialScenePart.ts"
+const parts = {
+  form: {
+    locator: byDataTestId(DataTestId.form),
+    driver: CredentialFormDriver,
+  },
+} satisfies ScenePart;
+```
+
+### Instantiate the Test Engine and write a test
+
+```ts title="CredentialForm.test.tsx"
+let testEngine: TestEngine<typeof parts>;
+let onNext: jest.Mock;
+
+beforeEach(() => {
+  onNext = jest.fn();
+  testEngine = createTestEngineForComponent(
+    <CredentialForm data-testid={DataTestId.form} onNextStep={onNext} />,
+    parts
+  );
+});
+
+afterEach(async () => {
+  await testEngine.cleanUp();
+});
+
+test('submits valid data', async () => {
+  await testEngine.parts.form.setValue({
+    email: 'john@example.com',
+    password: 'secret123',
+    confirmPassword: 'secret123',
+    birthday: '1990-01-01',
+  });
+  await testEngine.parts.form.next();
+  expect(onNext).toHaveBeenCalled();
+});
+```
+
+The test engine renders the component, exposes the parts defined in the `ScenePart`, and provides helper methods from the driver to interact with the component. Always call `cleanUp()` after each test to unmount the component and release resources.
+
+## 7. Build a login form driver
+
+Drivers can also model entire forms. Below is an example `LoginFormDriver` that wraps the username, password and submit parts. The `login()` method accepts an object with the credentials and performs all required interactions.
+
+```ts title="LoginFormDriver.ts"
+import { ButtonDriver, TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { ComponentDriver, Locator, Interactor, byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const loginFormParts = {
+  username: { locator: byDataTestId('username'), driver: TextFieldDriver },
+  password: { locator: byDataTestId('password'), driver: TextFieldDriver },
+  submit: { locator: byDataTestId('submit'), driver: ButtonDriver },
+} satisfies ScenePart;
+
+export class LoginFormDriver extends ComponentDriver<typeof loginFormParts> {
+  constructor(locator: Locator, interactor: Interactor) {
+    super(locator, interactor, { parts: loginFormParts });
+  }
+
+  async login(credentials: { username: string; password: string }): Promise<void> {
+    await this.parts.username.setValue(credentials.username);
+    await this.parts.password.setValue(credentials.password);
+    await this.parts.submit.click();
+  }
+
+  get driverName(): string {
+    return 'LoginFormDriver';
+  }
+}
+```
+
+Using this driver, a test becomes highly declarative:
+
+```ts title="LoginForm.test.tsx"
+await testEngine.parts.login.login({
+  username: 'john@example.com',
+  password: 'secret',
+});
+expect(await testEngine.parts.error.getText()).toBe('');
+```
+
+If the login implementation changes you only need to update the driver, not every test.
+
+## Next steps
+
+Browse the example source code to see how scene parts, drivers and the test engine are set up. Then refer back to the [Setup](./setup.mdx) and [Core Concepts](./core-concepts.mdx) pages for more details on creating your own tests.

--- a/docs/docs/snippets/login-form-driver.ts
+++ b/docs/docs/snippets/login-form-driver.ts
@@ -1,0 +1,34 @@
+import { ButtonDriver, TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { ComponentDriver, Locator, Interactor } from '@atomic-testing/core';
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const loginFormParts = {
+  username: {
+    locator: byDataTestId('username'),
+    driver: TextFieldDriver,
+  },
+  password: {
+    locator: byDataTestId('password'),
+    driver: TextFieldDriver,
+  },
+  submit: {
+    locator: byDataTestId('submit'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+export class LoginFormDriver extends ComponentDriver<typeof loginFormParts> {
+  constructor(locator: Locator, interactor: Interactor) {
+    super(locator, interactor, { parts: loginFormParts });
+  }
+
+  async login(credentials: { username: string; password: string }): Promise<void> {
+    await this.parts.username.setValue(credentials.username);
+    await this.parts.password.setValue(credentials.password);
+    await this.parts.submit.click();
+  }
+
+  get driverName(): string {
+    return 'LoginFormDriver';
+  }
+}


### PR DESCRIPTION
## Summary
- add a step-by-step tutorial describing how to write a test using Atomic Testing
- document how to build a simple component driver
- demonstrate building a login form driver to simplify tests

## Testing
- `pnpm run check:lint`
- `npx prettier --write docs/docs/getting-started-tutorial.mdx docs/docs/advanced-concepts/build-component-driver.mdx docs/docs/snippets/login-form-driver.ts`
- `pnpm run types` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_684ddb7d4478832b85e6e8711f6841fa