### PR TITLE
Add getting-started tutorial

### DIFF
--- a/docs/docs/advanced-concepts/build-component-driver.mdx
+++ b/docs/docs/advanced-concepts/build-component-driver.mdx
@@ -3,6 +3,55 @@ id: build-component-driver
 sidebar_position: 1
 ---
 
+import loginFormDriver from '!!raw-loader!../snippets/login-form-driver';
+import CodeBlock from '@theme/CodeBlock';
+
 # Build Component Driver
 
-Coming soon
+Component drivers encapsulate the logic for interacting with a UI component. While many drivers are provided out of the box, you can build your own for custom widgets.
+
+## Basic structure
+
+A driver extends `ComponentDriver` and implements any interfaces that describe its capabilities. The `constructor` receives a locator, an interactor and optional configuration.
+
+```ts title="SimpleButtonDriver.ts"
+import { ComponentDriver, IClickableDriver } from '@atomic-testing/core';
+
+export class SimpleButtonDriver extends ComponentDriver implements IClickableDriver {
+  click(): Promise<void> {
+    return this.interactor.click(this.locator);
+  }
+
+  get driverName(): string {
+    return 'SimpleButtonDriver';
+  }
+}
+```
+
+## Why use drivers?
+
+Drivers abstract away the DOM details of complex components. Instead of manipulating HTML in tests, you interact with high level methods (`next()`, `setValue()`, etc.). Drivers can expose child parts so you can compose them into larger units and reuse them across tests.
+
+For example, the signup form in the example project is implemented with a `CredentialFormDriver` that wraps four MUI text fields and a navigation component. Tests only call `setValue()` and `next()` on this driver, keeping the assertions focused on behavior rather than DOM markup.
+
+By composing multiple drivers you can model entire workflows with minimal test code.
+
+## Example: composing a login form driver
+
+The snippet below defines a `LoginFormDriver` that combines two `TextFieldDriver`s and a `ButtonDriver`. It exposes a high level `login()` helper so tests no longer deal with individual inputs.
+
+<CodeBlock language='ts'>{loginFormDriver}</CodeBlock>
+
+By wrapping the lower level drivers, the login test becomes very small:
+
+```ts
+await testEngine.parts.form.login({ username: 'alice', password: 's3cr3t' });
+```
+
+### Environment agnostic
+
+Drivers rely on the `Interactor` abstraction, so the same driver can run in unit tests with JSDOM or in browser tests using Playwright or Cypress. Tests remain identical across environments.
+
+:::tip Pro tip
+Encapsulating interactions in drivers keeps tests declarative. When the login flow changes, update the driver once and reuse it for both unit and end‑to‑end scenarios.
+:::

--- a/docs/docs/getting-started-tutorial.mdx
+++ b/docs/docs/getting-started-tutorial.mdx
@@ -1,0 +1,154 @@
+---
+id: tutorial
+title: 'Step-by-Step Tutorial'
+sidebar_position: 5
+---
+
+import loginFormDriver from '!!raw-loader!./snippets/login-form-driver';
+import signupE2e from '!!raw-loader!./snippets/signup-form-e2e.spec';
+import CodeBlock from '@theme/CodeBlock';
+
+This tutorial walks you through the `example-mui-signup-form` found in the `examples` folder. It demonstrates how to run the example application and introduces the basic **Atomic Testing** APIs for writing tests. Component drivers work the same in isolated unit tests or full browser tests so the code you see here applies to both environments.
+
+## 1. Install dependencies
+
+From the repository root run:
+
+```bash
+pnpm install
+```
+
+The example project has its own dependencies so install them as well:
+
+```bash
+cd examples/example-mui-signup-form
+pnpm install
+```
+
+## 2. Start the example application
+
+Run the app locally to see the signup form in action:
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:5371](http://localhost:5371) in your browser to interact with the multi‑step form.
+
+## 3. Run the component tests
+
+Unit tests for each form step live under their respective `__tests__` directories. Execute them with:
+
+```bash
+pnpm test:dom
+```
+
+## 4. Run the end‑to‑end test
+
+The example also includes an end‑to‑end scenario located in `e2e/success.spec.ts`. Launch it in Chrome with:
+
+```bash
+pnpm test:e2e:chrome
+```
+
+Add the `--ui` flag to open Playwright in UI mode if you want to watch the interactions.
+
+## 5. Explore Storybook (optional)
+
+Some components contain Storybook stories with interaction tests. To view them, run:
+
+```bash
+pnpm storybook
+```
+
+## 6. Write your first Atomic test
+
+The signup form example includes unit tests written with **Atomic Testing**. The steps below outline the main pieces required to create a test.
+
+### Declare `data-testid`
+
+Assign the `data-testid` attribute on components that you need to interact with. This example shows the markup for the credential form:
+
+```tsx title="CredentialForm.tsx"
+<form data-testid={DataTestId.form}>
+  <TextField data-testid={DataTestId.emailInput} label='Email' />
+  <TextField data-testid={DataTestId.passwordInput} label='Password' />
+  <WizardButton data-testid={DataTestId.navigation} onNextStep={onNextStep} />
+</form>
+```
+
+### Define a ScenePart
+
+Create a ScenePart describing how to locate each component and which driver to use:
+
+```ts title="credentialScenePart.ts"
+const parts = {
+  form: {
+    locator: byDataTestId(DataTestId.form),
+    driver: CredentialFormDriver,
+  },
+} satisfies ScenePart;
+```
+
+### Instantiate the Test Engine and write a test
+
+```ts title="CredentialForm.test.tsx"
+let testEngine: TestEngine<typeof parts>;
+let onNext: jest.Mock;
+
+beforeEach(() => {
+  onNext = jest.fn();
+  testEngine = createTestEngineForComponent(
+    <CredentialForm data-testid={DataTestId.form} onNextStep={onNext} />,
+    parts
+  );
+});
+
+afterEach(async () => {
+  await testEngine.cleanUp();
+});
+
+test('submits valid data', async () => {
+  await testEngine.parts.form.setValue({
+    email: 'john@example.com',
+    password: 'secret123',
+    confirmPassword: 'secret123',
+    birthday: '1990-01-01',
+  });
+  await testEngine.parts.form.next();
+  expect(onNext).toHaveBeenCalled();
+});
+```
+
+The test engine renders the component, exposes the parts defined in the `ScenePart`, and provides helper methods from the driver to interact with the component. Always call `cleanUp()` after each test to unmount the component and release resources.
+
+## 7. Build a form driver
+
+For larger forms it is convenient to create a driver that wraps the individual inputs. Below is a simplified driver for a login form.
+
+<CodeBlock language='ts'>{loginFormDriver}</CodeBlock>
+
+Use it in a test:
+
+```ts title="LoginForm.test.tsx"
+const parts = {
+  form: { locator: byDataTestId('login-form'), driver: LoginFormDriver },
+} satisfies ScenePart;
+
+const engine = createTestEngineForComponent(<LoginForm />, parts);
+await engine.parts.form.login({ username: 'admin', password: 'secret' });
+```
+
+With the `login()` helper tests stay declarative and don't depend on the form's markup. If the implementation changes, update only `LoginFormDriver`.
+
+## 8. Write an end-to-end test
+
+Drivers work the same way in browser-based tests. The snippet below shows a Playwright test that reuses the drivers from the unit tests.
+
+<CodeBlock language='ts'>{signupE2e}</CodeBlock>
+
+Because the driver encapsulates how to fill in the form, the test logic is short and can run in any browser supported by Playwright.
+
+## Next steps
+
+Browse the example source code to see how scene parts, drivers and the test engine are set up. Then refer back to the [Setup](./setup.mdx) and [Core Concepts](./core-concepts.mdx) pages for more details on creating your own tests.

--- a/docs/docs/snippets/login-form-driver.ts
+++ b/docs/docs/snippets/login-form-driver.ts
@@ -1,0 +1,42 @@
+import { TextFieldDriver, ButtonDriver } from '@atomic-testing/component-driver-mui-v5';
+import {
+  ComponentDriver,
+  Interactor,
+  IComponentDriverOption,
+  IInputDriver,
+  PartLocator,
+  ScenePart,
+  byDataTestId,
+} from '@atomic-testing/core';
+
+const parts = {
+  username: { locator: byDataTestId('username'), driver: TextFieldDriver },
+  password: { locator: byDataTestId('password'), driver: TextFieldDriver },
+  submit: { locator: byDataTestId('submit'), driver: ButtonDriver },
+} satisfies ScenePart;
+
+export interface LoginCredential {
+  username: string;
+  password: string;
+}
+
+export class LoginFormDriver extends ComponentDriver<typeof parts> implements IInputDriver<LoginCredential> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async setValue(value: LoginCredential): Promise<boolean> {
+    await this.parts.username.setValue(value.username);
+    await this.parts.password.setValue(value.password);
+    return true;
+  }
+
+  async login(value: LoginCredential): Promise<void> {
+    await this.setValue(value);
+    await this.parts.submit.click();
+  }
+
+  get driverName(): string {
+    return 'LoginFormDriver';
+  }
+}

--- a/docs/docs/snippets/signup-form-e2e.spec.ts
+++ b/docs/docs/snippets/signup-form-e2e.spec.ts
@@ -1,0 +1,16 @@
+import { createTestEngine } from '@atomic-testing/playwright';
+import { expect, test } from '@playwright/test';
+
+import { getGoodCredentialMock } from './__mocks__/signup';
+import { parts } from './signupScenePart';
+
+// Shortened end-to-end test using Playwright
+
+test('user can sign up', async ({ page }) => {
+  await page.goto('/');
+  const engine = createTestEngine(page, parts);
+
+  await engine.parts.credentialStep.setValue(getGoodCredentialMock());
+  await engine.parts.credentialStep.next();
+  await expect(await engine.parts.shippingStep.isVisible()).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a step-by-step tutorial describing how to write a test using Atomic Testing
- document how to build a simple component driver
- expand docs with a driver-based login example
- show how a driver works in end-to-end tests

## Testing
- `pnpm run check:lint`
- `npx prettier --write docs/docs/getting-started-tutorial.mdx docs/docs/advanced-concepts/build-component-driver.mdx docs/docs/snippets/login-form-driver.ts docs/docs/snippets/signup-form-e2e.spec.ts`
- `pnpm run types` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_684ddb7d4478832b85e6e8711f6841fa