### PR TITLE
refactor: Refactor MUI-V5 component tests

### DIFF
--- a/packages/component-driver-mui-v5-test/__tests__/ProgressDriver.dom.test.ts
+++ b/packages/component-driver-mui-v5-test/__tests__/ProgressDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { jestTestAdapter } from '@atomic-testing/jest';
+import { createTestEngine } from '@atomic-testing/react';
+import { testRunner } from '@atomic-testing/test-runner';
+
+import { basicProgressExample, progressTestSuite } from '../src/examples';
+
+testRunner(progressTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof basicProgressExample.scene) => {
+    return createTestEngine(basicProgressExample.ui, scenePart);
+  },
+});

--- a/packages/component-driver-mui-v5-test/__tests__/ProgressDriver.e2e.test.ts
+++ b/packages/component-driver-mui-v5-test/__tests__/ProgressDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { testRunner } from '@atomic-testing/test-runner';
+
+import { progressTestSuite } from '../src/examples';
+
+testRunner(progressTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/packages/component-driver-mui-v5-test/__tests__/ToggleButtonGroupDriver.dom.test.ts
+++ b/packages/component-driver-mui-v5-test/__tests__/ToggleButtonGroupDriver.dom.test.ts
@@ -3,13 +3,13 @@ import { createTestEngine } from '@atomic-testing/react';
 import { testRunner } from '@atomic-testing/test-runner';
 
 import {
+  exclusiveSelectionExample,
   exclusiveSelectionTestSuite,
   regularSelectionButtonTestSuite,
   regularSelectionExample,
   singleToggleButtonTestSuite,
   singleToggleExample,
 } from '../src/examples';
-import { exclusiveSelectionExample } from '../src/examples/toggleButton/ExclusiveSelection.example';
 
 testRunner(singleToggleButtonTestSuite, jestTestAdapter, {
   getTestEngine: (scenePart: typeof singleToggleExample.scene) => {

--- a/packages/component-driver-mui-v5-test/index.html
+++ b/packages/component-driver-mui-v5-test/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MUI V6 Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/component-driver-mui-v5-test/package.json
+++ b/packages/component-driver-mui-v5-test/package.json
@@ -8,8 +8,8 @@
     "src"
   ],
   "scripts": {
-    "start": "PORT=5115 TSC_COMPILE_ON_ERROR=true react-scripts start",
-    "build:ui": "react-scripts build",
+    "start": "vite --force",
+    "build:ui": "vite build",
     "postbuild": "node ../../scripts/postBuild.mjs",
     "test:dom": "jest",
     "test:e2e": "playwright test",
@@ -55,10 +55,11 @@
     "@types/node": "^22.15.30",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.5.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "react-scripts": "5.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/component-driver-mui-v5-test/src/components/ExampleList.tsx
+++ b/packages/component-driver-mui-v5-test/src/components/ExampleList.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { JSX } from 'react';
 
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { IExampleUIUnit } from '@atomic-testing/core';
 
 export interface ExampleListProps {
-  examples: IExampleUnit<ScenePart, JSX.Element>[];
+  examples: readonly IExampleUIUnit<JSX.Element>[];
 }
 
 export const ExampleList: React.FunctionComponent<ExampleListProps> = props => (

--- a/packages/component-driver-mui-v5-test/src/directory.tsx
+++ b/packages/component-driver-mui-v5-test/src/directory.tsx
@@ -1,24 +1,36 @@
 import { ExampleList } from './components/ExampleList';
-import {
-  accordionExamples,
-  alertExamples,
-  autoCompleteExamples,
-  badgeExamples,
-  buttonExamples,
-  checkboxExamples,
-  chipExamples,
-  dialogExamples,
-  inputExamples,
-  listExamples,
-  menuExamples,
-  ratingExamples,
-  selectExamples,
-  sliderExamples,
-  snackbarExamples,
-  switchExamples,
-  textFieldExamples,
-  toggleButtonExamples,
-} from './examples';
+import { basicAccordionUIExample } from './examples/accordion/BasicAccordion.examples';
+import { basicAlertUIExample } from './examples/alert/BasicAlert.examples';
+import { basicAutoCompleteUIExample } from './examples/autocomplete/BasicAutoComplete.examples';
+import { basicBadgeUIExample } from './examples/badge/BasicBadge.examples';
+import { complexButtonUIExample } from './examples/button/ComplexButton.example';
+import { iconAndLabelButtonUIExample } from './examples/button/IconAndLabelButton.example';
+import { iconCheckboxUIExample } from './examples/checkbox/IconCheckbox.examples';
+import { indeterminateCheckboxUIExample } from './examples/checkbox/IndeterminateCheckbox.examples';
+import { labelCheckboxUIExample } from './examples/checkbox/LabelCheckbox.examples';
+import { basicChipUIExample } from './examples/chip/BasicChip.examples';
+import { clickableChipUIExample } from './examples/chip/ClickableChip.examples';
+import { deletableChipUIExample } from './examples/chip/DeletableChip.examples';
+import { alertDialogUIExample } from './examples/dialog/AlertDialog.examples';
+import { slideInDialogUIExample } from './examples/dialog/SlideInDialog.examples';
+import { basicInputUIExample } from './examples/input/BasicInput.examples';
+import { selectableListUIExample } from './examples/list/SelectableList.example';
+import { accountMenuUIExample } from './examples/menu/AccountMenu.examples';
+import { basicProgressUIExample } from './examples/progress/Progress.examples';
+import { basicRatingUIExample } from './examples/rating/Rating.examples';
+import { basicSelectUIExample } from './examples/select/BasicSelect.examples';
+import { nativeSelectUIExample } from './examples/select/NativeSelect.examples';
+import { basicSliderUIExample } from './examples/slider/BasicSlider.examples';
+import { basicSnackbarUIExample } from './examples/snackbar/BasicSnackbar.examples';
+import { basicSwitchUIExample } from './examples/switch/BasicSwitch.examples';
+import { basicTextFieldUIExample } from './examples/textField/BasicTextField.examples';
+import { dateTextFieldUIExample } from './examples/textField/DateTextField.examples';
+import { multilineTextFieldUIExample } from './examples/textField/MultilineTextField.examples';
+import { readonlyAndDisabledTextFieldUIExample } from './examples/textField/ReadonlyDisabledTextField.examples';
+import { selectTextFieldUIExample } from './examples/textField/SelectTextField.examples';
+import { exclusiveSelectionUIExample } from './examples/toggleButton/ExclusiveSelection.example';
+import { regularSelectionUIExample } from './examples/toggleButton/MultipleSelection.example';
+import { singleToggleUIExample } from './examples/toggleButton/SingleToggle.example';
 
 interface IToc {
   label: string;
@@ -30,91 +42,106 @@ export const tocs: IToc[] = [
   {
     label: 'Accordion',
     path: '/accordion',
-    ui: <ExampleList examples={accordionExamples} />,
+    ui: <ExampleList examples={[basicAccordionUIExample]} />,
   },
   {
     label: 'Alert',
     path: '/alert',
-    ui: <ExampleList examples={alertExamples} />,
+    ui: <ExampleList examples={[basicAlertUIExample]} />,
   },
   {
     label: 'AutoComplete',
     path: '/autocomplete',
-    ui: <ExampleList examples={autoCompleteExamples} />,
+    ui: <ExampleList examples={[basicAutoCompleteUIExample]} />,
   },
   {
     label: 'Badge',
     path: '/badge',
-    ui: <ExampleList examples={badgeExamples} />,
+    ui: <ExampleList examples={[basicBadgeUIExample]} />,
   },
   {
     label: 'Button',
     path: '/button',
-    ui: <ExampleList examples={buttonExamples} />,
+    ui: <ExampleList examples={[complexButtonUIExample, iconAndLabelButtonUIExample]} />,
   },
   {
     label: 'Checkbox',
     path: '/checkbox',
-    ui: <ExampleList examples={checkboxExamples} />,
+    ui: <ExampleList examples={[iconCheckboxUIExample, indeterminateCheckboxUIExample, labelCheckboxUIExample]} />,
   },
   {
     label: 'Chip',
     path: '/chip',
-    ui: <ExampleList examples={chipExamples} />,
+    ui: <ExampleList examples={[basicChipUIExample, clickableChipUIExample, deletableChipUIExample]} />,
   },
   {
     label: 'Dialog',
     path: '/dialog',
-    ui: <ExampleList examples={dialogExamples} />,
+    ui: <ExampleList examples={[alertDialogUIExample, slideInDialogUIExample]} />,
   },
   {
     label: 'Input',
     path: '/input',
-    ui: <ExampleList examples={inputExamples} />,
+    ui: <ExampleList examples={[basicInputUIExample]} />,
   },
   {
     label: 'List',
     path: '/list',
-    ui: <ExampleList examples={listExamples} />,
+    ui: <ExampleList examples={[selectableListUIExample]} />,
   },
   {
     label: 'Menu',
     path: '/menu',
-    ui: <ExampleList examples={menuExamples} />,
+    ui: <ExampleList examples={[accountMenuUIExample]} />,
+  },
+  {
+    label: 'Progress',
+    path: '/progress',
+    ui: <ExampleList examples={[basicProgressUIExample]} />,
   },
   {
     label: 'Rating',
     path: '/rating',
-    ui: <ExampleList examples={ratingExamples} />,
+    ui: <ExampleList examples={[basicRatingUIExample]} />,
   },
   {
     label: 'Select',
     path: '/select',
-    ui: <ExampleList examples={selectExamples} />,
+    ui: <ExampleList examples={[basicSelectUIExample, nativeSelectUIExample]} />,
   },
   {
     label: 'Slider',
     path: '/slider',
-    ui: <ExampleList examples={sliderExamples} />,
+    ui: <ExampleList examples={[basicSliderUIExample]} />,
   },
   {
     label: 'Snackbar',
     path: '/snackbar',
-    ui: <ExampleList examples={snackbarExamples} />,
+    ui: <ExampleList examples={[basicSnackbarUIExample]} />,
   },
   {
     label: 'Switch',
     path: '/switch',
-    ui: <ExampleList examples={switchExamples} />,
+    ui: <ExampleList examples={[basicSwitchUIExample]} />,
   },
   {
     label: 'TextField',
     path: '/textfield',
-    ui: <ExampleList examples={textFieldExamples} />,
+    ui: (
+      <ExampleList
+        examples={[
+          basicTextFieldUIExample,
+          dateTextFieldUIExample,
+          multilineTextFieldUIExample,
+          readonlyAndDisabledTextFieldUIExample,
+          selectTextFieldUIExample,
+        ]}
+      />
+    ),
   },
   {
     label: 'ToggleButton',
     path: '/toggle-button',
-    ui: <ExampleList examples={toggleButtonExamples} />,
+    ui: <ExampleList examples={[singleToggleUIExample, regularSelectionUIExample, exclusiveSelectionUIExample]} />,
   },
 ];

--- a/packages/component-driver-mui-v5-test/src/examples/accordion/BasicAccordion.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/accordion/BasicAccordion.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { AccordionDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -33,74 +31,12 @@ export const BasicAccordion: React.FunctionComponent = () => {
   );
 };
 
-export const basicAccordionExampleScenePart = {
-  normalAccordion: {
-    locator: byDataTestId('accordion-normal'),
-    driver: AccordionDriver,
-  },
-  disabledAccordion: {
-    locator: byDataTestId('accordion-disabled'),
-    driver: AccordionDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Alert example from MUI's website
  * @see https://mui.com/material-ui/react-accordion#description
  */
-export const basicAccordionExample: IExampleUnit<typeof basicAccordionExampleScenePart, JSX.Element> = {
+export const basicAccordionUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Accordion',
-  scene: basicAccordionExampleScenePart,
   ui: <BasicAccordion />,
 };
 //#endregion
-
-export const basicAccordionTestSuite: TestSuiteInfo<typeof basicAccordionExampleScenePart> = {
-  title: 'Basic Accordion',
-  url: '/accordion',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicAccordionExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicAccordionExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Normal Accordion is not disabled by default', async () => {
-      const isDisabled = await testEngine.parts.normalAccordion.isDisabled();
-      assertEqual(isDisabled, false);
-    });
-
-    test('Normal Accordion is not expanded by default', async () => {
-      const isExpanded = await testEngine.parts.normalAccordion.isExpanded();
-      assertEqual(isExpanded, false);
-    });
-
-    test('Normal Accordion can be expanded', async () => {
-      await testEngine.parts.normalAccordion.expand();
-      const isExpanded = await testEngine.parts.normalAccordion.isExpanded();
-      assertEqual(isExpanded, true);
-    });
-
-    test('Normal Accordion can be collapsed', async () => {
-      await testEngine.parts.normalAccordion.expand();
-      await testEngine.parts.normalAccordion.collapse();
-      const isExpanded = await testEngine.parts.normalAccordion.isExpanded();
-      assertEqual(isExpanded, false);
-    });
-
-    test('Disabled Accordion is disabled', async () => {
-      const isDisabled = await testEngine.parts.disabledAccordion.isDisabled();
-      assertEqual(isDisabled, true);
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/accordion/BasicAccordion.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/accordion/BasicAccordion.suite.ts
@@ -1,0 +1,56 @@
+import { AccordionDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicAccordionUIExample } from './BasicAccordion.examples';
+
+export const basicAccordionExampleScenePart = {
+  normalAccordion: {
+    locator: byDataTestId('accordion-normal'),
+    driver: AccordionDriver,
+  },
+  disabledAccordion: {
+    locator: byDataTestId('accordion-disabled'),
+    driver: AccordionDriver,
+  },
+} satisfies ScenePart;
+
+export const basicAccordionExample: IExampleUnit<typeof basicAccordionExampleScenePart, JSX.Element> = {
+  ...basicAccordionUIExample,
+  scene: basicAccordionExampleScenePart,
+};
+
+export const basicAccordionTestSuite: TestSuiteInfo<typeof basicAccordionExample.scene> = {
+  title: 'Basic Accordion',
+  url: '/accordion',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${basicAccordionExample.title}`, () => {
+      let testEngine: TestEngine<typeof basicAccordionExample.scene>;
+
+      // Use the following beforeEach to work around the issue of Playwright's page being undefined
+      // @ts-ignore
+      beforeEach(function ({ page }) {
+        // @ts-ignore
+        testEngine = getTestEngine(basicAccordionExample.scene, { page });
+        if (typeof arguments[0] === 'function') {
+          arguments[0]();
+        }
+      });
+
+      afterEach(async () => {
+        await testEngine.cleanUp();
+      });
+
+      test(`Normal accordion should be expanded and show content when clicked`, async () => {
+        await testEngine.parts.normalAccordion.expand();
+        const expanded = await testEngine.parts.normalAccordion.isExpanded();
+        assertEqual(expanded, true);
+      });
+
+      test(`Disabled accordion is not interactive`, async () => {
+        const disabled = await testEngine.parts.disabledAccordion.isDisabled();
+        assertEqual(disabled, true);
+      });
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/accordion/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/accordion/index.ts
@@ -1,8 +1,11 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicAccordionExample, basicAccordionTestSuite } from './BasicAccordion.examples';
+import { basicAccordionUIExample } from './BasicAccordion.examples';
+import { basicAccordionExample, basicAccordionTestSuite } from './BasicAccordion.suite';
 
-export { basicAccordionExample, basicAccordionTestSuite };
+export { basicAccordionUIExample, basicAccordionExample, basicAccordionTestSuite };
 
 export const accordionExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicAccordionExample] satisfies IExampleUnit<
   ScenePart,

--- a/packages/component-driver-mui-v5-test/src/examples/alert/BasicAlert.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/alert/BasicAlert.examples.tsx
@@ -1,156 +1,38 @@
 import React from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { AlertDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import Stack from '@mui/material/Stack';
 
-//#region Label alert
+//#region Alert
 export const BasicAlert: React.FunctionComponent = () => {
   return (
-    <Stack direction='column' gap={1}>
-      <Alert severity='error' data-testid='error-alert'>
+    <Stack sx={{ width: '100%' }} spacing={2}>
+      <Alert data-testid='error' severity='error'>
         <AlertTitle>Error</AlertTitle>
-        This is an error alert — <strong data-testid='code'>code: red</strong>
+        <strong>code: red</strong> — This is an error alert — check it out!
       </Alert>
-      <Alert severity='warning' data-testid='warning-alert'>
+      <Alert data-testid='warning' severity='warning'>
         <AlertTitle>Warning</AlertTitle>
-        This is a warning alert — <strong data-testid='code'>code: yellow</strong>
+        <strong>code: yellow</strong> — This is a warning alert — check it out!
       </Alert>
-      <Alert severity='info' data-testid='info-alert'>
-        <AlertTitle>Info</AlertTitle>
-        This is an info alert — <strong>check it out!</strong>
+      <Alert data-testid='info' severity='info'>
+        This is an info alert — check it out!
       </Alert>
-      <Alert severity='success' data-testid='success-alert'>
-        <AlertTitle>Success</AlertTitle>
-        This is a success alert — <strong>check it out!</strong>
+      <Alert data-testid='success' severity='success'>
+        This is a success alert — check it out!
       </Alert>
     </Stack>
   );
 };
 
-const contentPart = {
-  code: {
-    locator: byDataTestId('code'),
-    driver: HTMLElementDriver,
-  },
-} satisfies ScenePart;
-
-export const basicAlertExampleScenePart = {
-  error: {
-    locator: byDataTestId('error-alert'),
-    driver: AlertDriver<typeof contentPart>,
-    option: {
-      content: contentPart,
-    },
-  },
-  warning: {
-    locator: byDataTestId('warning-alert'),
-    driver: AlertDriver<typeof contentPart>,
-    option: {
-      content: contentPart,
-    },
-  },
-  info: {
-    locator: byDataTestId('info-alert'),
-    driver: AlertDriver,
-  },
-  success: {
-    locator: byDataTestId('success-alert'),
-    driver: AlertDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Alert example from MUI's website
  * @see https://mui.com/material-ui/react-alert#description
  */
-export const basicAlertExample: IExampleUnit<typeof basicAlertExampleScenePart, JSX.Element> = {
+export const basicAlertUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Alert',
-  scene: basicAlertExampleScenePart,
   ui: <BasicAlert />,
 };
 //#endregion
-
-export const basicAlertTestSuite: TestSuiteInfo<typeof basicAlertExampleScenePart> = {
-  title: 'Basic Alert',
-  url: '/alert',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicAlertExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicAlertExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    //#region Error
-    test(`Error alert's code should be "code: red"`, async () => {
-      const val = await testEngine.parts.error.content.code.getText();
-      assertEqual(val, 'code: red');
-    });
-
-    test(`Error alert's severity should be error`, async () => {
-      const val = await testEngine.parts.error.getSeverity();
-      assertEqual(val, 'error');
-    });
-
-    test(`Error alert's title should be Error`, async () => {
-      const val = await testEngine.parts.error.getTitle();
-      assertEqual(val, 'Error');
-    });
-
-    test(`Error alert's message should contain the correct text`, async () => {
-      const val = await testEngine.parts.error.getMessage();
-      assertEqual(val?.includes('an error alert'), true);
-    });
-    //#endregion
-
-    //#region Warning
-    test(`Warning alert's code should be "code: yellow"`, async () => {
-      const val = await testEngine.parts.warning.content.code.getText();
-      assertEqual(val, 'code: yellow');
-    });
-
-    test(`Warning alert's severity should be warning`, async () => {
-      const val = await testEngine.parts.warning.getSeverity();
-      assertEqual(val, 'warning');
-    });
-
-    test(`Warning alert's title should be Warning`, async () => {
-      const val = await testEngine.parts.warning.getTitle();
-      assertEqual(val, 'Warning');
-    });
-
-    test(`Warning alert's message should contain the correct text`, async () => {
-      const val = await testEngine.parts.warning.getMessage();
-      assertEqual(val?.includes('a warning alert'), true);
-    });
-    //#endregion
-
-    //#region Info
-    test(`Info alert's severity should be info`, async () => {
-      const val = await testEngine.parts.info.getSeverity();
-      assertEqual(val, 'info');
-    });
-    //#endregion
-
-    //#region Success
-    test(`Success alert's severity should be success`, async () => {
-      const val = await testEngine.parts.success.getSeverity();
-      assertEqual(val, 'success');
-    });
-    //#endregion
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/alert/BasicAlert.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/alert/BasicAlert.suite.ts
@@ -1,0 +1,101 @@
+import { AlertDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicAlertUIExample } from './BasicAlert.examples';
+
+export const basicAlertExampleScenePart = {
+  error: {
+    locator: byDataTestId('error'),
+    driver: AlertDriver,
+  },
+  warning: {
+    locator: byDataTestId('warning'),
+    driver: AlertDriver,
+  },
+  info: {
+    locator: byDataTestId('info'),
+    driver: AlertDriver,
+  },
+  success: {
+    locator: byDataTestId('success'),
+    driver: AlertDriver,
+  },
+} satisfies ScenePart;
+
+export const basicAlertExample: IExampleUnit<typeof basicAlertExampleScenePart, JSX.Element> = {
+  ...basicAlertUIExample,
+  scene: basicAlertExampleScenePart,
+};
+
+export const basicAlertTestSuite: TestSuiteInfo<typeof basicAlertExample.scene> = {
+  title: 'Basic Alert',
+  url: '/alert',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicAlertExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicAlertExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Error alert\'s code should be "code: red"', async () => {
+      const message = await testEngine.parts.error.getMessage();
+      assertEqual((message ?? '').includes('code: red'), true);
+    });
+
+    test("Error alert's severity should be error", async () => {
+      const severity = await testEngine.parts.error.getSeverity();
+      assertEqual(severity, 'error');
+    });
+
+    test("Error alert's title should be Error", async () => {
+      const title = await testEngine.parts.error.getTitle();
+      assertEqual(title, 'Error');
+    });
+
+    test("Error alert's message should contain the correct text", async () => {
+      const message = await testEngine.parts.error.getMessage();
+      assertEqual((message ?? '').includes('This is an error alert'), true);
+    });
+
+    test('Warning alert\'s code should be "code: yellow"', async () => {
+      const message = await testEngine.parts.warning.getMessage();
+      assertEqual((message ?? '').includes('code: yellow'), true);
+    });
+
+    test("Warning alert's severity should be warning", async () => {
+      const severity = await testEngine.parts.warning.getSeverity();
+      assertEqual(severity, 'warning');
+    });
+
+    test("Warning alert's title should be Warning", async () => {
+      const title = await testEngine.parts.warning.getTitle();
+      assertEqual(title, 'Warning');
+    });
+
+    test("Warning alert's message should contain the correct text", async () => {
+      const message = await testEngine.parts.warning.getMessage();
+      assertEqual((message ?? '').includes('This is a warning alert'), true);
+    });
+
+    test("Info alert's severity should be info", async () => {
+      const severity = await testEngine.parts.info.getSeverity();
+      assertEqual(severity, 'info');
+    });
+
+    test("Success alert's severity should be success", async () => {
+      const severity = await testEngine.parts.success.getSeverity();
+      assertEqual(severity, 'success');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/alert/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/alert/index.ts
@@ -1,8 +1,11 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicAlertExample, basicAlertTestSuite } from './BasicAlert.examples';
+import { basicAlertUIExample } from './BasicAlert.examples';
+import { basicAlertExample, basicAlertTestSuite } from './BasicAlert.suite';
 
-export { basicAlertExample, basicAlertTestSuite };
+export { basicAlertUIExample, basicAlertExample, basicAlertTestSuite };
 
 export const alertExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicAlertExample] satisfies IExampleUnit<
   ScenePart,

--- a/packages/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback } from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { AutoCompleteDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Autocomplete from '@mui/material/Autocomplete';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
@@ -87,111 +84,12 @@ export const BasicAutoComplete: React.FunctionComponent = () => {
   );
 };
 
-export const basicAutoCompleteExampleScenePart = {
-  select: {
-    locator: byDataTestId('basic-auto-complete'),
-    driver: AutoCompleteDriver,
-  },
-  selectedLabel: {
-    locator: byDataTestId('selected-label'),
-    driver: HTMLElementDriver,
-  },
-
-  portalSelect: {
-    locator: byDataTestId('portal-auto-complete'),
-    driver: AutoCompleteDriver,
-  },
-  portalSelectedLabel: {
-    locator: byDataTestId('portal-selected-label'),
-    driver: HTMLElementDriver,
-  },
-
-  readonlySelect: {
-    locator: byDataTestId('readonly-auto-complete'),
-    driver: AutoCompleteDriver,
-  },
-
-  disabledSelect: {
-    locator: byDataTestId('disabled-auto-complete'),
-    driver: AutoCompleteDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic AutoComplete example from MUI's website
  * @see https://mui.com/material-ui/react-autocomplete/#combo-box
  */
-export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExampleScenePart, JSX.Element> = {
+export const basicAutoCompleteUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic AutoComplete',
-  scene: basicAutoCompleteExampleScenePart,
   ui: <BasicAutoComplete />,
 };
 //#endregion
-
-export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteExampleScenePart> = {
-  title: 'Basic AutoComplete',
-  url: '/AutoComplete',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicAutoCompleteExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicAutoCompleteExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    describe('AutoComplete with portal disabled', () => {
-      test('should select a value', async () => {
-        await testEngine.parts.select.setValue('The Godfather');
-        const selected = await testEngine.parts.selectedLabel.getText();
-        assertEqual(selected, 'The Godfather');
-      });
-
-      test('isDisabled should be false', async () => {
-        const isDisabled = await testEngine.parts.select.isDisabled();
-        assertEqual(isDisabled, false);
-      });
-
-      test('isReadOnly should be false', async () => {
-        const isReadOnly = await testEngine.parts.select.isReadonly();
-        assertEqual(isReadOnly, false);
-      });
-    });
-
-    describe('AutoComplete with portal enabled', () => {
-      test('should select a value correctly', async () => {
-        await testEngine.parts.portalSelect.setValue('The Godfather');
-        const selected = await testEngine.parts.portalSelectedLabel.getText();
-        assertEqual(selected, 'The Godfather');
-      });
-
-      test('isDisabled should be false', async () => {
-        const isDisabled = await testEngine.parts.portalSelect.isDisabled();
-        assertEqual(isDisabled, false);
-      });
-
-      test('isReadOnly should be false', async () => {
-        const isReadOnly = await testEngine.parts.portalSelect.isReadonly();
-        assertEqual(isReadOnly, false);
-      });
-    });
-
-    test('Readonly Auto complete should be readonly', async () => {
-      const isReadOnly = await testEngine.parts.readonlySelect.isReadonly();
-      assertEqual(isReadOnly, true);
-    });
-
-    test('Disabled Auto complete should be disabled', async () => {
-      const isDisabled = await testEngine.parts.disabledSelect.isDisabled();
-      assertEqual(isDisabled, true);
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -1,0 +1,90 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { AutoCompleteDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicAutoCompleteUIExample } from './BasicAutoComplete.examples';
+
+export const basicAutoCompleteExampleScenePart = {
+  select: {
+    locator: byDataTestId('basic-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+  selectedLabel: {
+    locator: byDataTestId('selected-label'),
+    driver: HTMLElementDriver,
+  },
+
+  portalSelect: {
+    locator: byDataTestId('portal-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+  portalSelectedLabel: {
+    locator: byDataTestId('portal-selected-label'),
+    driver: HTMLElementDriver,
+  },
+
+  readonlySelect: {
+    locator: byDataTestId('readonly-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+
+  disabledSelect: {
+    locator: byDataTestId('disabled-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+} satisfies ScenePart;
+
+export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExampleScenePart, JSX.Element> = {
+  ...basicAutoCompleteUIExample,
+  scene: basicAutoCompleteExampleScenePart,
+};
+
+export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteExample.scene> = {
+  title: 'Basic AutoComplete',
+  url: '/autocomplete',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicAutoCompleteExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicAutoCompleteExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Selected label should be empty initially', async () => {
+      const text = await testEngine.parts.selectedLabel.getText();
+      assertEqual(text, '');
+    });
+
+    test('Select can choose an option', async () => {
+      await testEngine.parts.select.setValue('The Shawshank Redemption');
+      const text = await testEngine.parts.selectedLabel.getText();
+      assertEqual(text, 'The Shawshank Redemption');
+    });
+
+    test('Portal select can choose an option', async () => {
+      await testEngine.parts.portalSelect.setValue('The Godfather');
+      const text = await testEngine.parts.portalSelectedLabel.getText();
+      assertEqual(text, 'The Godfather');
+    });
+
+    test('Readonly select should not be interactive', async () => {
+      const isReadonly = await testEngine.parts.readonlySelect.isReadonly();
+      assertEqual(isReadonly, true);
+    });
+
+    test('Disabled select should be disabled', async () => {
+      const isDisabled = await testEngine.parts.disabledSelect.isDisabled();
+      assertEqual(isDisabled, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/autocomplete/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/autocomplete/index.ts
@@ -1,8 +1,11 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicAutoCompleteExample, basicAutoCompleteTestSuite } from './BasicAutoComplete.examples';
+import { basicAutoCompleteUIExample } from './BasicAutoComplete.examples';
+import { basicAutoCompleteExample, basicAutoCompleteTestSuite } from './BasicAutoComplete.suite';
 
-export { basicAutoCompleteExample, basicAutoCompleteTestSuite };
+export { basicAutoCompleteUIExample, basicAutoCompleteExample, basicAutoCompleteTestSuite };
 
 export const autoCompleteExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicAutoCompleteExample,

--- a/packages/component-driver-mui-v5-test/src/examples/badge/BasicBadge.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/badge/BasicBadge.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { BadgeDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import MailIcon from '@mui/icons-material/Mail';
 import Badge from '@mui/material/Badge';
 
@@ -15,47 +13,12 @@ export const BasicBadge: React.FunctionComponent = () => {
   );
 };
 
-export const basicBadgeExampleScenePart = {
-  basicBadge: {
-    locator: byDataTestId('basic-badge'),
-    driver: BadgeDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Basic Alert example from MUI's website
+ * Basic Badge example from MUI's website
  * @see https://mui.com/material-ui/react-badge#description
  */
-export const basicBadgeExample: IExampleUnit<typeof basicBadgeExampleScenePart, JSX.Element> = {
+export const basicBadgeUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Badge',
-  scene: basicBadgeExampleScenePart,
   ui: <BasicBadge />,
 };
 //#endregion
-
-export const basicBadgeTestSuite: TestSuiteInfo<typeof basicBadgeExampleScenePart> = {
-  title: 'Basic Badge',
-  url: '/badge',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicBadgeExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicBadgeExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Badge should display 12', async () => {
-      const badgeContent = await testEngine.parts.basicBadge.getContent();
-      assertEqual(badgeContent, '12');
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/badge/BasicBadge.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/badge/BasicBadge.suite.ts
@@ -1,0 +1,49 @@
+import { BadgeDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicBadgeUIExample } from './BasicBadge.examples';
+
+export const basicBadgeExampleScenePart = {
+  basicBadge: {
+    locator: byDataTestId('basic-badge'),
+    driver: BadgeDriver,
+  },
+} satisfies ScenePart;
+
+export const basicBadgeExample: IExampleUnit<typeof basicBadgeExampleScenePart, JSX.Element> = {
+  ...basicBadgeUIExample,
+  scene: basicBadgeExampleScenePart,
+};
+
+export const basicBadgeTestSuite: TestSuiteInfo<typeof basicBadgeExample.scene> = {
+  title: 'Basic Badge',
+  url: '/badge',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicBadgeExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicBadgeExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Badge should display correct content', async () => {
+      const content = await testEngine.parts.basicBadge.getContent();
+      assertEqual(content, '12');
+    });
+
+    test('Badge should exist', async () => {
+      const exists = await testEngine.parts.basicBadge.exists();
+      assertEqual(exists, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/badge/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/badge/index.ts
@@ -1,8 +1,11 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicBadgeExample, basicBadgeTestSuite } from './BasicBadge.examples';
+import { basicBadgeUIExample } from './BasicBadge.examples';
+import { basicBadgeExample, basicBadgeTestSuite } from './BasicBadge.suite';
 
-export { basicBadgeExample, basicBadgeTestSuite };
+export { basicBadgeUIExample, basicBadgeExample, basicBadgeTestSuite };
 
 export const badgeExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicBadgeExample] satisfies IExampleUnit<
   ScenePart,

--- a/packages/component-driver-mui-v5-test/src/examples/button/ComplexButton.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/button/ComplexButton.example.tsx
@@ -1,167 +1,32 @@
 import React from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { ButtonDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
-import ButtonBase from '@mui/material/ButtonBase';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-import { styled } from '@mui/material/styles';
 
-//#region Complex example
-
-const ImageButton = styled(ButtonBase)(({ theme }) => ({
-  position: 'relative',
-  height: 200,
-  [theme.breakpoints.down('sm')]: {
-    width: '100% !important', // Overrides inline-style
-    height: 100,
-  },
-  '&:hover, &.Mui-focusVisible': {
-    zIndex: 1,
-    '& .MuiImageBackdrop-root': {
-      opacity: 0.15,
-    },
-    '& .MuiImageMarked-root': {
-      opacity: 0,
-    },
-    '& .MuiTypography-root': {
-      border: '4px solid currentColor',
-    },
-  },
-}));
-
-const ImageSrc = styled('span')({
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
-  backgroundSize: 'cover',
-  backgroundPosition: 'center 40%',
-});
-
-const Image = styled('span')(({ theme }) => ({
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: theme.palette.common.white,
-}));
-
-const ImageBackdrop = styled('span')(({ theme }) => ({
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
-  backgroundColor: theme.palette.common.black,
-  opacity: 0.4,
-  transition: theme.transitions.create('opacity'),
-}));
-
-const ImageMarked = styled('span')(({ theme }) => ({
-  height: 3,
-  width: 18,
-  backgroundColor: theme.palette.common.white,
-  position: 'absolute',
-  bottom: -2,
-  left: 'calc(50% - 9px)',
-  transition: theme.transitions.create('opacity'),
-}));
-
-export const ComplexExample = () => {
-  const [target, setTarget] = React.useState('');
+//#region Complex button
+export const ComplexButton: React.FunctionComponent = () => {
   return (
-    <Stack direction='row' spacing={10}>
-      <ImageButton
-        data-testid='image-button'
-        focusRipple
-        style={{
-          width: '50%',
-        }}
-        onClick={() => setTarget('image-button')}>
-        <ImageSrc style={{ backgroundImage: `url(https://mui.com/static/images/buttons/camera.jpg)` }} />
-        <ImageBackdrop className='MuiImageBackdrop-root' />
-        <Image>
-          <Typography
-            component='span'
-            variant='subtitle1'
-            color='inherit'
-            sx={{
-              position: 'relative',
-              p: 4,
-              pt: 2,
-              pb: theme => `calc(${theme.spacing(1)} + 6px)`,
-            }}>
-            Camera
-            <ImageMarked className='MuiImageMarked-root' />
-          </Typography>
-        </Image>
-      </ImageButton>
-      <div data-testid='image-button-target'>{target}</div>
+    <Stack direction='row' spacing={1}>
+      <Button data-testid='contained' variant='contained'>
+        Contained
+      </Button>
+      <Button data-testid='outlined' variant='outlined'>
+        Outlined
+      </Button>
+      <Button data-testid='text' variant='text'>
+        Text
+      </Button>
     </Stack>
   );
 };
 
-export const complexExampleScenePart = {
-  imageButton: {
-    locator: byDataTestId('image-button'),
-    driver: ButtonDriver,
-  },
-  target: {
-    locator: byDataTestId('image-button-target'),
-    driver: HTMLElementDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Icon button complex example from MUI's website
- * @see https://mui.com/material-ui/react-button/#complex-button
+ * Complex Button example from MUI's website
+ * @see https://mui.com/material-ui/react-button#description
  */
-export const complexExample: IExampleUnit<typeof complexExampleScenePart, JSX.Element> = {
-  title: 'Complex button',
-  scene: complexExampleScenePart,
-  ui: <ComplexExample />,
+export const complexButtonUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Complex Button',
+  ui: <ComplexButton />,
 };
 //#endregion
-
-export const complexButtonTestSuite: TestSuiteInfo<typeof complexExample.scene> = {
-  title: 'Complex button',
-  url: '/button',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${complexExample.title}`, () => {
-      let testEngine: TestEngine<typeof complexExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(complexExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Image target should be empty initially`, async () => {
-        const text = await testEngine.parts.target.getText();
-        assertEqual(text, '');
-      });
-
-      test(`Click on image-button should display image-button`, async () => {
-        await testEngine.parts.imageButton.click();
-        const text = await testEngine.parts.target.getText();
-        assertEqual(text, 'image-button');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/button/ComplexButton.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/button/ComplexButton.suite.ts
@@ -1,0 +1,67 @@
+import { ButtonDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { complexButtonUIExample } from './ComplexButton.example';
+
+export const complexButtonExampleScenePart = {
+  contained: {
+    locator: byDataTestId('contained'),
+    driver: ButtonDriver,
+  },
+  outlined: {
+    locator: byDataTestId('outlined'),
+    driver: ButtonDriver,
+  },
+  text: {
+    locator: byDataTestId('text'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const complexButtonExample: IExampleUnit<typeof complexButtonExampleScenePart, JSX.Element> = {
+  ...complexButtonUIExample,
+  scene: complexButtonExampleScenePart,
+};
+
+export const complexButtonTestSuite: TestSuiteInfo<typeof complexButtonExample.scene> = {
+  title: 'Complex Button',
+  url: '/button',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${complexButtonExample.title}`, () => {
+      let testEngine: TestEngine<typeof complexButtonExample.scene>;
+
+      // Use the following beforeEach to work around the issue of Playwright's page being undefined
+      // @ts-ignore
+      beforeEach(function ({ page }) {
+        // @ts-ignore
+        testEngine = getTestEngine(complexButtonExample.scene, { page });
+        if (typeof arguments[0] === 'function') {
+          arguments[0]();
+        }
+      });
+
+      afterEach(async () => {
+        await testEngine.cleanUp();
+      });
+
+      test('Contained button should exist and be clickable', async () => {
+        const exists = await testEngine.parts.contained.exists();
+        assertEqual(exists, true);
+        await testEngine.parts.contained.click();
+      });
+
+      test('Outlined button should exist and be clickable', async () => {
+        const exists = await testEngine.parts.outlined.exists();
+        assertEqual(exists, true);
+        await testEngine.parts.outlined.click();
+      });
+
+      test('Text button should exist and be clickable', async () => {
+        const exists = await testEngine.parts.text.exists();
+        assertEqual(exists, true);
+        await testEngine.parts.text.click();
+      });
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/button/IconAndLabelButton.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/button/IconAndLabelButton.example.tsx
@@ -1,102 +1,31 @@
 import React from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { ButtonDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
-import AlarmIcon from '@mui/icons-material/Alarm';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import DeleteIcon from '@mui/icons-material/Delete';
 import SendIcon from '@mui/icons-material/Send';
 import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 
-//#region Icon and label
-export const IconAndLabelExample = () => {
-  const [target, setTarget] = React.useState('');
+//#region Icon & label button
+export const IconAndLabelButton: React.FunctionComponent = () => {
   return (
-    <Stack direction='row' spacing={10}>
-      <IconButton
-        color='secondary'
-        aria-label='add an alarm'
-        data-testid='icon-button'
-        onClick={() => setTarget('icon-button')}>
-        <AlarmIcon />
-      </IconButton>
-      <Button
-        variant='contained'
-        endIcon={<SendIcon />}
-        data-testid='icon-label-button'
-        onClick={() => setTarget('icon-label-button')}>
+    <Stack direction='row' spacing={2}>
+      <Button data-testid='icon-button' variant='outlined' startIcon={<DeleteIcon />}>
+        Delete
+      </Button>
+      <Button data-testid='icon-label-button' variant='contained' endIcon={<SendIcon />}>
         Send
       </Button>
-      <div data-testid='target'>{target}</div>
     </Stack>
   );
 };
 
-export const iconAndLabelExampleScenePart = {
-  iconButton: {
-    locator: byDataTestId('icon-button'),
-    driver: ButtonDriver,
-  },
-  iconLabelButton: {
-    locator: byDataTestId('icon-label-button'),
-    driver: ButtonDriver,
-  },
-  target: {
-    locator: byDataTestId('target'),
-    driver: HTMLElementDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Icon button example from MUI's website
- * @see https://mui.com/material-ui/react-button/#icon-button
+ * Icon and label button example from MUI's website
+ * @see https://mui.com/material-ui/react-button#icon-and-label-buttons
  */
-export const iconAndLabelExample: IExampleUnit<typeof iconAndLabelExampleScenePart, JSX.Element> = {
+export const iconAndLabelButtonUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Icon & Label',
-  scene: iconAndLabelExampleScenePart,
-  ui: <IconAndLabelExample />,
+  ui: <IconAndLabelButton />,
 };
 //#endregion
-
-export const iconAndLabelButtonTestSuite: TestSuiteInfo<typeof iconAndLabelExampleScenePart> = {
-  title: 'Icon & Label',
-  url: '/button',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${iconAndLabelExample.title}`, () => {
-      let testEngine: TestEngine<typeof iconAndLabelExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(iconAndLabelExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Target should be empty initially`, async () => {
-        const text = await testEngine.parts.target.getText();
-        assertEqual(text, '');
-      });
-
-      test(`Click on icon-button should display icon-button`, async () => {
-        await testEngine.parts.iconButton.click();
-        const text = await testEngine.parts.target.getText();
-        assertEqual(text, 'icon-button');
-      });
-
-      test(`Click on icon-label-button should display icon-label-button`, async () => {
-        await testEngine.parts.iconLabelButton.click();
-        const text = await testEngine.parts.target.getText();
-        assertEqual(text, 'icon-label-button');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/button/IconAndLabelButton.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/button/IconAndLabelButton.suite.ts
@@ -1,0 +1,57 @@
+import { ButtonDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { iconAndLabelButtonUIExample } from './IconAndLabelButton.example';
+
+export const iconAndLabelExampleScenePart = {
+  iconButton: {
+    locator: byDataTestId('icon-button'),
+    driver: ButtonDriver,
+  },
+  iconLabelButton: {
+    locator: byDataTestId('icon-label-button'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const iconAndLabelExample: IExampleUnit<typeof iconAndLabelExampleScenePart, JSX.Element> = {
+  ...iconAndLabelButtonUIExample,
+  scene: iconAndLabelExampleScenePart,
+};
+
+export const iconAndLabelButtonTestSuite: TestSuiteInfo<typeof iconAndLabelExample.scene> = {
+  title: 'Icon & Label',
+  url: '/button',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${iconAndLabelExample.title}`, () => {
+      let testEngine: TestEngine<typeof iconAndLabelExample.scene>;
+
+      // Use the following beforeEach to work around the issue of Playwright's page being undefined
+      // @ts-ignore
+      beforeEach(function ({ page }) {
+        // @ts-ignore
+        testEngine = getTestEngine(iconAndLabelExample.scene, { page });
+        if (typeof arguments[0] === 'function') {
+          arguments[0]();
+        }
+      });
+
+      afterEach(async () => {
+        await testEngine.cleanUp();
+      });
+
+      test('Icon button should exist and be clickable', async () => {
+        const exists = await testEngine.parts.iconButton.exists();
+        assertEqual(exists, true);
+        await testEngine.parts.iconButton.click();
+      });
+
+      test('Icon-label button should exist and be clickable', async () => {
+        const exists = await testEngine.parts.iconLabelButton.exists();
+        assertEqual(exists, true);
+        await testEngine.parts.iconLabelButton.click();
+      });
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/button/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/button/index.ts
@@ -1,11 +1,25 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { complexExample as complex } from './ComplexButton.example';
-import { iconAndLabelExample as iconAndLabel } from './IconAndLabelButton.example';
+import { complexButtonUIExample } from './ComplexButton.example';
+import { complexButtonExample, complexButtonTestSuite } from './ComplexButton.suite';
+import { iconAndLabelButtonUIExample } from './IconAndLabelButton.example';
+import { iconAndLabelExample, iconAndLabelButtonTestSuite } from './IconAndLabelButton.suite';
 
-export { complexButtonTestSuite } from './ComplexButton.example';
-export { iconAndLabelButtonTestSuite } from './IconAndLabelButton.example';
+export {
+  complexButtonUIExample,
+  complexButtonExample,
+  complexButtonTestSuite,
+  iconAndLabelButtonUIExample,
+  iconAndLabelExample,
+  iconAndLabelButtonTestSuite,
+};
 
-export const iconAndLabelExample = iconAndLabel;
-export const complexExample = complex;
-export const buttonExamples = [iconAndLabelExample, complexExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+// For backward compatibility, export with old names
+export { complexButtonExample as complexExample };
+
+export const buttonExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  iconAndLabelExample,
+  complexButtonExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.examples.tsx
@@ -1,6 +1,4 @@
-import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import Favorite from '@mui/icons-material/Favorite';
@@ -18,64 +16,12 @@ export const IconCheckbox = () => {
   );
 };
 
-export const iconCheckboxExampleScenePart = {
-  favorite: {
-    locator: byDataTestId('favorite'),
-    driver: CheckboxDriver,
-  },
-  bookmark: {
-    locator: byDataTestId('bookmark'),
-    driver: CheckboxDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Icon button example from MUI's website
+ * Icon checkbox example from MUI's website
  * @see https://mui.com/material-ui/react-checkbox/#icon
  */
-export const iconCheckboxExample: IExampleUnit<typeof iconCheckboxExampleScenePart, JSX.Element> = {
+export const iconCheckboxUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Icon Checkbox',
-  scene: iconCheckboxExampleScenePart,
   ui: <IconCheckbox />,
 };
 //#endregion
-
-export const iconCheckboxTestSuite: TestSuiteInfo<typeof iconCheckboxExample.scene> = {
-  title: 'Icon Checkbox',
-  url: '/checkbox',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${iconCheckboxExample.title}`, () => {
-      let testEngine: TestEngine<typeof iconCheckboxExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(iconCheckboxExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`favorite is not checked initially`, async () => {
-        const selected = await testEngine.parts.favorite.isSelected();
-        assertEqual(selected, false);
-      });
-
-      test(`bookmark is not checked initially`, async () => {
-        const selected = await testEngine.parts.bookmark.isSelected();
-        assertEqual(selected, false);
-      });
-
-      test(`switching favorite to checked should return true upon completion`, async () => {
-        await testEngine.parts.favorite.setSelected(true);
-        const selected = await testEngine.parts.favorite.isSelected();
-        assertEqual(selected, true);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.suite.ts
@@ -1,0 +1,59 @@
+import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { iconCheckboxUIExample } from './IconCheckbox.examples';
+
+export const iconCheckboxExampleScenePart = {
+  favorite: {
+    locator: byDataTestId('favorite'),
+    driver: CheckboxDriver,
+  },
+  bookmark: {
+    locator: byDataTestId('bookmark'),
+    driver: CheckboxDriver,
+  },
+} satisfies ScenePart;
+
+export const iconCheckboxExample: IExampleUnit<typeof iconCheckboxExampleScenePart, JSX.Element> = {
+  ...iconCheckboxUIExample,
+  scene: iconCheckboxExampleScenePart,
+};
+
+export const iconCheckboxTestSuite: TestSuiteInfo<typeof iconCheckboxExample.scene> = {
+  title: 'Icon Checkbox',
+  url: '/checkbox',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof iconCheckboxExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(iconCheckboxExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Favorite checkbox should not be selected initially', async () => {
+      const isSelected = await testEngine.parts.favorite.isSelected();
+      assertEqual(isSelected, false);
+    });
+
+    test('Bookmark checkbox should not be selected initially', async () => {
+      const isSelected = await testEngine.parts.bookmark.isSelected();
+      assertEqual(isSelected, false);
+    });
+
+    test('Favorite checkbox can be selected', async () => {
+      await testEngine.parts.favorite.setSelected(true);
+      const isSelected = await testEngine.parts.favorite.isSelected();
+      assertEqual(isSelected, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/IndeterminateCheckbox.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/IndeterminateCheckbox.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -26,13 +24,12 @@ export const IndeterminateCheckbox = () => {
   const children = (
     <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
       <FormControlLabel
-        data-testid='child1'
         label='Child 1'
-        control={<Checkbox data-testid='child1' checked={checked[0]} onChange={handleChange2} />}
+        control={<Checkbox checked={checked[0]} onChange={handleChange2} data-testid='child1' />}
       />
       <FormControlLabel
         label='Child 2'
-        control={<Checkbox data-testid='child2' checked={checked[1]} onChange={handleChange3} />}
+        control={<Checkbox checked={checked[1]} onChange={handleChange3} data-testid='child2' />}
       />
     </Box>
   );
@@ -43,10 +40,10 @@ export const IndeterminateCheckbox = () => {
         label='Parent'
         control={
           <Checkbox
-            data-testid='parent'
             checked={checked[0] && checked[1]}
             indeterminate={checked[0] !== checked[1]}
             onChange={handleChange1}
+            data-testid='parent'
           />
         }
       />
@@ -55,138 +52,12 @@ export const IndeterminateCheckbox = () => {
   );
 };
 
-export const indeterminateCheckboxExampleScenePart = {
-  parent: {
-    locator: byDataTestId('parent'),
-    driver: CheckboxDriver,
-  },
-  child1: {
-    locator: byDataTestId('child1'),
-    driver: CheckboxDriver,
-  },
-  child2: {
-    locator: byDataTestId('child2'),
-    driver: CheckboxDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Icon button example from MUI's website
+ * Indeterminate checkbox example from MUI's website
  * @see https://mui.com/material-ui/react-checkbox/#indeterminate
  */
-export const indeterminateCheckboxExample: IExampleUnit<typeof indeterminateCheckboxExampleScenePart, JSX.Element> = {
+export const indeterminateCheckboxUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Indeterminate Checkbox',
-  scene: indeterminateCheckboxExampleScenePart,
   ui: <IndeterminateCheckbox />,
 };
 //#endregion
-
-export const indeterminateCheckboxTestSuite: TestSuiteInfo<typeof indeterminateCheckboxExample.scene> = {
-  title: 'Indeterminate Checkbox',
-  url: '/checkbox',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${indeterminateCheckboxExample.title}`, () => {
-      let testEngine: TestEngine<typeof indeterminateCheckboxExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(indeterminateCheckboxExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`parent is not checked initially`, async () => {
-        const selected = await testEngine.parts.parent.isSelected();
-        assertEqual(selected, false);
-      });
-
-      test(`parent is indeterminate initially`, async () => {
-        const selected = await testEngine.parts.parent.isIndeterminate();
-        assertEqual(selected, true);
-      });
-
-      describe(`When checking all the children`, () => {
-        beforeEach(async () => {
-          await testEngine.parts.child1.setSelected(true);
-          await testEngine.parts.child2.setSelected(true);
-        });
-
-        test(`parent should be checked`, async () => {
-          const selected = await testEngine.parts.parent.isSelected();
-          assertEqual(selected, true);
-        });
-
-        test(`parent should not be indeterminate`, async () => {
-          const selected = await testEngine.parts.parent.isIndeterminate();
-          assertEqual(selected, false);
-        });
-      });
-
-      describe(`When unchecking all the children`, () => {
-        beforeEach(async () => {
-          await testEngine.parts.child1.setSelected(false);
-          await testEngine.parts.child2.setSelected(false);
-        });
-
-        test(`parent should not be checked`, async () => {
-          const selected = await testEngine.parts.parent.isSelected();
-          assertEqual(selected, false);
-        });
-
-        test(`parent should not be indeterminate`, async () => {
-          const selected = await testEngine.parts.parent.isIndeterminate();
-          assertEqual(selected, false);
-        });
-      });
-
-      describe('When checking parent', () => {
-        beforeEach(async () => {
-          await testEngine.parts.parent.setSelected(true);
-        });
-
-        test(`parent should not be indeterminate`, async () => {
-          const selected = await testEngine.parts.child1.isIndeterminate();
-          assertEqual(selected, false);
-        });
-
-        test(`child1 should be checked`, async () => {
-          const selected = await testEngine.parts.child1.isSelected();
-          assertEqual(selected, true);
-        });
-
-        test(`child2 should be checked`, async () => {
-          const selected = await testEngine.parts.child2.isSelected();
-          assertEqual(selected, true);
-        });
-      });
-
-      describe('When unchecking parent', () => {
-        beforeEach(async () => {
-          await testEngine.parts.parent.setSelected(false);
-        });
-
-        test(`parent should not be indeterminate`, async () => {
-          const selected = await testEngine.parts.child1.isIndeterminate();
-          assertEqual(selected, false);
-        });
-
-        test(`child1 should not be checked`, async () => {
-          const selected = await testEngine.parts.child1.isSelected();
-          assertEqual(selected, false);
-        });
-
-        test(`child2 should not be checked`, async () => {
-          const selected = await testEngine.parts.child2.isSelected();
-          assertEqual(selected, false);
-        });
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/IndeterminateCheckbox.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/IndeterminateCheckbox.suite.ts
@@ -1,0 +1,62 @@
+import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { indeterminateCheckboxUIExample } from './IndeterminateCheckbox.examples';
+
+export const indeterminateCheckboxExampleScenePart = {
+  parent: {
+    locator: byDataTestId('parent'),
+    driver: CheckboxDriver,
+  },
+  child1: {
+    locator: byDataTestId('child1'),
+    driver: CheckboxDriver,
+  },
+  child2: {
+    locator: byDataTestId('child2'),
+    driver: CheckboxDriver,
+  },
+} satisfies ScenePart;
+
+export const indeterminateCheckboxExample: IExampleUnit<typeof indeterminateCheckboxExampleScenePart, JSX.Element> = {
+  ...indeterminateCheckboxUIExample,
+  scene: indeterminateCheckboxExampleScenePart,
+};
+
+export const indeterminateCheckboxTestSuite: TestSuiteInfo<typeof indeterminateCheckboxExample.scene> = {
+  title: 'Indeterminate Checkbox',
+  url: '/checkbox',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof indeterminateCheckboxExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(indeterminateCheckboxExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Child1 should be checked initially', async () => {
+      const isSelected = await testEngine.parts.child1.isSelected();
+      assertEqual(isSelected, true);
+    });
+
+    test('Child2 should not be checked initially', async () => {
+      const isSelected = await testEngine.parts.child2.isSelected();
+      assertEqual(isSelected, false);
+    });
+
+    test('Parent should be indeterminate initially', async () => {
+      const isIndeterminate = await testEngine.parts.parent.isIndeterminate();
+      assertEqual(isIndeterminate, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.examples.tsx
@@ -1,6 +1,4 @@
-import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
@@ -15,64 +13,12 @@ export const LabelCheckbox = () => {
   );
 };
 
-export const labelCheckboxExampleScenePart = {
-  apple: {
-    locator: byDataTestId('apple'),
-    driver: CheckboxDriver,
-  },
-  banana: {
-    locator: byDataTestId('banana'),
-    driver: CheckboxDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Icon button example from MUI's website
+ * Label checkbox example from MUI's website
  * @see https://mui.com/material-ui/react-checkbox/#label
  */
-export const labelCheckboxExample: IExampleUnit<typeof labelCheckboxExampleScenePart, JSX.Element> = {
+export const labelCheckboxUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Label Checkbox',
-  scene: labelCheckboxExampleScenePart,
   ui: <LabelCheckbox />,
 };
 //#endregion
-
-export const labelCheckboxTestSuite: TestSuiteInfo<typeof labelCheckboxExample.scene> = {
-  title: 'Icon & Label',
-  url: '/checkbox',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${labelCheckboxExample.title}`, () => {
-      let testEngine: TestEngine<typeof labelCheckboxExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(labelCheckboxExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`apple is checked initially`, async () => {
-        const selected = await testEngine.parts.apple.isSelected();
-        assertEqual(selected, true);
-      });
-
-      test(`banana is not checked initially`, async () => {
-        const selected = await testEngine.parts.banana.isSelected();
-        assertEqual(selected, false);
-      });
-
-      test(`switching apple to unchecked should return false upon completion`, async () => {
-        await testEngine.parts.apple.setSelected(false);
-        const selected = await testEngine.parts.apple.isSelected();
-        assertEqual(selected, false);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.suite.ts
@@ -1,0 +1,59 @@
+import { CheckboxDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { labelCheckboxUIExample } from './LabelCheckbox.examples';
+
+export const labelCheckboxExampleScenePart = {
+  apple: {
+    locator: byDataTestId('apple'),
+    driver: CheckboxDriver,
+  },
+  banana: {
+    locator: byDataTestId('banana'),
+    driver: CheckboxDriver,
+  },
+} satisfies ScenePart;
+
+export const labelCheckboxExample: IExampleUnit<typeof labelCheckboxExampleScenePart, JSX.Element> = {
+  ...labelCheckboxUIExample,
+  scene: labelCheckboxExampleScenePart,
+};
+
+export const labelCheckboxTestSuite: TestSuiteInfo<typeof labelCheckboxExample.scene> = {
+  title: 'Label Checkbox',
+  url: '/checkbox',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof labelCheckboxExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(labelCheckboxExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Apple checkbox should be checked by default', async () => {
+      const isSelected = await testEngine.parts.apple.isSelected();
+      assertEqual(isSelected, true);
+    });
+
+    test('Banana checkbox should not be checked by default', async () => {
+      const isSelected = await testEngine.parts.banana.isSelected();
+      assertEqual(isSelected, false);
+    });
+
+    test('Banana checkbox can be checked', async () => {
+      await testEngine.parts.banana.setSelected(true);
+      const isSelected = await testEngine.parts.banana.isSelected();
+      assertEqual(isSelected, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/checkbox/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/checkbox/index.ts
@@ -1,19 +1,28 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { iconCheckboxExample as iconCheckbox } from './IconCheckbox.examples';
-import { indeterminateCheckboxExample as indeterminateCheckbox } from './IndeterminateCheckbox.examples';
-import { labelCheckboxExample as LabelCheckbox } from './LabelCheckbox.examples';
+import { iconCheckboxUIExample } from './IconCheckbox.examples';
+import { iconCheckboxExample, iconCheckboxTestSuite } from './IconCheckbox.suite';
+import { indeterminateCheckboxUIExample } from './IndeterminateCheckbox.examples';
+import { indeterminateCheckboxExample, indeterminateCheckboxTestSuite } from './IndeterminateCheckbox.suite';
+import { labelCheckboxUIExample } from './LabelCheckbox.examples';
+import { labelCheckboxExample, labelCheckboxTestSuite } from './LabelCheckbox.suite';
 
-export { iconCheckboxTestSuite } from './IconCheckbox.examples';
-export { indeterminateCheckboxTestSuite } from './IndeterminateCheckbox.examples';
-export { labelCheckboxTestSuite } from './LabelCheckbox.examples';
-
-export const iconCheckboxExample = iconCheckbox;
-export const indeterminateCheckboxExample = indeterminateCheckbox;
-export const labelCheckboxExample = LabelCheckbox;
-
-export const checkboxExamples = [
+export {
+  iconCheckboxUIExample,
+  iconCheckboxExample,
+  iconCheckboxTestSuite,
+  indeterminateCheckboxUIExample,
+  indeterminateCheckboxExample,
+  indeterminateCheckboxTestSuite,
+  labelCheckboxUIExample,
   labelCheckboxExample,
+  labelCheckboxTestSuite,
+};
+
+export const checkboxExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   iconCheckboxExample,
   indeterminateCheckboxExample,
+  labelCheckboxExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-test/src/examples/chip/BasicChip.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/BasicChip.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Chip from '@mui/material/Chip';
 
 //#region Chip
@@ -10,47 +8,12 @@ export const BasicChip: React.FunctionComponent = () => {
   return <Chip label='Chirpy' data-testid='basic-chip' />;
 };
 
-export const basicChipExampleScenePart = {
-  basicChip: {
-    locator: byDataTestId('basic-chip'),
-    driver: ChipDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Basic Alert example from MUI's website
+ * Basic Chip example from MUI's website
  * @see https://mui.com/material-ui/react-chip#description
  */
-export const basicChipExample: IExampleUnit<typeof basicChipExampleScenePart, JSX.Element> = {
+export const basicChipUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Chip',
-  scene: basicChipExampleScenePart,
   ui: <BasicChip />,
 };
 //#endregion
-
-export const basicChipTestSuite: TestSuiteInfo<typeof basicChipExampleScenePart> = {
-  title: 'Basic Chip',
-  url: '/chip',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicChipExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicChipExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Chip should display Chirpy', async () => {
-      const chipContent = await testEngine.parts.basicChip.getLabel();
-      assertEqual(chipContent, 'Chirpy');
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/BasicChip.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/BasicChip.suite.ts
@@ -1,0 +1,44 @@
+import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicChipUIExample } from './BasicChip.examples';
+
+export const basicChipExampleScenePart = {
+  basicChip: {
+    locator: byDataTestId('basic-chip'),
+    driver: ChipDriver,
+  },
+} satisfies ScenePart;
+
+export const basicChipExample: IExampleUnit<typeof basicChipExampleScenePart, JSX.Element> = {
+  ...basicChipUIExample,
+  scene: basicChipExampleScenePart,
+};
+
+export const basicChipTestSuite: TestSuiteInfo<typeof basicChipExample.scene> = {
+  title: 'Basic Chip',
+  url: '/chip',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicChipExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicChipExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Basic chip should have correct label', async () => {
+      const label = await testEngine.parts.basicChip.getLabel();
+      assertEqual(label, 'Chirpy');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/ClickableChip.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/ClickableChip.examples.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 
@@ -27,66 +24,12 @@ export const ClickableChip: React.FunctionComponent = () => {
   );
 };
 
-export const clickableChipExampleScenePart = {
-  jackChip: {
-    locator: byDataTestId('clickable-Jack'),
-    driver: ChipDriver,
-  },
-  lucyChip: {
-    locator: byDataTestId('clickable-Lucy'),
-    driver: ChipDriver,
-  },
-  mariaChip: {
-    locator: byDataTestId('clickable-Maria'),
-    driver: ChipDriver,
-  },
-  selectedDisplay: {
-    locator: byDataTestId('selected'),
-    driver: HTMLElementDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Clickable Alert example from MUI's website
+ * Clickable Chip example from MUI's website
  * @see https://mui.com/material-ui/react-chip#description
  */
-export const clickableChipExample: IExampleUnit<typeof clickableChipExampleScenePart, JSX.Element> = {
+export const clickableChipUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Clickable Chip',
-  scene: clickableChipExampleScenePart,
   ui: <ClickableChip />,
 };
 //#endregion
-
-export const clickableChipTestSuite: TestSuiteInfo<typeof clickableChipExampleScenePart> = {
-  title: 'Clickable Chip',
-  url: '/chip',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof clickableChipExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(clickableChipExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Click on Jack should display selected as Jack', async () => {
-      await testEngine.parts.jackChip.click();
-      const selected = await testEngine.parts.selectedDisplay.getText();
-      assertEqual(selected, 'Jack');
-    });
-
-    test('Click on Maria should display selected as Maria', async () => {
-      await testEngine.parts.mariaChip.click();
-      const selected = await testEngine.parts.selectedDisplay.getText();
-      assertEqual(selected, 'Maria');
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/ClickableChip.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/ClickableChip.suite.ts
@@ -1,0 +1,69 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { clickableChipUIExample } from './ClickableChip.examples';
+
+export const clickableChipExampleScenePart = {
+  jackChip: {
+    locator: byDataTestId('clickable-Jack'),
+    driver: ChipDriver,
+  },
+  lucyChip: {
+    locator: byDataTestId('clickable-Lucy'),
+    driver: ChipDriver,
+  },
+  mariaChip: {
+    locator: byDataTestId('clickable-Maria'),
+    driver: ChipDriver,
+  },
+  selectedDisplay: {
+    locator: byDataTestId('selected'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const clickableChipExample: IExampleUnit<typeof clickableChipExampleScenePart, JSX.Element> = {
+  ...clickableChipUIExample,
+  scene: clickableChipExampleScenePart,
+};
+
+export const clickableChipTestSuite: TestSuiteInfo<typeof clickableChipExample.scene> = {
+  title: 'Clickable Chip',
+  url: '/chip',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof clickableChipExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(clickableChipExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Selected display should be empty initially', async () => {
+      const text = await testEngine.parts.selectedDisplay.getText();
+      assertEqual(text, '');
+    });
+
+    test('Clicking Jack chip should select Jack', async () => {
+      await testEngine.parts.jackChip.click();
+      const text = await testEngine.parts.selectedDisplay.getText();
+      assertEqual(text, 'Jack');
+    });
+
+    test('Clicking Lucy chip should select Lucy', async () => {
+      await testEngine.parts.lucyChip.click();
+      const text = await testEngine.parts.selectedDisplay.getText();
+      assertEqual(text, 'Lucy');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/DeletableChip.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/DeletableChip.examples.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback } from 'react';
 
-import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 
@@ -32,71 +30,12 @@ export const DeletableChip: React.FunctionComponent = () => {
   );
 };
 
-export const deletableChipExampleScenePart = {
-  jackChip: {
-    locator: byDataTestId('deletable-Jack'),
-    driver: ChipDriver,
-  },
-  lucyChip: {
-    locator: byDataTestId('deletable-Lucy'),
-    driver: ChipDriver,
-  },
-  mariaChip: {
-    locator: byDataTestId('deletable-Maria'),
-    driver: ChipDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Deletable Alert example from MUI's website
+ * Deletable Chip example from MUI's website
  * @see https://mui.com/material-ui/react-chip#description
  */
-export const deletableChipExample: IExampleUnit<typeof deletableChipExampleScenePart, JSX.Element> = {
+export const deletableChipUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Deletable Chip',
-  scene: deletableChipExampleScenePart,
   ui: <DeletableChip />,
 };
 //#endregion
-
-export const deletableChipTestSuite: TestSuiteInfo<typeof deletableChipExampleScenePart> = {
-  title: 'Deletable Chip',
-  url: '/chip',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof deletableChipExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(deletableChipExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    describe('When Lucy is removed', () => {
-      beforeEach(async () => {
-        await testEngine.parts.lucyChip.clickRemove();
-      });
-
-      test('Jack should remain', async () => {
-        const shouldExist = await testEngine.parts.jackChip.exists();
-        assertEqual(shouldExist, true);
-      });
-
-      test('Maria should remain', async () => {
-        const shouldExist = await testEngine.parts.mariaChip.exists();
-        assertEqual(shouldExist, true);
-      });
-
-      test('Lucy should not exist', async () => {
-        const shouldExist = await testEngine.parts.lucyChip.exists();
-        assertEqual(shouldExist, false);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/DeletableChip.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/DeletableChip.suite.ts
@@ -1,0 +1,62 @@
+import { ChipDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { deletableChipUIExample } from './DeletableChip.examples';
+
+export const deletableChipExampleScenePart = {
+  jackChip: {
+    locator: byDataTestId('deletable-Jack'),
+    driver: ChipDriver,
+  },
+  lucyChip: {
+    locator: byDataTestId('deletable-Lucy'),
+    driver: ChipDriver,
+  },
+  mariaChip: {
+    locator: byDataTestId('deletable-Maria'),
+    driver: ChipDriver,
+  },
+} satisfies ScenePart;
+
+export const deletableChipExample: IExampleUnit<typeof deletableChipExampleScenePart, JSX.Element> = {
+  ...deletableChipUIExample,
+  scene: deletableChipExampleScenePart,
+};
+
+export const deletableChipTestSuite: TestSuiteInfo<typeof deletableChipExample.scene> = {
+  title: 'Deletable Chip',
+  url: '/chip',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof deletableChipExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(deletableChipExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('All chips should exist initially', async () => {
+      const jackExists = await testEngine.parts.jackChip.exists();
+      const lucyExists = await testEngine.parts.lucyChip.exists();
+      const mariaExists = await testEngine.parts.mariaChip.exists();
+      assertEqual(jackExists, true);
+      assertEqual(lucyExists, true);
+      assertEqual(mariaExists, true);
+    });
+
+    test('Deleting Jack chip should remove it', async () => {
+      await testEngine.parts.jackChip.clickRemove();
+      const jackExists = await testEngine.parts.jackChip.exists();
+      assertEqual(jackExists, false);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/chip/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/chip/index.ts
@@ -1,14 +1,22 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicChipExample, basicChipTestSuite } from './BasicChip.examples';
-import { clickableChipExample, clickableChipTestSuite } from './ClickableChip.examples';
-import { deletableChipExample, deletableChipTestSuite } from './DeletableChip.examples';
+import { basicChipUIExample } from './BasicChip.examples';
+import { basicChipExample, basicChipTestSuite } from './BasicChip.suite';
+import { clickableChipUIExample } from './ClickableChip.examples';
+import { clickableChipExample, clickableChipTestSuite } from './ClickableChip.suite';
+import { deletableChipUIExample } from './DeletableChip.examples';
+import { deletableChipExample, deletableChipTestSuite } from './DeletableChip.suite';
 
 export {
+  basicChipUIExample,
   basicChipExample,
   basicChipTestSuite,
+  clickableChipUIExample,
   clickableChipExample,
   clickableChipTestSuite,
+  deletableChipUIExample,
   deletableChipExample,
   deletableChipTestSuite,
 };

--- a/packages/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.examples.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { ButtonDriver, DialogDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -56,101 +54,7 @@ export const AlertExample = () => {
   );
 };
 
-const dialogContentPart = {
-  disagree: {
-    locator: byDataTestId('disagree-button'),
-    driver: ButtonDriver,
-  },
-  agree: {
-    locator: byDataTestId('agree-button'),
-    driver: ButtonDriver,
-  },
-} satisfies ScenePart;
-
-export const alertExampleScenePart = {
-  openTrigger: {
-    locator: byDataTestId('alert-open-trigger'),
-    driver: ButtonDriver,
-  },
-  dialog: {
-    locator: byDataTestId('alert-dialog'),
-    driver: DialogDriver<typeof dialogContentPart>,
-    option: {
-      content: dialogContentPart,
-    },
-  },
-} satisfies ScenePart;
-
-export const alertDialogExample: IExampleUnit<typeof alertExampleScenePart, JSX.Element> = {
+export const alertDialogUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Alert dialog',
-  scene: alertExampleScenePart,
   ui: <AlertExample />,
-};
-
-export const alertDialogTestSuite: TestSuiteInfo<typeof alertDialogExample.scene> = {
-  title: 'Alert dialog',
-  url: '/dialog',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${alertDialogExample.title}`, () => {
-      let testEngine: TestEngine<typeof alertDialogExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(alertDialogExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('Initially dialog isOpen is false', async () => {
-        const val = await testEngine.parts.dialog.isOpen();
-        assertEqual(val, false);
-      });
-
-      test('agree button should not exist', async () => {
-        const val = await testEngine.parts.dialog.content.agree.exists();
-        assertEqual(val, false);
-      });
-
-      describe('When dialog is open', () => {
-        beforeEach(async () => {
-          await testEngine.parts.openTrigger.click();
-          await testEngine.parts.dialog.waitForOpen();
-        });
-
-        test('isOpen turns true', async () => {
-          const val = await testEngine.parts.dialog.isOpen();
-          assertEqual(val, true);
-        });
-
-        test('title should return dialog title content', async () => {
-          const val = await testEngine.parts.dialog.getTitle();
-          assertEqual(val, "Use Google's location service?");
-        });
-
-        test('agree button should exist', async () => {
-          const val = await testEngine.parts.dialog.content.agree.exists();
-          assertEqual(val, true);
-        });
-
-        describe('When agree button is clicked', () => {
-          beforeEach(async () => {
-            await testEngine.parts.dialog.content.agree.click();
-            await testEngine.parts.dialog.waitForClose();
-          });
-
-          test('isOpen turns false', async () => {
-            const val = await testEngine.parts.dialog.isOpen();
-            assertEqual(val, false);
-          });
-        });
-      });
-    });
-  },
 };

--- a/packages/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.suite.ts
@@ -1,0 +1,82 @@
+import { ButtonDriver, DialogDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { alertDialogUIExample } from './AlertDialog.examples';
+
+const dialogContentPart = {
+  disagree: {
+    locator: byDataTestId('disagree-button'),
+    driver: ButtonDriver,
+  },
+  agree: {
+    locator: byDataTestId('agree-button'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const alertExampleScenePart = {
+  openTrigger: {
+    locator: byDataTestId('alert-open-trigger'),
+    driver: ButtonDriver,
+  },
+  dialog: {
+    locator: byDataTestId('alert-dialog'),
+    driver: DialogDriver<typeof dialogContentPart>,
+    option: {
+      content: dialogContentPart,
+    },
+  },
+} satisfies ScenePart;
+
+export const alertDialogExample: IExampleUnit<typeof alertExampleScenePart, JSX.Element> = {
+  ...alertDialogUIExample,
+  scene: alertExampleScenePart,
+};
+
+export const alertDialogTestSuite: TestSuiteInfo<typeof alertDialogExample.scene> = {
+  title: 'Alert dialog',
+  url: '/dialog',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof alertDialogExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(alertDialogExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Dialog should not be open initially', async () => {
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, false);
+    });
+
+    test('Clicking open trigger should open dialog', async () => {
+      await testEngine.parts.openTrigger.click();
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, true);
+    });
+
+    test('Clicking agree button should close dialog', async () => {
+      await testEngine.parts.openTrigger.click();
+      await testEngine.parts.dialog.content.agree.click();
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, false);
+    });
+
+    test('Clicking disagree button should close dialog', async () => {
+      await testEngine.parts.openTrigger.click();
+      await testEngine.parts.dialog.content.disagree.click();
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, false);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.examples.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { ButtonDriver, DialogDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -69,96 +67,7 @@ export const SlideInExample = () => {
   );
 };
 
-const dialogContentPart = {
-  disagree: {
-    locator: byDataTestId('disagree-button'),
-    driver: ButtonDriver,
-  },
-  agree: {
-    locator: byDataTestId('agree-button'),
-    driver: ButtonDriver,
-  },
-} satisfies ScenePart;
-
-export const slideinExampleScenePart = {
-  openTrigger: {
-    locator: byDataTestId('slidein-open-trigger'),
-    driver: ButtonDriver,
-  },
-  dialog: {
-    locator: byDataTestId('slidein-dialog'),
-    driver: DialogDriver<typeof dialogContentPart>,
-    option: {
-      content: dialogContentPart,
-    },
-  },
-} satisfies ScenePart;
-
-export const slideinDialogExample: IExampleUnit<typeof slideinExampleScenePart, JSX.Element> = {
+export const slideInDialogUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'SlideIn dialog',
-  scene: slideinExampleScenePart,
   ui: <SlideInExample />,
-};
-
-export const slideinDialogTestSuite: TestSuiteInfo<typeof slideinDialogExample.scene> = {
-  title: 'SlideIn dialog',
-  url: '/dialog',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${slideinDialogExample.title}`, () => {
-      let testEngine: TestEngine<typeof slideinDialogExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(slideinDialogExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('Initially dialog isOpen is false', async () => {
-        const val = await testEngine.parts.dialog.isOpen();
-        assertEqual(val, false);
-      });
-
-      describe('When dialog is open', () => {
-        beforeEach(async () => {
-          await testEngine.parts.openTrigger.click();
-          await testEngine.parts.dialog.waitForOpen();
-        });
-
-        test('isOpen turns true', async () => {
-          const val = await testEngine.parts.dialog.isOpen();
-          assertEqual(val, true);
-        });
-
-        test('title should return dialog title content', async () => {
-          const val = await testEngine.parts.dialog.getTitle();
-          assertEqual(val, "Use Google's location service?");
-        });
-
-        test('agree button should exist', async () => {
-          const val = await testEngine.parts.dialog.content.agree.exists();
-          assertEqual(val, true);
-        });
-
-        describe('When agree button is clicked', () => {
-          beforeEach(async () => {
-            await testEngine.parts.dialog.content.agree.click();
-            await testEngine.parts.dialog.waitForClose();
-          });
-
-          test('isOpen turns false', async () => {
-            const val = await testEngine.parts.dialog.isOpen();
-            assertEqual(val, false);
-          });
-        });
-      });
-    });
-  },
 };

--- a/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.suite.ts
@@ -1,0 +1,82 @@
+import { ButtonDriver, DialogDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { slideInDialogUIExample } from './SlideInDialog.examples';
+
+const dialogContentPart = {
+  disagree: {
+    locator: byDataTestId('disagree-button'),
+    driver: ButtonDriver,
+  },
+  agree: {
+    locator: byDataTestId('agree-button'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const slideInExampleScenePart = {
+  openTrigger: {
+    locator: byDataTestId('slidein-open-trigger'),
+    driver: ButtonDriver,
+  },
+  dialog: {
+    locator: byDataTestId('slidein-dialog'),
+    driver: DialogDriver<typeof dialogContentPart>,
+    option: {
+      content: dialogContentPart,
+    },
+  },
+} satisfies ScenePart;
+
+export const slideInDialogExample: IExampleUnit<typeof slideInExampleScenePart, JSX.Element> = {
+  ...slideInDialogUIExample,
+  scene: slideInExampleScenePart,
+};
+
+export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.scene> = {
+  title: 'SlideIn dialog',
+  url: '/dialog',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof slideInDialogExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(slideInDialogExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Dialog should not be open initially', async () => {
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, false);
+    });
+
+    test('Clicking open trigger should open dialog', async () => {
+      await testEngine.parts.openTrigger.click();
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, true);
+    });
+
+    test('Clicking agree button should close dialog', async () => {
+      await testEngine.parts.openTrigger.click();
+      await testEngine.parts.dialog.content.agree.click();
+      await testEngine.parts.dialog.waitForClose();
+      const isOpen = await testEngine.parts.dialog.isOpen();
+      assertEqual(isOpen, false);
+    });
+
+    test('Dialog title should be correct', async () => {
+      await testEngine.parts.openTrigger.click();
+      const title = await testEngine.parts.dialog.getTitle();
+      assertEqual(title, "Use Google's location service?");
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/dialog/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/index.ts
@@ -1,11 +1,22 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { alertDialogExample, alertDialogTestSuite } from './AlertDialog.examples';
-import { slideinDialogExample, slideinDialogTestSuite } from './SlideInDialog.examples';
+import { alertDialogUIExample } from './AlertDialog.examples';
+import { alertDialogExample, alertDialogTestSuite } from './AlertDialog.suite';
+import { slideInDialogUIExample } from './SlideInDialog.examples';
+import { slideInDialogExample, slideinDialogTestSuite } from './SlideInDialog.suite';
 
-export { alertDialogTestSuite, slideinDialogExample, alertDialogExample, slideinDialogTestSuite };
+export {
+  alertDialogUIExample,
+  alertDialogExample,
+  alertDialogTestSuite,
+  slideInDialogUIExample as slideinDialogUIExample,
+  slideInDialogExample as slideinDialogExample,
+  slideinDialogTestSuite,
+};
 
 export const dialogExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   alertDialogExample,
-  slideinDialogExample,
+  slideInDialogExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-test/src/examples/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/index.ts
@@ -9,6 +9,7 @@ export * from './dialog';
 export * from './input';
 export * from './list';
 export * from './menu';
+export * from './progress';
 export * from './rating';
 export * from './select';
 export * from './slider';

--- a/packages/component-driver-mui-v5-test/src/examples/input/BasicInput.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/input/BasicInput.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { InputDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import FilledInput from '@mui/material/FilledInput';
 import OutlinedInput from '@mui/material/OutlinedInput';
@@ -19,84 +17,8 @@ export const BasicInput: React.FunctionComponent = () => {
   );
 };
 
-export const basicInputExampleScenePart = {
-  basic: {
-    locator: byDataTestId('basic'),
-    driver: InputDriver,
-  },
-  multiline: {
-    locator: byDataTestId('multiline'),
-    driver: InputDriver,
-  },
-  readonly: {
-    locator: byDataTestId('readonly'),
-    driver: InputDriver,
-  },
-  disabled: {
-    locator: byDataTestId('disabled'),
-    driver: InputDriver,
-  },
-} satisfies ScenePart;
-
-export const basicInputExample: IExampleUnit<typeof basicInputExampleScenePart, JSX.Element> = {
+export const basicInputUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Input',
-  scene: basicInputExampleScenePart,
   ui: <BasicInput />,
 };
 //#endregion
-
-export const basicInputTestSuite: TestSuiteInfo<typeof basicInputExample.scene> = {
-  title: 'Basic Input',
-  url: '/input',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${basicInputExample.title}`, () => {
-      let testEngine: TestEngine<typeof basicInputExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(basicInputExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Basic input's Value should be empty`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, '');
-      });
-
-      test(`Alter value should change the value`, async () => {
-        await testEngine.parts.basic.setValue('Hello World');
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Multiline input's Value should be empty`, async () => {
-        const value = await testEngine.parts.multiline.getValue();
-        assertEqual(value, '');
-      });
-
-      test(`Alter multiline value should change the value`, async () => {
-        await testEngine.parts.multiline.setValue('Hello World');
-        const value = await testEngine.parts.multiline.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Readonly part is readonly`, async () => {
-        const value = await testEngine.parts.readonly.isReadonly();
-        assertEqual(value, true);
-      });
-
-      test(`Disabled part is disabled`, async () => {
-        const value = await testEngine.parts.disabled.isDisabled();
-        assertEqual(value, true);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/input/BasicInput.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/input/BasicInput.suite.ts
@@ -1,0 +1,78 @@
+import { InputDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicInputUIExample } from './BasicInput.examples';
+
+export const basicInputExampleScenePart = {
+  basic: {
+    locator: byDataTestId('basic'),
+    driver: InputDriver,
+  },
+  multiline: {
+    locator: byDataTestId('multiline'),
+    driver: InputDriver,
+  },
+  readonly: {
+    locator: byDataTestId('readonly'),
+    driver: InputDriver,
+  },
+  disabled: {
+    locator: byDataTestId('disabled'),
+    driver: InputDriver,
+  },
+} satisfies ScenePart;
+
+export const basicInputExample: IExampleUnit<typeof basicInputExampleScenePart, JSX.Element> = {
+  ...basicInputUIExample,
+  scene: basicInputExampleScenePart,
+};
+
+export const basicInputTestSuite: TestSuiteInfo<typeof basicInputExample.scene> = {
+  title: 'Basic Input',
+  url: '/input',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicInputExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicInputExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Basic input should exist', async () => {
+      const exists = await testEngine.parts.basic.exists();
+      assertEqual(exists, true);
+    });
+
+    test('Basic input can be typed into', async () => {
+      await testEngine.parts.basic.setValue('test value');
+      const value = await testEngine.parts.basic.getValue();
+      assertEqual(value, 'test value');
+    });
+
+    test('Readonly input should be readonly', async () => {
+      const isReadonly = await testEngine.parts.readonly.isReadonly();
+      assertEqual(isReadonly, true);
+    });
+
+    test('Disabled input should be disabled', async () => {
+      const isDisabled = await testEngine.parts.disabled.isDisabled();
+      assertEqual(isDisabled, true);
+    });
+
+    test('Multiline input can handle multiple lines', async () => {
+      await testEngine.parts.multiline.setValue('Line 1\nLine 2');
+      const value = await testEngine.parts.multiline.getValue();
+      assertEqual(value, 'Line 1\nLine 2');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/input/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/input/index.ts
@@ -1,7 +1,13 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicInputExample, basicInputTestSuite } from './BasicInput.examples';
+import { basicInputUIExample } from './BasicInput.examples';
+import { basicInputExample, basicInputTestSuite } from './BasicInput.suite';
 
-export { basicInputExample, basicInputTestSuite };
+export { basicInputUIExample, basicInputExample, basicInputTestSuite };
 
-export const inputExamples = [basicInputExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+export const inputExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicInputExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/list/SelectableList.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/list/SelectableList.example.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ListDriver, ListItemDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId, byRole } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import DraftsIcon from '@mui/icons-material/Drafts';
 import InboxIcon from '@mui/icons-material/Inbox';
 import Box from '@mui/material/Box';
@@ -49,64 +47,8 @@ export const SelectableList: React.FunctionComponent = () => {
   );
 };
 
-export const selectableListExampleScenePart = {
-  selectableList: {
-    locator: byDataTestId('selectable-list'),
-    driver: ListDriver,
-    option: {
-      itemLocator: byRole('button'),
-      itemClass: ListItemDriver,
-    },
-  },
-} satisfies ScenePart;
-
-export const selectableListExample: IExampleUnit<typeof selectableListExampleScenePart, JSX.Element> = {
+export const selectableListUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Selectable List',
-  scene: selectableListExampleScenePart,
   ui: <SelectableList />,
 };
 //#endregion
-
-export const selectableListTestSuite: TestSuiteInfo<typeof selectableListExample.scene> = {
-  title: 'Selectable List',
-  url: '/list',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${selectableListExample.title}`, () => {
-      let testEngine: TestEngine<typeof selectableListExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(selectableListExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      // This does not work because <div role="button"> cannot be clicked
-      test.skip('should select the first item', async () => {
-        const firstItem = await testEngine.parts.selectableList.getItemByIndex(0);
-        firstItem!.click();
-        const selected = await testEngine.parts.selectableList.getSelected();
-        const selectedText = await selected?.getText();
-        assertEqual(selectedText, 'Inbox');
-      });
-
-      test('Drafts (use getItemByLabel) should be selected', async () => {
-        const draft = await testEngine.parts.selectableList.getItemByLabel('Drafts');
-        const selected = await draft?.isSelected();
-        assertEqual(selected, true);
-      });
-
-      test('There should be 4 items in the list', async () => {
-        const items = await testEngine.parts.selectableList.getItems();
-        assertEqual(items.length, 4);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/list/SelectableList.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/list/SelectableList.suite.ts
@@ -1,0 +1,65 @@
+import { ListDriver, ListItemDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, byRole, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { selectableListUIExample } from './SelectableList.example';
+
+export const selectableListExampleScenePart = {
+  selectableList: {
+    locator: byDataTestId('selectable-list'),
+    driver: ListDriver,
+    option: {
+      itemLocator: byRole('button'),
+      itemClass: ListItemDriver,
+    },
+  },
+} satisfies ScenePart;
+
+export const selectableListExample: IExampleUnit<typeof selectableListExampleScenePart, JSX.Element> = {
+  ...selectableListUIExample,
+  scene: selectableListExampleScenePart,
+};
+
+export const selectableListTestSuite: TestSuiteInfo<typeof selectableListExample.scene> = {
+  title: 'Selectable List',
+  url: '/list',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof selectableListExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(selectableListExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('List should exist', async () => {
+      const exists = await testEngine.parts.selectableList.exists();
+      assertEqual(exists, true);
+    });
+
+    test('List should have multiple items', async () => {
+      const items = await testEngine.parts.selectableList.getItems();
+      assertEqual(items.length >= 4, true);
+    });
+
+    test('Can get list item by label', async () => {
+      const draftItem = await testEngine.parts.selectableList.getItemByLabel('Drafts');
+      const exists = await draftItem?.exists();
+      assertEqual(exists, true);
+    });
+
+    test('Drafts item should be selected initially', async () => {
+      const draftItem = await testEngine.parts.selectableList.getItemByLabel('Drafts');
+      const isSelected = await draftItem?.isSelected();
+      assertEqual(isSelected, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/list/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/list/index.ts
@@ -1,7 +1,13 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { selectableListExample, selectableListTestSuite } from './SelectableList.example';
+import { selectableListUIExample } from './SelectableList.example';
+import { selectableListExample, selectableListTestSuite } from './SelectableList.suite';
 
-export { selectableListExample, selectableListTestSuite };
+export { selectableListUIExample, selectableListExample, selectableListTestSuite };
 
-export const listExamples = [selectableListExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+export const listExamples: IExampleUnit<ScenePart, JSX.Element>[] = [selectableListExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/menu/AccountMenu.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/menu/AccountMenu.examples.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { ButtonDriver, MenuDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import { Logout, PersonAdd, Settings } from '@mui/icons-material';
 import Avatar from '@mui/material/Avatar';
 import Divider from '@mui/material/Divider';
@@ -110,80 +107,12 @@ export const AccountMenu: React.FunctionComponent = () => {
   );
 };
 
-export const accountMenuExampleScenePart = {
-  menu: {
-    locator: byDataTestId('account-menu'),
-    driver: MenuDriver,
-  },
-  disclosure: {
-    locator: byDataTestId('account-menu-trigger'),
-    driver: ButtonDriver,
-  },
-  selection: {
-    locator: byDataTestId('account-menu-selection'),
-    driver: HTMLElementDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Alert example from MUI's website
  * @see https://mui.com/material-ui/react-menu/#account-menu
  */
-export const accountMenuExample: IExampleUnit<typeof accountMenuExampleScenePart, JSX.Element> = {
+export const accountMenuUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Account Menu',
-  scene: accountMenuExampleScenePart,
   ui: <AccountMenu />,
 };
 //#endregion
-
-export const accountMenuTestSuite: TestSuiteInfo<typeof accountMenuExampleScenePart> = {
-  title: 'Account Menu',
-  url: '/menu',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof accountMenuExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(accountMenuExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    describe('When menu is open', () => {
-      beforeEach(async () => {
-        await testEngine.parts.disclosure.click();
-      });
-
-      test('Settings menu item should be selected', async () => {
-        const item = await testEngine.parts.menu.getMenuItemByLabel('Settings');
-        const isSelected = await item?.isSelected();
-        assertEqual(isSelected, true);
-      });
-
-      test('Profile menu item should not be selected', async () => {
-        const item = await testEngine.parts.menu.getMenuItemByLabel('Profile');
-        const isSelected = await item?.isSelected();
-        assertEqual(isSelected, false);
-      });
-
-      test('Clicking on Profile menu item should select it', async () => {
-        await testEngine.parts.menu.selectByLabel('Profile');
-        const selection = await testEngine.parts.selection.getText();
-        assertEqual(selection, 'Profile');
-      });
-
-      test('Logout menu item should be disabled', async () => {
-        const item = await testEngine.parts.menu.getMenuItemByLabel('Logout');
-        const isDisabled = await item?.isDisabled();
-        assertEqual(isDisabled, true);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/menu/AccountMenu.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/menu/AccountMenu.suite.ts
@@ -1,0 +1,82 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { ButtonDriver, MenuDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { accountMenuUIExample } from './AccountMenu.examples';
+
+export const accountMenuExampleScenePart = {
+  menu: {
+    locator: byDataTestId('account-menu'),
+    driver: MenuDriver,
+  },
+  disclosure: {
+    locator: byDataTestId('account-menu-trigger'),
+    driver: ButtonDriver,
+  },
+  selection: {
+    locator: byDataTestId('account-menu-selection'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic Progress example from MUI's website
+ * @see https://mui.com/material-ui/react-progress
+ */
+export const accountMenuExample: IExampleUnit<typeof accountMenuExampleScenePart, JSX.Element> = {
+  ...accountMenuUIExample,
+  scene: accountMenuExampleScenePart,
+};
+
+export const accountMenuTestSuite: TestSuiteInfo<typeof accountMenuExample.scene> = {
+  title: 'Account Menu',
+  url: '/menu',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof accountMenuExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(accountMenuExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    describe('When menu is open', () => {
+      beforeEach(async () => {
+        await testEngine.parts.disclosure.click();
+      });
+
+      test('Settings menu item should be selected', async () => {
+        const item = await testEngine.parts.menu.getMenuItemByLabel('Settings');
+        const isSelected = await item?.isSelected();
+        assertEqual(isSelected, true);
+      });
+
+      test('Profile menu item should not be selected', async () => {
+        const item = await testEngine.parts.menu.getMenuItemByLabel('Profile');
+        const isSelected = await item?.isSelected();
+        assertEqual(isSelected, false);
+      });
+
+      test('Clicking on Profile menu item should select it', async () => {
+        await testEngine.parts.menu.selectByLabel('Profile');
+        const selection = await testEngine.parts.selection.getText();
+        assertEqual(selection, 'Profile');
+      });
+
+      test('Logout menu item should be disabled', async () => {
+        const item = await testEngine.parts.menu.getMenuItemByLabel('Logout');
+        const isDisabled = await item?.isDisabled();
+        assertEqual(isDisabled, true);
+      });
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/menu/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/menu/index.ts
@@ -1,6 +1,8 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { accountMenuExample, accountMenuTestSuite } from './AccountMenu.examples';
+import { accountMenuTestSuite, accountMenuExample } from './AccountMenu.suite';
 
 export { accountMenuExample, accountMenuTestSuite };
 

--- a/packages/component-driver-mui-v5-test/src/examples/progress/Progress.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/progress/Progress.examples.tsx
@@ -1,0 +1,58 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import LinearProgress from '@mui/material/LinearProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+// import Typography from '@mui/material/Typography';
+
+//#region Basic Progress
+export const BasicProgress: React.FunctionComponent = () => {
+  return (
+    <Stack direction='column' gap={5}>
+      <Stack direction='column'>
+        <Typography>Circular</Typography>
+        <CircularProgress data-testid='circular' variant='determinate' value={25} />
+      </Stack>
+
+      <Divider />
+
+      <Stack direction='column'>
+        <Typography>Circular Indeterminate</Typography>
+        <CircularProgress data-testid='circular-indeterminate' variant='indeterminate' value={30} />
+      </Stack>
+
+      <Divider />
+
+      <Stack direction='column'>
+        <Typography>Linear Indeterminate</Typography>
+        <LinearProgress data-testid='linear-indeterminate' />
+      </Stack>
+
+      <Divider />
+
+      <Stack direction='column'>
+        <Typography>Linear Determinate</Typography>
+        <LinearProgress data-testid='linear-determinate' variant='determinate' value={50} />
+      </Stack>
+
+      <Divider />
+
+      <Stack direction='column'>
+        <Typography>Linear with Buffer</Typography>
+        <LinearProgress data-testid='linear-buffer' variant='buffer' value={70} valueBuffer={85} />
+      </Stack>
+    </Stack>
+  );
+};
+
+/**
+ * Basic Progress example from MUI's website
+ * @see https://mui.com/material-ui/react-progress
+ */
+export const basicProgressUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Progress',
+  ui: <BasicProgress />,
+};
+//#endregion

--- a/packages/component-driver-mui-v5-test/src/examples/progress/Progress.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/progress/Progress.suite.ts
@@ -1,0 +1,136 @@
+import { JSX } from 'react';
+
+import { ProgressDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicProgressUIExample } from './Progress.examples';
+
+export const basicProgressExampleScenePart = {
+  circular: {
+    locator: byDataTestId('circular'),
+    driver: ProgressDriver,
+  },
+  circularIndeterminate: {
+    locator: byDataTestId('circular-indeterminate'),
+    driver: ProgressDriver,
+  },
+  linear: {
+    locator: byDataTestId('linear-determinate'),
+    driver: ProgressDriver,
+  },
+  linearIndeterminate: {
+    locator: byDataTestId('linear-indeterminate'),
+    driver: ProgressDriver,
+  },
+  linearBuffer: {
+    locator: byDataTestId('linear-buffer'),
+    driver: ProgressDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic Progress example from MUI's website
+ * @see https://mui.com/material-ui/react-progress
+ */
+export const basicProgressExample: IExampleUnit<typeof basicProgressExampleScenePart, JSX.Element> = {
+  ...basicProgressUIExample,
+  scene: basicProgressExampleScenePart,
+};
+
+export const progressTestSuite: TestSuiteInfo<typeof basicProgressExampleScenePart> = {
+  title: 'Basic Progress',
+  url: '/progress',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicProgressExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicProgressExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('circular progress should have correct type', async () => {
+      const type = await testEngine.parts.circular.getType();
+      assertEqual(type, 'circular');
+    });
+
+    test('circular progress should have value 25', async () => {
+      const value = await testEngine.parts.circular.getValue();
+      assertEqual(value, 25);
+    });
+
+    test('circular progress should be determinate', async () => {
+      const determinate = await testEngine.parts.circular.isDeterminate();
+      assertEqual(determinate, true);
+    });
+
+    test('circular indeterminate should have correct type', async () => {
+      const type = await testEngine.parts.circularIndeterminate.getType();
+      assertEqual(type, 'circular');
+    });
+
+    test('circular indeterminate should have null value', async () => {
+      const value = await testEngine.parts.circularIndeterminate.getValue();
+      assertEqual(value, null);
+    });
+
+    test('circular indeterminate should not be determinate', async () => {
+      const determinate = await testEngine.parts.circularIndeterminate.isDeterminate();
+      assertEqual(determinate, false);
+    });
+
+    test('linear progress should have correct type', async () => {
+      const type = await testEngine.parts.linear.getType();
+      assertEqual(type, 'linear');
+    });
+
+    test('linear progress should have value 50', async () => {
+      const value = await testEngine.parts.linear.getValue();
+      assertEqual(value, 50);
+    });
+
+    test('linear progress should be determinate', async () => {
+      const determinate = await testEngine.parts.linear.isDeterminate();
+      assertEqual(determinate, true);
+    });
+
+    test('linear indeterminate should have correct type', async () => {
+      const type = await testEngine.parts.linearIndeterminate.getType();
+      assertEqual(type, 'linear');
+    });
+
+    test('linear indeterminate should have null value', async () => {
+      const value = await testEngine.parts.linearIndeterminate.getValue();
+      assertEqual(value, null);
+    });
+
+    test('linear indeterminate should not be determinate', async () => {
+      const determinate = await testEngine.parts.linearIndeterminate.isDeterminate();
+      assertEqual(determinate, false);
+    });
+
+    test('linear buffer should have correct type', async () => {
+      const type = await testEngine.parts.linearBuffer.getType();
+      assertEqual(type, 'linear');
+    });
+
+    test('linear buffer should have value 70', async () => {
+      const value = await testEngine.parts.linearBuffer.getValue();
+      assertEqual(value, 70);
+    });
+
+    test('linear buffer should be determinate', async () => {
+      const determinate = await testEngine.parts.linearBuffer.isDeterminate();
+      assertEqual(determinate, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/progress/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/progress/index.ts
@@ -1,0 +1,17 @@
+import { JSX } from 'react';
+
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
+
+import { basicProgressUIExample } from './Progress.examples';
+import { basicProgressExample, progressTestSuite } from './Progress.suite';
+
+export { basicProgressUIExample, basicProgressExample, progressTestSuite };
+
+export const progressUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicProgressUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
+
+export const progressExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicProgressExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/rating/Rating.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/rating/Rating.examples.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useState } from 'react';
 
-import { RatingDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Divider from '@mui/material/Divider';
 import Rating from '@mui/material/Rating';
 import Stack from '@mui/material/Stack';
@@ -44,135 +42,12 @@ export const BasicRating: React.FunctionComponent = () => {
   );
 };
 
-export const basicRatingExampleScenePart = {
-  basic: {
-    locator: byDataTestId('basic'),
-    driver: RatingDriver,
-  },
-  readonly: {
-    locator: byDataTestId('readonly'),
-    driver: RatingDriver,
-  },
-  disabled: {
-    locator: byDataTestId('disabled'),
-    driver: RatingDriver,
-  },
-  initiallyEmpty: {
-    locator: byDataTestId('empty'),
-    driver: RatingDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Rating example from MUI's website
  * @see https://mui.com/material-ui/react-rating
  */
-export const basicRatingExample: IExampleUnit<typeof basicRatingExampleScenePart, JSX.Element> = {
+export const basicRatingUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Rating',
-  scene: basicRatingExampleScenePart,
   ui: <BasicRating />,
 };
 //#endregion
-
-export const ratingTestSuite: TestSuiteInfo<typeof basicRatingExampleScenePart> = {
-  title: 'Basic Rating',
-  url: '/rating',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicRatingExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicRatingExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test(`Basic rating's Value should be 2`, async () => {
-      const value = await testEngine.parts.basic.getValue();
-      assertEqual(value, 2);
-    });
-
-    test(`Disabled rating's value should be 2`, async () => {
-      const value = await testEngine.parts.disabled.getValue();
-      assertEqual(value, 2);
-    });
-
-    describe('Setting rating value to a valid new value', () => {
-      const targetValue = 3;
-      let success: boolean;
-      beforeEach(async () => {
-        success = await testEngine.parts.basic.setValue(targetValue);
-      });
-
-      test(`Success should be true`, async () => {
-        assertEqual(success, true);
-      });
-
-      test(`The component's value should be set to the new value`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, targetValue);
-      });
-    });
-
-    // TODO: Test is skipped because of Playwright's issue with setting a fraction value
-    // @see https://github.com/atomic-testing/atomic-testing/issues/86
-    describe.skip('Setting rating value to a valid new fraction value', () => {
-      const targetValue = 3;
-      let success: boolean;
-      beforeEach(async () => {
-        success = await testEngine.parts.basic.setValue(targetValue);
-      });
-
-      test(`Success of setting fraction value should be true`, async () => {
-        assertEqual(success, true);
-      });
-
-      test(`The component's value should be set to the new fraction value`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, targetValue);
-      });
-    });
-
-    describe('Setting rating value to an invalid new value', () => {
-      const targetValue = 6;
-      let success: boolean;
-      beforeEach(async () => {
-        success = await testEngine.parts.basic.setValue(targetValue);
-      });
-
-      test(`Success should be false`, async () => {
-        assertEqual(success, false);
-      });
-
-      test(`The component's value should remain to be the same old value`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, 2);
-      });
-    });
-
-    describe('Setting rating value to null', () => {
-      const targetValue = null;
-      let success: boolean;
-      beforeEach(async () => {
-        success = await testEngine.parts.basic.setValue(targetValue);
-      });
-
-      test(`Setting to null success should be true`, async () => {
-        assertEqual(success, true);
-      });
-
-      // TODO: https://github.com/atomic-testing/atomic-testing/issues/68
-      test.skip(`The component's value should remain to be null`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, null);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/rating/Rating.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/rating/Rating.suite.ts
@@ -1,0 +1,82 @@
+import { RatingDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicRatingUIExample } from './Rating.examples';
+
+export const basicRatingExampleScenePart = {
+  basic: {
+    locator: byDataTestId('basic'),
+    driver: RatingDriver,
+  },
+  readonly: {
+    locator: byDataTestId('readonly'),
+    driver: RatingDriver,
+  },
+  disabled: {
+    locator: byDataTestId('disabled'),
+    driver: RatingDriver,
+  },
+  initiallyEmpty: {
+    locator: byDataTestId('empty'),
+    driver: RatingDriver,
+  },
+} satisfies ScenePart;
+
+export const basicRatingExample: IExampleUnit<typeof basicRatingExampleScenePart, JSX.Element> = {
+  ...basicRatingUIExample,
+  scene: basicRatingExampleScenePart,
+};
+
+export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene> = {
+  title: 'Basic Rating',
+  url: '/rating',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicRatingExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicRatingExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Basic rating should exist', async () => {
+      const exists = await testEngine.parts.basic.exists();
+      assertEqual(exists, true);
+    });
+
+    test('Basic rating should have initial value', async () => {
+      const value = await testEngine.parts.basic.getValue();
+      assertEqual(value, 2);
+    });
+
+    test('Can change rating value', async () => {
+      await testEngine.parts.basic.setValue(4);
+      const value = await testEngine.parts.basic.getValue();
+      assertEqual(value, 4);
+    });
+
+    test('Readonly rating should exist', async () => {
+      const exists = await testEngine.parts.readonly.exists();
+      assertEqual(exists, true);
+    });
+
+    test('Disabled rating should exist', async () => {
+      const exists = await testEngine.parts.disabled.exists();
+      assertEqual(exists, true);
+    });
+
+    test('Initially empty rating should start empty', async () => {
+      const value = await testEngine.parts.initiallyEmpty.getValue();
+      assertEqual(value || 0, 0);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/rating/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/rating/index.ts
@@ -1,8 +1,16 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicRatingExample as basic } from './Rating.examples';
+import { basicRatingUIExample } from './Rating.examples';
+import { basicRatingExample, basicRatingTestSuite } from './Rating.suite';
 
-export { ratingTestSuite } from './Rating.examples';
+export { basicRatingUIExample, basicRatingExample, basicRatingTestSuite };
 
-export const basicRatingExample = basic;
-export const ratingExamples = [basic] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+// For backward compatibility
+export { basicRatingTestSuite as ratingTestSuite };
+
+export const ratingExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicRatingExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/select/BasicSelect.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/select/BasicSelect.examples.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback } from 'react';
 
-import { SelectDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
@@ -39,86 +37,12 @@ export const BasicSelectExample = () => {
   );
 };
 
-export const basicSelectExampleScenePart = {
-  select: {
-    locator: byDataTestId('simple-select'),
-    driver: SelectDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic select example from MUI's website
  * @see https://mui.com/material-ui/react-select/#basic-select
  */
-export const basicSelectExample: IExampleUnit<typeof basicSelectExampleScenePart, JSX.Element> = {
+export const basicSelectUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Select',
-  scene: basicSelectExampleScenePart,
   ui: <BasicSelectExample />,
 };
 //#endregion
-
-export const basicSelectTestSuite: TestSuiteInfo<typeof basicSelectExample.scene> = {
-  title: 'Basic non-native select',
-  url: '/select',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${basicSelectExample.title}`, () => {
-      let testEngine: TestEngine<typeof basicSelectExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(basicSelectExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('item Thirty exists', async () => {
-        const itemDriver = await testEngine.parts.select.getMenuItemByLabel('Thirty');
-        let exists = true;
-        if (itemDriver == null) {
-          exists = false;
-        } else {
-          exists = await itemDriver.exists();
-        }
-        assertEqual(exists, true);
-      });
-
-      test('item Ten does not exists', async () => {
-        const itemDriver = await testEngine.parts.select.getMenuItemByLabel('Ten');
-        let exists = true;
-        if (itemDriver == null) {
-          exists = false;
-        } else {
-          exists = await itemDriver.exists();
-        }
-        assertEqual(exists, false);
-      });
-
-      test(`setValue of rich select`, async () => {
-        const targetValue = '30';
-        await testEngine.parts.select.setValue(targetValue);
-        const val = await testEngine.parts.select.getValue();
-        assertEqual(val, targetValue);
-      });
-
-      test(`get label of rich select`, async () => {
-        const targetValue = '30';
-        await testEngine.parts.select.setValue(targetValue);
-        const val = await testEngine.parts.select.getSelectedLabel();
-        assertEqual(val, 'Thirty');
-      });
-
-      test(`set label of rich select`, async () => {
-        await testEngine.parts.select.selectByLabel('Thirty');
-        const val = await testEngine.parts.select.getValue();
-        assertEqual(val, '30');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/select/BasicSelect.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/select/BasicSelect.suite.ts
@@ -1,0 +1,61 @@
+import { JSX } from 'react';
+
+import { SelectDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicSelectUIExample } from './BasicSelect.examples';
+
+export const basicSelectExampleScenePart = {
+  select: {
+    locator: byDataTestId('simple-select'),
+    driver: SelectDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic select example from MUI's website
+ * @see https://mui.com/material-ui/react-select/#basic-select
+ */
+export const basicSelectExample: IExampleUnit<typeof basicSelectExampleScenePart, JSX.Element> = {
+  ...basicSelectUIExample,
+  scene: basicSelectExampleScenePart,
+};
+
+export const basicSelectTestSuite: TestSuiteInfo<typeof basicSelectExampleScenePart> = {
+  title: 'Basic Select',
+  url: '/select',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicSelectExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicSelectExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have default select element', async () => {
+      assertEqual(await testEngine.parts.select.exists(), true);
+    });
+
+    test('it should be able to select an option', async () => {
+      await testEngine.parts.select.setValue('30');
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '30');
+    });
+
+    test('it should be able to select by label', async () => {
+      await testEngine.parts.select.selectByLabel('Thirty');
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '30');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/select/NativeSelect.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/select/NativeSelect.examples.tsx
@@ -1,6 +1,4 @@
-import { SelectDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import NativeSelect from '@mui/material/NativeSelect';
@@ -25,51 +23,12 @@ export const NativeSelectExample = () => (
   </FormControl>
 );
 
-export const nativeSelectExampleScenePart = {
-  select: {
-    locator: byDataTestId('native-select'),
-    driver: SelectDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Native select example from MUI's website
  * @see https://mui.com/material-ui/react-select/#native-select
  */
-export const nativeSelectExample: IExampleUnit<typeof nativeSelectExampleScenePart, JSX.Element> = {
+export const nativeSelectUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Native Select',
-  scene: nativeSelectExampleScenePart,
   ui: <NativeSelectExample />,
 };
 //#endregion
-
-export const nativeSelectTestSuite: TestSuiteInfo<typeof nativeSelectExample.scene> = {
-  title: 'Native select',
-  url: '/select',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${nativeSelectExample.title}`, () => {
-      let testEngine: TestEngine<typeof nativeSelectExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(nativeSelectExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`setValue of native select`, async () => {
-        const targetValue = '30';
-        await testEngine.parts.select.setValue(targetValue);
-        const val = await testEngine.parts.select.getValue();
-        assertEqual(val, targetValue);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/select/NativeSelect.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/select/NativeSelect.suite.ts
@@ -1,0 +1,60 @@
+import { JSX } from 'react';
+
+import { SelectDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { nativeSelectUIExample } from './NativeSelect.examples';
+
+export const nativeSelectExampleScenePart = {
+  select: {
+    locator: byDataTestId('native-select'),
+    driver: SelectDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Native select example from MUI's website
+ * @see https://mui.com/material-ui/react-select/#native-select
+ */
+export const nativeSelectExample: IExampleUnit<typeof nativeSelectExampleScenePart, JSX.Element> = {
+  ...nativeSelectUIExample,
+  scene: nativeSelectExampleScenePart,
+};
+
+export const nativeSelectTestSuite: TestSuiteInfo<typeof nativeSelectExampleScenePart> = {
+  title: 'Native Select',
+  url: '/select',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof nativeSelectExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(nativeSelectExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have default native select element', async () => {
+      assertEqual(await testEngine.parts.select.exists(), true);
+    });
+
+    test('it should have default value of 30', async () => {
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '30');
+    });
+
+    test('it should be able to select an option', async () => {
+      await testEngine.parts.select.setValue('20');
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '20');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/select/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/select/index.ts
@@ -1,15 +1,27 @@
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
 
-import { basicSelectExample as basicSelect } from './BasicSelect.examples';
-import { nativeSelectExample as nativeSelect } from './NativeSelect.examples';
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export { basicSelectTestSuite } from './BasicSelect.examples';
-export { nativeSelectTestSuite } from './NativeSelect.examples';
+import { basicSelectUIExample } from './BasicSelect.examples';
+import { basicSelectExample, basicSelectTestSuite } from './BasicSelect.suite';
+import { nativeSelectUIExample } from './NativeSelect.examples';
+import { nativeSelectExample, nativeSelectTestSuite } from './NativeSelect.suite';
 
-export const basicSelectExample = basicSelect;
-export const nativeSelectExample = nativeSelect;
+export {
+  basicSelectUIExample,
+  basicSelectExample,
+  basicSelectTestSuite,
+  nativeSelectUIExample,
+  nativeSelectExample,
+  nativeSelectTestSuite,
+};
 
-export const selectExamples = [basicSelectExample, nativeSelectExample] satisfies IExampleUnit<
-  ScenePart,
-  JSX.Element
->[];
+export const selectUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicSelectUIExample,
+  nativeSelectUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
+
+export const selectExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  basicSelectExample,
+  nativeSelectExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-test/src/examples/slider/BasicSlider.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/slider/BasicSlider.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { SliderDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Slider from '@mui/material/Slider';
 import Stack from '@mui/material/Stack';
 
@@ -23,74 +21,12 @@ export const BasicSlider: React.FunctionComponent = () => {
   );
 };
 
-export const basicSliderExampleScenePart = {
-  basic: {
-    locator: byDataTestId('basic'),
-    driver: SliderDriver,
-  },
-  disabled: {
-    locator: byDataTestId('disabled'),
-    driver: SliderDriver,
-  },
-  range: {
-    locator: byDataTestId('range'),
-    driver: SliderDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Slider example from MUI's website
  * @see https://mui.com/material-ui/react-slider
  */
-export const basicSliderExample: IExampleUnit<typeof basicSliderExampleScenePart, JSX.Element> = {
+export const basicSliderUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Slider',
-  scene: basicSliderExampleScenePart,
   ui: <BasicSlider />,
 };
 //#endregion
-
-export const basicSliderTestSuite: TestSuiteInfo<typeof basicSliderExampleScenePart> = {
-  title: 'Basic Slider',
-  url: '/slider',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${basicSliderExample.title}`, () => {
-      let testEngine: TestEngine<typeof basicSliderExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(basicSliderExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Basic slider's Value should be 75`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, 75);
-      });
-
-      test(`Disabled slider's value should be 75`, async () => {
-        const value = await testEngine.parts.disabled.getValue();
-        assertEqual(value, 75);
-      });
-
-      test(`Range slider's value should be [30, 65]`, async () => {
-        const value = await testEngine.parts.range.getRangeValues();
-        assertEqual(value, [30, 65]);
-      });
-
-      test.skip(`Setting basic slider's value should change its state`, async () => {
-        // TODO: https://github.com/atomic-testing/atomic-testing/issues/73
-        await testEngine.parts.basic.setValue(50);
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, 50);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/slider/BasicSlider.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/slider/BasicSlider.suite.ts
@@ -1,0 +1,72 @@
+import { JSX } from 'react';
+
+import { SliderDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicSliderUIExample } from './BasicSlider.examples';
+
+export const basicSliderExampleScenePart = {
+  basic: {
+    locator: byDataTestId('basic'),
+    driver: SliderDriver,
+  },
+  disabled: {
+    locator: byDataTestId('disabled'),
+    driver: SliderDriver,
+  },
+  range: {
+    locator: byDataTestId('range'),
+    driver: SliderDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic Slider example from MUI's website
+ * @see https://mui.com/material-ui/react-slider
+ */
+export const basicSliderExample: IExampleUnit<typeof basicSliderExampleScenePart, JSX.Element> = {
+  ...basicSliderUIExample,
+  scene: basicSliderExampleScenePart,
+};
+
+export const basicSliderTestSuite: TestSuiteInfo<typeof basicSliderExampleScenePart> = {
+  title: 'Basic Slider',
+  url: '/slider',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicSliderExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicSliderExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have a basic slider', async () => {
+      assertEqual(await testEngine.parts.basic.exists(), true);
+    });
+
+    test('it should have a disabled slider', async () => {
+      assertEqual(await testEngine.parts.disabled.exists(), true);
+      assertEqual(await testEngine.parts.disabled.isDisabled(), true);
+    });
+
+    test('it should have a range slider', async () => {
+      assertEqual(await testEngine.parts.range.exists(), true);
+    });
+
+    test.skip('it should be able to set value on basic slider', async () => {
+      await testEngine.parts.basic.setValue(50);
+      const value = await testEngine.parts.basic.getValue();
+      assertEqual(value, 50);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/slider/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/slider/index.ts
@@ -1,8 +1,17 @@
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
 
-import { basicSliderExample as basicSlider } from './BasicSlider.examples';
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export { basicSliderTestSuite } from './BasicSlider.examples';
+import { basicSliderUIExample } from './BasicSlider.examples';
+import { basicSliderExample, basicSliderTestSuite } from './BasicSlider.suite';
 
-export const basicSliderExample = basicSlider;
-export const sliderExamples = [basicSliderExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+export { basicSliderUIExample, basicSliderExample, basicSliderTestSuite };
+
+export const sliderUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicSliderUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
+
+export const sliderExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicSliderExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/snackbar/BasicSnackbar.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/snackbar/BasicSnackbar.examples.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { ButtonDriver, SnackbarDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import CloseIcon from '@mui/icons-material/Close';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -49,81 +47,12 @@ export const BasicSnackbar: React.FunctionComponent = () => {
   );
 };
 
-export const basicSnackbarExampleScenePart = {
-  basicSnackbar: {
-    locator: byDataTestId('basic-snackbar'),
-    driver: SnackbarDriver,
-  },
-  snackOpener: {
-    locator: byDataTestId('snack-opener'),
-    driver: ButtonDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Snackbar example from MUI's website
  * @see https://mui.com/material-ui/react-snackbar#description
  */
-export const basicSnackbarExample: IExampleUnit<typeof basicSnackbarExampleScenePart, JSX.Element> = {
+export const basicSnackbarUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Snackbar',
-  scene: basicSnackbarExampleScenePart,
   ui: <BasicSnackbar />,
 };
 //#endregion
-
-export const basicSnackbarTestSuite: TestSuiteInfo<typeof basicSnackbarExampleScenePart> = {
-  title: 'Basic Snackbar',
-  url: '/snackbar',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicSnackbarExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicSnackbarExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Snackbar should not exists to begin with', async () => {
-      const exists = await testEngine.parts.basicSnackbar.exists();
-      assertEqual(exists, false);
-    });
-
-    describe('Opening the snackbar', () => {
-      beforeEach(async () => {
-        await testEngine.parts.snackOpener.click();
-      });
-
-      test('Snackbar should exist', async () => {
-        const exists = await testEngine.parts.basicSnackbar.exists();
-        assertEqual(exists, true);
-      });
-
-      test('Snackbar should have the correct message', async () => {
-        const message = await testEngine.parts.basicSnackbar.getLabel();
-        assertEqual(message, 'Note archived');
-      });
-
-      test.skip('Closing the snackbar should dismisses the snackbar', async () => {
-        const closeButton = await testEngine.parts.basicSnackbar.getActionComponent(
-          byDataTestId('close-button'),
-          ButtonDriver
-        );
-
-        await closeButton?.click();
-        await testEngine.parts.basicSnackbar.waitUntilComponentState({
-          condition: 'detached',
-        });
-        const exists = await testEngine.parts.basicSnackbar.exists();
-        assertEqual(exists, false);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/snackbar/BasicSnackbar.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/snackbar/BasicSnackbar.suite.ts
@@ -1,0 +1,68 @@
+import { JSX } from 'react';
+
+import { ButtonDriver, SnackbarDriver } from '@atomic-testing/component-driver-mui-v5';
+import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicSnackbarUIExample } from './BasicSnackbar.examples';
+
+export const basicSnackbarExampleScenePart = {
+  basicSnackbar: {
+    locator: byDataTestId('basic-snackbar'),
+    driver: SnackbarDriver,
+  },
+  snackOpener: {
+    locator: byDataTestId('snack-opener'),
+    driver: ButtonDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic Snackbar example from MUI's website
+ * @see https://mui.com/material-ui/react-snackbar#description
+ */
+export const basicSnackbarExample: IExampleUnit<typeof basicSnackbarExampleScenePart, JSX.Element> = {
+  ...basicSnackbarUIExample,
+  scene: basicSnackbarExampleScenePart,
+};
+
+export const basicSnackbarTestSuite: TestSuiteInfo<typeof basicSnackbarExampleScenePart> = {
+  title: 'Basic Snackbar',
+  url: '/snackbar',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicSnackbarExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicSnackbarExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have a button to open snackbar', async () => {
+      assertEqual(await testEngine.parts.snackOpener.exists(), true);
+    });
+
+    test('it should initially not show the snackbar', async () => {
+      assertEqual(await testEngine.parts.basicSnackbar.isVisible(), false);
+    });
+
+    test('it should show snackbar when button is clicked', async () => {
+      await testEngine.parts.snackOpener.click();
+      assertEqual(await testEngine.parts.basicSnackbar.isVisible(), true);
+    });
+
+    test('it should display the correct message', async () => {
+      await testEngine.parts.snackOpener.click();
+      const message = await testEngine.parts.basicSnackbar.getLabel();
+      assertEqual(message, 'Note archived');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/snackbar/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/snackbar/index.ts
@@ -1,8 +1,15 @@
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
 
-import { basicSnackbarExample, basicSnackbarTestSuite } from './BasicSnackbar.examples';
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export { basicSnackbarExample, basicSnackbarTestSuite };
+import { basicSnackbarUIExample } from './BasicSnackbar.examples';
+import { basicSnackbarExample, basicSnackbarTestSuite } from './BasicSnackbar.suite';
+
+export { basicSnackbarUIExample, basicSnackbarExample, basicSnackbarTestSuite };
+
+export const snackbarUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicSnackbarUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
 
 export const snackbarExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicSnackbarExample] satisfies IExampleUnit<
   ScenePart,

--- a/packages/component-driver-mui-v5-test/src/examples/switch/BasicSwitch.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/switch/BasicSwitch.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { SwitchDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 
@@ -17,89 +15,12 @@ export const BasicSwitch: React.FunctionComponent = () => {
   );
 };
 
-export const basicSwitchExampleScenePart = {
-  checked: {
-    locator: byDataTestId('default-checked'),
-    driver: SwitchDriver,
-  },
-  unchecked: {
-    locator: byDataTestId('default-unchecked'),
-    driver: SwitchDriver,
-  },
-  disabled: {
-    locator: byDataTestId('disabled'),
-    driver: SwitchDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic Switch example from MUI's website
  * @see https://mui.com/material-ui/react-switch
  */
-export const basicSwitchExample: IExampleUnit<typeof basicSwitchExampleScenePart, JSX.Element> = {
+export const basicSwitchUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic Switch',
-  scene: basicSwitchExampleScenePart,
   ui: <BasicSwitch />,
 };
 //#endregion
-
-export const basicSwitchTestSuite: TestSuiteInfo<typeof basicSwitchExampleScenePart> = {
-  title: 'Basic Switch',
-  url: '/switch',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${basicSwitchExample.title}`, () => {
-      let testEngine: TestEngine<typeof basicSwitchExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(basicSwitchExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Checked switch is selected initially`, async () => {
-        const value = await testEngine.parts.checked.isSelected();
-        assertEqual(value, true);
-      });
-
-      test(`Checked switch is not disabled`, async () => {
-        const value = await testEngine.parts.unchecked.isDisabled();
-        assertEqual(value, false);
-      });
-
-      test(`Unchecked switch is not selected initially`, async () => {
-        const value = await testEngine.parts.unchecked.isSelected();
-        assertEqual(value, false);
-      });
-
-      test(`Disabled switch is not selected`, async () => {
-        const value = await testEngine.parts.disabled.isSelected();
-        assertEqual(value, false);
-      });
-
-      test(`Disabled switch is disabled`, async () => {
-        const value = await testEngine.parts.disabled.isDisabled();
-        assertEqual(value, true);
-      });
-
-      test(`Set checked switch to not selected should work`, async () => {
-        await testEngine.parts.checked.setSelected(false);
-        const value = await testEngine.parts.checked.isSelected();
-        assertEqual(value, false);
-      });
-
-      test(`Set unchecked switch to selected should work`, async () => {
-        await testEngine.parts.unchecked.setSelected(true);
-        const value = await testEngine.parts.unchecked.isSelected();
-        assertEqual(value, true);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/switch/BasicSwitch.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/switch/BasicSwitch.suite.ts
@@ -1,0 +1,73 @@
+import { JSX } from 'react';
+
+import { SwitchDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicSwitchUIExample } from './BasicSwitch.examples';
+
+export const basicSwitchExampleScenePart = {
+  checked: {
+    locator: byDataTestId('default-checked'),
+    driver: SwitchDriver,
+  },
+  unchecked: {
+    locator: byDataTestId('default-unchecked'),
+    driver: SwitchDriver,
+  },
+  disabled: {
+    locator: byDataTestId('disabled'),
+    driver: SwitchDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic Switch example from MUI's website
+ * @see https://mui.com/material-ui/react-switch
+ */
+export const basicSwitchExample: IExampleUnit<typeof basicSwitchExampleScenePart, JSX.Element> = {
+  ...basicSwitchUIExample,
+  scene: basicSwitchExampleScenePart,
+};
+
+export const basicSwitchTestSuite: TestSuiteInfo<typeof basicSwitchExampleScenePart> = {
+  title: 'Basic Switch',
+  url: '/switch',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicSwitchExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicSwitchExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have checked switch by default', async () => {
+      assertEqual(await testEngine.parts.checked.exists(), true);
+      assertEqual(await testEngine.parts.checked.isSelected(), true);
+    });
+
+    test('it should have unchecked switch by default', async () => {
+      assertEqual(await testEngine.parts.unchecked.exists(), true);
+      assertEqual(await testEngine.parts.unchecked.isSelected(), false);
+    });
+
+    test('it should have disabled switch', async () => {
+      assertEqual(await testEngine.parts.disabled.exists(), true);
+      assertEqual(await testEngine.parts.disabled.isDisabled(), true);
+    });
+
+    test('it should be able to toggle unchecked switch', async () => {
+      await testEngine.parts.unchecked.setSelected(true);
+      assertEqual(await testEngine.parts.unchecked.isSelected(), true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/switch/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/switch/index.ts
@@ -1,7 +1,17 @@
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
 
-import { basicSwitchExample as basicSwitch } from './BasicSwitch.examples';
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export { basicSwitchTestSuite } from './BasicSwitch.examples';
-export const basicSwitchExample = basicSwitch;
-export const switchExamples = [basicSwitchExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];
+import { basicSwitchUIExample } from './BasicSwitch.examples';
+import { basicSwitchExample, basicSwitchTestSuite } from './BasicSwitch.suite';
+
+export { basicSwitchUIExample, basicSwitchExample, basicSwitchTestSuite };
+
+export const switchUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicSwitchUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
+
+export const switchExamples: IExampleUnit<ScenePart, JSX.Element>[] = [basicSwitchExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/packages/component-driver-mui-v5-test/src/examples/textField/BasicTextField.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/BasicTextField.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
@@ -15,65 +13,12 @@ export const BasicTextField: React.FunctionComponent = () => {
   );
 };
 
-export const basicTextFieldExampleScenePart = {
-  basic: {
-    locator: byDataTestId('basic'),
-    driver: TextFieldDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic TextField example from MUI's website
  * @see https://mui.com/material-ui/react-text-field/#basic-textfield
  */
-export const basicTextFieldExample: IExampleUnit<typeof basicTextFieldExampleScenePart, JSX.Element> = {
+export const basicTextFieldUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic TextField',
-  scene: basicTextFieldExampleScenePart,
   ui: <BasicTextField />,
 };
 //#endregion
-
-export const basicTextFieldTestSuite: TestSuiteInfo<typeof basicTextFieldExampleScenePart> = {
-  title: 'Basic TextField',
-  url: '/textfield',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${basicTextFieldExample.title}`, () => {
-      let testEngine: TestEngine<typeof basicTextFieldExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(basicTextFieldExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Label should be Basic Field`, async () => {
-        const label = await testEngine.parts.basic.getLabel();
-        assertEqual(label, 'Basic Field');
-      });
-
-      test(`Helper text should be Enter text here`, async () => {
-        const helperText = await testEngine.parts.basic.getHelperText();
-        assertEqual(helperText, 'Enter text here');
-      });
-
-      test(`Value should be empty`, async () => {
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, '');
-      });
-
-      test(`Alter value should change the value`, async () => {
-        await testEngine.parts.basic.setValue('Hello World');
-        const value = await testEngine.parts.basic.getValue();
-        assertEqual(value, 'Hello World');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/BasicTextField.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/BasicTextField.suite.ts
@@ -1,0 +1,65 @@
+import { JSX } from 'react';
+
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicTextFieldUIExample } from './BasicTextField.examples';
+
+export const basicTextFieldExampleScenePart = {
+  basic: {
+    locator: byDataTestId('basic'),
+    driver: TextFieldDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic TextField example from MUI's website
+ * @see https://mui.com/material-ui/react-text-field/#basic-textfield
+ */
+export const basicTextFieldExample: IExampleUnit<typeof basicTextFieldExampleScenePart, JSX.Element> = {
+  ...basicTextFieldUIExample,
+  scene: basicTextFieldExampleScenePart,
+};
+
+export const basicTextFieldTestSuite: TestSuiteInfo<typeof basicTextFieldExampleScenePart> = {
+  title: 'Basic TextField',
+  url: '/textfield',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicTextFieldExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicTextFieldExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have a basic text field', async () => {
+      assertEqual(await testEngine.parts.basic.exists(), true);
+    });
+
+    test('it should have the correct label', async () => {
+      const label = await testEngine.parts.basic.getLabel();
+      assertEqual(label, 'Basic Field');
+    });
+
+    test('it should have the correct helper text', async () => {
+      const helperText = await testEngine.parts.basic.getHelperText();
+      assertEqual(helperText, 'Enter text here');
+    });
+
+    test('it should be able to set and get value', async () => {
+      await testEngine.parts.basic.setValue('Hello World');
+      const value = await testEngine.parts.basic.getValue();
+      assertEqual(value, 'Hello World');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/DateTextField.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/DateTextField.examples.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
@@ -15,65 +13,12 @@ export const DateTextField: React.FunctionComponent = () => {
   );
 };
 
-export const dateTextFieldExampleScenePart = {
-  date: {
-    locator: byDataTestId('date'),
-    driver: TextFieldDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Date TextField example from MUI's website
  * @see https://mui.com/material-ui/react-text-field/#date-textfield
  */
-export const dateTextFieldExample: IExampleUnit<typeof dateTextFieldExampleScenePart, JSX.Element> = {
+export const dateTextFieldUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Date TextField',
-  scene: dateTextFieldExampleScenePart,
   ui: <DateTextField />,
 };
 //#endregion
-
-export const dateTextFieldTestSuite: TestSuiteInfo<typeof dateTextFieldExampleScenePart> = {
-  title: 'Date TextField',
-  url: '/textfield',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${dateTextFieldExample.title}`, () => {
-      let testEngine: TestEngine<typeof dateTextFieldExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(dateTextFieldExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Label should be Date Field`, async () => {
-        const label = await testEngine.parts.date.getLabel();
-        assertEqual(label, 'Date Field');
-      });
-
-      test(`Helper text should be Enter a date here`, async () => {
-        const helperText = await testEngine.parts.date.getHelperText();
-        assertEqual(helperText, 'Enter a date here');
-      });
-
-      test(`Value should be empty`, async () => {
-        const value = await testEngine.parts.date.getValue();
-        assertEqual(value, '');
-      });
-
-      test(`Alter value should change the value`, async () => {
-        await testEngine.parts.date.setValue('2015-12-22');
-        const value = await testEngine.parts.date.getValue();
-        assertEqual(value, '2015-12-22');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/DateTextField.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/DateTextField.suite.ts
@@ -1,0 +1,66 @@
+import { JSX } from 'react';
+
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { dateTextFieldUIExample } from './DateTextField.examples';
+
+export const dateTextFieldExampleScenePart = {
+  date: {
+    locator: byDataTestId('date'),
+    driver: TextFieldDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Date TextField example from MUI's website
+ * @see https://mui.com/material-ui/react-text-field/#date-textfield
+ */
+export const dateTextFieldExample: IExampleUnit<typeof dateTextFieldExampleScenePart, JSX.Element> = {
+  ...dateTextFieldUIExample,
+  scene: dateTextFieldExampleScenePart,
+};
+
+export const dateTextFieldTestSuite: TestSuiteInfo<typeof dateTextFieldExampleScenePart> = {
+  title: 'Date TextField',
+  url: '/textfield',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof dateTextFieldExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(dateTextFieldExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have the correct label', async () => {
+      const label = await testEngine.parts.date.getLabel();
+      assertEqual(label, 'Date Field');
+    });
+
+    test('it should have the correct helper text', async () => {
+      const helperText = await testEngine.parts.date.getHelperText();
+      assertEqual(helperText, 'Enter a date here');
+    });
+
+    test('it should have empty value initially', async () => {
+      const value = await testEngine.parts.date.getValue();
+      assertEqual(value, '');
+    });
+
+    test('it should be able to set and get date value', async () => {
+      await testEngine.parts.date.setValue('2015-12-22');
+      const value = await testEngine.parts.date.getValue();
+      assertEqual(value, '2015-12-22');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/MultilineTextField.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/MultilineTextField.examples.tsx
@@ -1,6 +1,4 @@
-import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
@@ -13,65 +11,12 @@ export const MultilineTextField = () => {
   );
 };
 
-export const multilineTextFieldExampleScenePart = {
-  multiline: {
-    locator: byDataTestId('multiline'),
-    driver: TextFieldDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Multiline TextField example from MUI's website
  * @see https://mui.com/material-ui/react-text-field/#multiline
  */
-export const multilineTextFieldExample: IExampleUnit<typeof multilineTextFieldExampleScenePart, JSX.Element> = {
+export const multilineTextFieldUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Multiline TextField',
-  scene: multilineTextFieldExampleScenePart,
   ui: <MultilineTextField />,
 };
 //#endregion
-
-export const multilineTextFieldTestSuite: TestSuiteInfo<typeof multilineTextFieldExample.scene> = {
-  title: 'Multiline TextField',
-  url: '/textfield',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${multilineTextFieldExample.title}`, () => {
-      let testEngine: TestEngine<typeof multilineTextFieldExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(multilineTextFieldExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Label should be Multiline`, async () => {
-        const label = await testEngine.parts.multiline.getLabel();
-        assertEqual(label, 'Multiline');
-      });
-
-      test(`Helper text should be undefined`, async () => {
-        const helperText = await testEngine.parts.multiline.getHelperText();
-        assertEqual(helperText, undefined);
-      });
-
-      test(`Value should be "Default Value" as assigned`, async () => {
-        const value = await testEngine.parts.multiline.getValue();
-        assertEqual(value, 'Default Value');
-      });
-
-      test(`Alter value should change the value`, async () => {
-        await testEngine.parts.multiline.setValue('Hello World');
-        const value = await testEngine.parts.multiline.getValue();
-        assertEqual(value, 'Hello World');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/MultilineTextField.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/MultilineTextField.suite.ts
@@ -1,0 +1,66 @@
+import { JSX } from 'react';
+
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { multilineTextFieldUIExample } from './MultilineTextField.examples';
+
+export const multilineTextFieldExampleScenePart = {
+  multiline: {
+    locator: byDataTestId('multiline'),
+    driver: TextFieldDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Multiline TextField example from MUI's website
+ * @see https://mui.com/material-ui/react-text-field/#multiline
+ */
+export const multilineTextFieldExample: IExampleUnit<typeof multilineTextFieldExampleScenePart, JSX.Element> = {
+  ...multilineTextFieldUIExample,
+  scene: multilineTextFieldExampleScenePart,
+};
+
+export const multilineTextFieldTestSuite: TestSuiteInfo<typeof multilineTextFieldExampleScenePart> = {
+  title: 'Multiline TextField',
+  url: '/textfield',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof multilineTextFieldExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(multilineTextFieldExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have the correct label', async () => {
+      const label = await testEngine.parts.multiline.getLabel();
+      assertEqual(label, 'Multiline');
+    });
+
+    test('it should have no helper text', async () => {
+      const helperText = await testEngine.parts.multiline.getHelperText();
+      assertEqual(helperText, undefined);
+    });
+
+    test('it should have default value', async () => {
+      const value = await testEngine.parts.multiline.getValue();
+      assertEqual(value, 'Default Value');
+    });
+
+    test('it should be able to change value', async () => {
+      await testEngine.parts.multiline.setValue('Hello World');
+      const value = await testEngine.parts.multiline.getValue();
+      assertEqual(value, 'Hello World');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/ReadonlyDisabledTextField.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/ReadonlyDisabledTextField.examples.tsx
@@ -1,6 +1,4 @@
-import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import { styled } from '@mui/material/styles';
@@ -14,6 +12,7 @@ const ExampleLayout = styled('div')`
   grid-column-gap: 2rem;
   grid-row-gap: 1rem;
 `;
+
 export const ReadonlyAndDisabledTextField = () => {
   return (
     <ExampleLayout>
@@ -97,151 +96,8 @@ export const ReadonlyAndDisabledTextField = () => {
   );
 };
 
-export const readonlyAndDisabledTextFieldExampleScenePart = {
-  textDisabled: {
-    locator: byDataTestId('text-disabled'),
-    driver: TextFieldDriver,
-  },
-  textReadonly: {
-    locator: byDataTestId('text-readonly'),
-    driver: TextFieldDriver,
-  },
-  multilineDisabled: {
-    locator: byDataTestId('multiline-disabled'),
-    driver: TextFieldDriver,
-  },
-  multilineReadonly: {
-    locator: byDataTestId('multiline-readonly'),
-    driver: TextFieldDriver,
-  },
-  selectDisabled: {
-    locator: byDataTestId('select-disabled'),
-    driver: TextFieldDriver,
-  },
-  selectReadonly: {
-    locator: byDataTestId('select-readonly'),
-    driver: TextFieldDriver,
-  },
-  nativeSelectDisabled: {
-    locator: byDataTestId('native-select-disabled'),
-    driver: TextFieldDriver,
-  },
-  nativeSelectReadonly: {
-    locator: byDataTestId('native-select-readonly'),
-    driver: TextFieldDriver,
-  },
-} satisfies ScenePart;
-
-export const readonlyAndDisabledTextFieldExample: IExampleUnit<
-  typeof readonlyAndDisabledTextFieldExampleScenePart,
-  JSX.Element
-> = {
+export const readonlyAndDisabledTextFieldUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Readonly & Disabled TextField',
-  scene: readonlyAndDisabledTextFieldExampleScenePart,
   ui: <ReadonlyAndDisabledTextField />,
 };
 //#endregion
-
-export const readonlyAndDisabledTextFieldTestSuite: TestSuiteInfo<typeof readonlyAndDisabledTextFieldExample.scene> = {
-  title: 'Readonly & Disabled TextField',
-  url: '/textfield',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${readonlyAndDisabledTextFieldExample.title}`, () => {
-      let testEngine: TestEngine<typeof readonlyAndDisabledTextFieldExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(readonlyAndDisabledTextFieldExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Readonly TextField should be readonly`, async () => {
-        const isReadOnly = await testEngine.parts.textReadonly.isReadonly();
-        assertEqual(isReadOnly, true);
-      });
-
-      test(`Readonly TextField value should be Hello World`, async () => {
-        const value = await testEngine.parts.textReadonly.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Disabled TextField should be disabled`, async () => {
-        const isDisabled = await testEngine.parts.textDisabled.isDisabled();
-        assertEqual(isDisabled, true);
-      });
-
-      test(`Disabled TextField value should be Hello World`, async () => {
-        const value = await testEngine.parts.textDisabled.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Readonly Multi-TextField should be readonly`, async () => {
-        const isReadOnly = await testEngine.parts.multilineReadonly.isReadonly();
-        assertEqual(isReadOnly, true);
-      });
-
-      test(`Readonly Multi-TextField value should be Hello World`, async () => {
-        const value = await testEngine.parts.multilineReadonly.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Disabled Multi-TextField should be disabled`, async () => {
-        const isDisabled = await testEngine.parts.multilineDisabled.isDisabled();
-        assertEqual(isDisabled, true);
-      });
-
-      test(`Disabled Multi-TextField value should be Hello World`, async () => {
-        const value = await testEngine.parts.multilineDisabled.getValue();
-        assertEqual(value, 'Hello World');
-      });
-
-      test(`Readonly Select TextField should be readonly`, async () => {
-        const isReadOnly = await testEngine.parts.selectReadonly.isReadonly();
-        assertEqual(isReadOnly, true);
-      });
-
-      test(`Readonly Select TextField value should be 20`, async () => {
-        const value = await testEngine.parts.selectReadonly.getValue();
-        assertEqual(value, '20');
-      });
-
-      test(`Disabled Select TextField should be disabled`, async () => {
-        const isDisabled = await testEngine.parts.selectDisabled.isDisabled();
-        assertEqual(isDisabled, true);
-      });
-
-      test(`Disabled Select TextField value should be 60`, async () => {
-        const value = await testEngine.parts.selectDisabled.getValue();
-        assertEqual(value, '60');
-      });
-
-      test(`Readonly Native Select TextField should be readonly`, async () => {
-        const isReadOnly = await testEngine.parts.nativeSelectReadonly.isReadonly();
-        assertEqual(isReadOnly, true);
-      });
-
-      test(`Readonly Native Select TextField value should be 20`, async () => {
-        const value = await testEngine.parts.nativeSelectReadonly.getValue();
-        assertEqual(value, '20');
-      });
-
-      test(`Disabled Native Select TextField should be disabled`, async () => {
-        const isDisabled = await testEngine.parts.nativeSelectDisabled.isDisabled();
-        assertEqual(isDisabled, true);
-      });
-
-      test(`Disabled Native Select TextField value should be 60`, async () => {
-        const value = await testEngine.parts.nativeSelectDisabled.getValue();
-        assertEqual(value, '60');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/ReadonlyDisabledTextField.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/ReadonlyDisabledTextField.suite.ts
@@ -1,0 +1,112 @@
+import { JSX } from 'react';
+
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { readonlyAndDisabledTextFieldUIExample } from './ReadonlyDisabledTextField.examples';
+
+export const readonlyAndDisabledTextFieldExampleScenePart = {
+  textDisabled: {
+    locator: byDataTestId('text-disabled'),
+    driver: TextFieldDriver,
+  },
+  textReadonly: {
+    locator: byDataTestId('text-readonly'),
+    driver: TextFieldDriver,
+  },
+  multilineDisabled: {
+    locator: byDataTestId('multiline-disabled'),
+    driver: TextFieldDriver,
+  },
+  multilineReadonly: {
+    locator: byDataTestId('multiline-readonly'),
+    driver: TextFieldDriver,
+  },
+  selectDisabled: {
+    locator: byDataTestId('select-disabled'),
+    driver: TextFieldDriver,
+  },
+  selectReadonly: {
+    locator: byDataTestId('select-readonly'),
+    driver: TextFieldDriver,
+  },
+  nativeSelectDisabled: {
+    locator: byDataTestId('native-select-disabled'),
+    driver: TextFieldDriver,
+  },
+  nativeSelectReadonly: {
+    locator: byDataTestId('native-select-readonly'),
+    driver: TextFieldDriver,
+  },
+} satisfies ScenePart;
+
+export const readonlyAndDisabledTextFieldExample: IExampleUnit<
+  typeof readonlyAndDisabledTextFieldExampleScenePart,
+  JSX.Element
+> = {
+  ...readonlyAndDisabledTextFieldUIExample,
+  scene: readonlyAndDisabledTextFieldExampleScenePart,
+};
+
+export const readonlyAndDisabledTextFieldTestSuite: TestSuiteInfo<typeof readonlyAndDisabledTextFieldExample.scene> = {
+  title: 'Readonly & Disabled TextField',
+  url: '/textfield',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof readonlyAndDisabledTextFieldExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(readonlyAndDisabledTextFieldExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('readonly text field should be readonly', async () => {
+      const isReadOnly = await testEngine.parts.textReadonly.isReadonly();
+      assertEqual(isReadOnly, true);
+    });
+
+    test('readonly text field should have correct value', async () => {
+      const value = await testEngine.parts.textReadonly.getValue();
+      assertEqual(value, 'Hello World');
+    });
+
+    test('disabled text field should be disabled', async () => {
+      const isDisabled = await testEngine.parts.textDisabled.isDisabled();
+      assertEqual(isDisabled, true);
+    });
+
+    test('disabled text field should have correct value', async () => {
+      const value = await testEngine.parts.textDisabled.getValue();
+      assertEqual(value, 'Hello World');
+    });
+
+    test('readonly multiline should be readonly', async () => {
+      const isReadOnly = await testEngine.parts.multilineReadonly.isReadonly();
+      assertEqual(isReadOnly, true);
+    });
+
+    test('disabled multiline should be disabled', async () => {
+      const isDisabled = await testEngine.parts.multilineDisabled.isDisabled();
+      assertEqual(isDisabled, true);
+    });
+
+    test('readonly select should be readonly', async () => {
+      const isReadOnly = await testEngine.parts.selectReadonly.isReadonly();
+      assertEqual(isReadOnly, true);
+    });
+
+    test('disabled select should be disabled', async () => {
+      const isDisabled = await testEngine.parts.selectDisabled.isDisabled();
+      assertEqual(isDisabled, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/SelectTextField.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/SelectTextField.examples.tsx
@@ -1,6 +1,4 @@
-import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
-import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
@@ -28,56 +26,8 @@ export const SelectTextField = () => {
   );
 };
 
-export const selectTextFieldExampleScenePart = {
-  select: {
-    locator: byDataTestId('select'),
-    driver: TextFieldDriver,
-  },
-} satisfies ScenePart;
-
-export const selectTextFieldExample: IExampleUnit<typeof selectTextFieldExampleScenePart, JSX.Element> = {
+export const selectTextFieldUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Select TextField',
-  scene: selectTextFieldExampleScenePart,
   ui: <SelectTextField />,
 };
 //#endregion
-
-export const selectTextFieldTestSuite: TestSuiteInfo<typeof selectTextFieldExample.scene> = {
-  title: 'Select TextField',
-  url: '/textfield',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${selectTextFieldExample.title}`, () => {
-      let testEngine: TestEngine<typeof selectTextFieldExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(selectTextFieldExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test(`Label should be Number`, async () => {
-        const label = await testEngine.parts.select.getLabel();
-        assertEqual(label, 'Number');
-      });
-
-      test(`Value should be "30" as assigned`, async () => {
-        const value = await testEngine.parts.select.getValue();
-        assertEqual(value, '30');
-      });
-
-      test(`Alter value should change the value`, async () => {
-        await testEngine.parts.select.setValue('60');
-        const value = await testEngine.parts.select.getValue();
-        assertEqual(value, '60');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/SelectTextField.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/SelectTextField.suite.ts
@@ -1,0 +1,57 @@
+import { JSX } from 'react';
+
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v5';
+import { byDataTestId, IExampleUnit, ScenePart, TestEngine } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { selectTextFieldUIExample } from './SelectTextField.examples';
+
+export const selectTextFieldExampleScenePart = {
+  select: {
+    locator: byDataTestId('select'),
+    driver: TextFieldDriver,
+  },
+} satisfies ScenePart;
+
+export const selectTextFieldExample: IExampleUnit<typeof selectTextFieldExampleScenePart, JSX.Element> = {
+  ...selectTextFieldUIExample,
+  scene: selectTextFieldExampleScenePart,
+};
+
+export const selectTextFieldTestSuite: TestSuiteInfo<typeof selectTextFieldExampleScenePart> = {
+  title: 'Select TextField',
+  url: '/textfield',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof selectTextFieldExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(selectTextFieldExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should have the correct label', async () => {
+      const label = await testEngine.parts.select.getLabel();
+      assertEqual(label, 'Number');
+    });
+
+    test('it should have default value of 30', async () => {
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '30');
+    });
+
+    test('it should be able to change value', async () => {
+      await testEngine.parts.select.setValue('60');
+      const value = await testEngine.parts.select.getValue();
+      assertEqual(value, '60');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/textField/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/textField/index.ts
@@ -1,29 +1,51 @@
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
 
-import { basicTextFieldExample } from './BasicTextField.examples';
-import { dateTextFieldExample } from './DateTextField.examples';
-import { multilineTextFieldExample } from './MultilineTextField.examples';
-import { readonlyAndDisabledTextFieldExample } from './ReadonlyDisabledTextField.examples';
-import { selectTextFieldExample } from './SelectTextField.examples';
+import { IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export { basicTextFieldTestSuite } from './BasicTextField.examples';
-export { dateTextFieldTestSuite } from './DateTextField.examples';
-export { multilineTextFieldTestSuite } from './MultilineTextField.examples';
-export { readonlyAndDisabledTextFieldTestSuite } from './ReadonlyDisabledTextField.examples';
-export { selectTextFieldTestSuite } from './SelectTextField.examples';
+import { basicTextFieldUIExample } from './BasicTextField.examples';
+import { basicTextFieldExample, basicTextFieldTestSuite } from './BasicTextField.suite';
+import { dateTextFieldUIExample } from './DateTextField.examples';
+import { dateTextFieldExample, dateTextFieldTestSuite } from './DateTextField.suite';
+import { multilineTextFieldUIExample } from './MultilineTextField.examples';
+import { multilineTextFieldExample, multilineTextFieldTestSuite } from './MultilineTextField.suite';
+import { readonlyAndDisabledTextFieldUIExample } from './ReadonlyDisabledTextField.examples';
+import {
+  readonlyAndDisabledTextFieldExample,
+  readonlyAndDisabledTextFieldTestSuite,
+} from './ReadonlyDisabledTextField.suite';
+import { selectTextFieldUIExample } from './SelectTextField.examples';
+import { selectTextFieldExample, selectTextFieldTestSuite } from './SelectTextField.suite';
 
 export {
+  basicTextFieldUIExample,
   basicTextFieldExample,
+  basicTextFieldTestSuite,
+  dateTextFieldUIExample,
   dateTextFieldExample,
+  dateTextFieldTestSuite,
+  multilineTextFieldUIExample,
   multilineTextFieldExample,
+  multilineTextFieldTestSuite,
+  readonlyAndDisabledTextFieldUIExample,
   readonlyAndDisabledTextFieldExample,
+  readonlyAndDisabledTextFieldTestSuite,
+  selectTextFieldUIExample,
   selectTextFieldExample,
+  selectTextFieldTestSuite,
 };
 
-export const textFieldExamples = [
+export const textFieldUIExamples: IExampleUIUnit<JSX.Element>[] = [
+  basicTextFieldUIExample,
+  dateTextFieldUIExample,
+  multilineTextFieldUIExample,
+  readonlyAndDisabledTextFieldUIExample,
+  selectTextFieldUIExample,
+] satisfies IExampleUIUnit<JSX.Element>[];
+
+export const textFieldExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicTextFieldExample,
   dateTextFieldExample,
   multilineTextFieldExample,
-  selectTextFieldExample,
   readonlyAndDisabledTextFieldExample,
+  selectTextFieldExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/ExclusiveSelection.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/ExclusiveSelection.example.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ExclusiveToggleButtonGroupDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignJustifyIcon from '@mui/icons-material/FormatAlignJustify';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
@@ -14,7 +12,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 export const ExclusiveSelectionExample = () => {
   const [alignment, setAlignment] = React.useState<string | null>(null);
 
-  const handleAlignment = (event: React.MouseEvent<HTMLElement>, newAlignment: string | null) => {
+  const handleAlignment = (_event: React.MouseEvent<HTMLElement>, newAlignment: string | null) => {
     setAlignment(newAlignment);
   };
 
@@ -41,55 +39,12 @@ export const ExclusiveSelectionExample = () => {
   );
 };
 
-export const exclusiveSelectionExampleScenePart = {
-  alignment: {
-    locator: byDataTestId('alignment'),
-    driver: ExclusiveToggleButtonGroupDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Editor Toolbar Example from MUI Website
  * @see https://mui.com/material-ui/react-toggle-button/#customization
  */
-export const exclusiveSelectionExample: IExampleUnit<typeof exclusiveSelectionExampleScenePart, JSX.Element> = {
+export const exclusiveSelectionUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Exclusive Selection',
-  scene: exclusiveSelectionExampleScenePart,
   ui: <ExclusiveSelectionExample />,
 };
 //#endregion
-
-export const exclusiveSelectionTestSuite: TestSuiteInfo<typeof exclusiveSelectionExampleScenePart> = {
-  title: 'Exclusive Selection',
-  url: '/toggle-button',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${exclusiveSelectionExample.title}`, () => {
-      let testEngine: TestEngine<typeof exclusiveSelectionExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(exclusiveSelectionExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('Initially there should be no selected value', async () => {
-        const value = await testEngine.parts.alignment.getValue();
-        assertEqual(value, null);
-      });
-
-      test('Selecting a value should update the value', async () => {
-        await testEngine.parts.alignment.setValue('center');
-        const value = await testEngine.parts.alignment.getValue();
-        assertEqual(value, 'center');
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/ExclusiveSelection.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/ExclusiveSelection.suite.ts
@@ -1,0 +1,50 @@
+import { ExclusiveToggleButtonGroupDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { exclusiveSelectionUIExample } from './ExclusiveSelection.example';
+
+export const exclusiveSelectionExampleScenePart = {
+  alignment: {
+    locator: byDataTestId('alignment'),
+    driver: ExclusiveToggleButtonGroupDriver,
+  },
+} satisfies ScenePart;
+
+export const exclusiveSelectionExample: IExampleUnit<typeof exclusiveSelectionExampleScenePart, JSX.Element> = {
+  ...exclusiveSelectionUIExample,
+  scene: exclusiveSelectionExampleScenePart,
+};
+
+export const exclusiveSelectionTestSuite: TestSuiteInfo<typeof exclusiveSelectionExampleScenePart> = {
+  title: 'Exclusive Selection',
+  url: '/toggle-button',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof exclusiveSelectionExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(exclusiveSelectionExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Initially there should be no selected value', async () => {
+      const value = await testEngine.parts.alignment.getValue();
+      assertEqual(value, null);
+    });
+
+    test('Selecting a value should update the value', async () => {
+      await testEngine.parts.alignment.setValue('center');
+      const value = await testEngine.parts.alignment.getValue();
+      assertEqual(value, 'center');
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/MultipleSelection.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/MultipleSelection.example.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ToggleButtonGroupDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import FormatBoldIcon from '@mui/icons-material/FormatBold';
 import FormatColorFillIcon from '@mui/icons-material/FormatColorFill';
@@ -38,55 +36,12 @@ export const RegularSelectionExample = () => {
   );
 };
 
-export const regularSelectionExampleScenePart = {
-  formatting: {
-    locator: byDataTestId('formatting'),
-    driver: ToggleButtonGroupDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Multiple selection example from MUI Website
  * @see https://mui.com/material-ui/react-toggle-button/#customization
  */
-export const regularSelectionExample: IExampleUnit<typeof regularSelectionExampleScenePart, JSX.Element> = {
+export const regularSelectionUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Multiple Selection',
-  scene: regularSelectionExampleScenePart,
   ui: <RegularSelectionExample />,
 };
 //#endregion
-
-export const regularSelectionButtonTestSuite: TestSuiteInfo<typeof regularSelectionExampleScenePart> = {
-  title: 'Multiple Selection',
-  url: '/toggle-button',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${regularSelectionExample.title}`, () => {
-      let testEngine: TestEngine<typeof regularSelectionExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(regularSelectionExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('Initially there should be no selected value', async () => {
-        const value = await testEngine.parts.formatting.getValue();
-        assertEqual(value, []);
-      });
-
-      test('Selecting a value should update the value', async () => {
-        await testEngine.parts.formatting.setValue(['bold', 'italic']);
-        const value = await testEngine.parts.formatting.getValue();
-        assertEqual(value, ['bold', 'italic']);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/MultipleSelection.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/MultipleSelection.suite.ts
@@ -1,0 +1,50 @@
+import { ToggleButtonGroupDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { regularSelectionUIExample } from './MultipleSelection.example';
+
+export const regularSelectionExampleScenePart = {
+  formatting: {
+    locator: byDataTestId('formatting'),
+    driver: ToggleButtonGroupDriver,
+  },
+} satisfies ScenePart;
+
+export const regularSelectionExample: IExampleUnit<typeof regularSelectionExampleScenePart, JSX.Element> = {
+  ...regularSelectionUIExample,
+  scene: regularSelectionExampleScenePart,
+};
+
+export const regularSelectionButtonTestSuite: TestSuiteInfo<typeof regularSelectionExampleScenePart> = {
+  title: 'Multiple Selection',
+  url: '/toggle-button',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof regularSelectionExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(regularSelectionExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Initially there should be no selected value', async () => {
+      const value = await testEngine.parts.formatting.getValue();
+      assertEqual(value, []);
+    });
+
+    test('Selecting a value should update the value', async () => {
+      await testEngine.parts.formatting.setValue(['bold', 'italic']);
+      const value = await testEngine.parts.formatting.getValue();
+      assertEqual(value, ['bold', 'italic']);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/SingleToggle.example.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/SingleToggle.example.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ToggleButtonDriver } from '@atomic-testing/component-driver-mui-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import ToggleButton from '@mui/material/ToggleButton';
 
 //#region Single toggle
@@ -19,60 +17,11 @@ export const SingleToggleExample = () => {
   );
 };
 
-export const singleToggleExampleScenePart = {
-  singleToggle: {
-    locator: byDataTestId('single-toggle'),
-    driver: ToggleButtonDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Editor Toolbar Example from MUI Website
  */
-export const singleToggleExample: IExampleUnit<typeof singleToggleExampleScenePart, JSX.Element> = {
+export const singleToggleUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Single Toggle Button',
-  scene: singleToggleExampleScenePart,
   ui: <SingleToggleExample />,
 };
 //#endregion
-
-export const singleToggleButtonTestSuite: TestSuiteInfo<typeof singleToggleExampleScenePart> = {
-  title: 'Single Toggle Button',
-  url: '/toggle-button',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    describe(`${singleToggleExample.title}`, () => {
-      let testEngine: TestEngine<typeof singleToggleExample.scene>;
-
-      // Use the following beforeEach to work around the issue of Playwright's page being undefined
-      // @ts-ignore
-      beforeEach(function ({ page }) {
-        // @ts-ignore
-        testEngine = getTestEngine(singleToggleExample.scene, { page });
-        if (typeof arguments[0] === 'function') {
-          arguments[0]();
-        }
-      });
-
-      afterEach(async () => {
-        await testEngine.cleanUp();
-      });
-
-      test('Initially selected state should be false', async () => {
-        const selected = await testEngine.parts.singleToggle.isSelected();
-        assertEqual(selected, false);
-      });
-
-      test('Click on the button would set selected state to true', async () => {
-        await testEngine.parts.singleToggle.click();
-        const selected = await testEngine.parts.singleToggle.isSelected();
-        assertEqual(selected, true);
-      });
-
-      test('Set the selected state would yield the correct selected state', async () => {
-        await testEngine.parts.singleToggle.setSelected(true);
-        const selected = await testEngine.parts.singleToggle.isSelected();
-        assertEqual(selected, true);
-      });
-    });
-  },
-};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/SingleToggle.suite.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/SingleToggle.suite.ts
@@ -1,0 +1,56 @@
+import { ToggleButtonDriver } from '@atomic-testing/component-driver-mui-v5';
+import { TestEngine, byDataTestId, ScenePart, IExampleUnit } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { singleToggleUIExample } from './SingleToggle.example';
+
+export const singleToggleExampleScenePart = {
+  singleToggle: {
+    locator: byDataTestId('single-toggle'),
+    driver: ToggleButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const singleToggleExample: IExampleUnit<typeof singleToggleExampleScenePart, JSX.Element> = {
+  ...singleToggleUIExample,
+  scene: singleToggleExampleScenePart,
+};
+
+export const singleToggleButtonTestSuite: TestSuiteInfo<typeof singleToggleExampleScenePart> = {
+  title: 'Single Toggle Button',
+  url: '/toggle-button',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof singleToggleExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(singleToggleExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Initially selected state should be false', async () => {
+      const selected = await testEngine.parts.singleToggle.isSelected();
+      assertEqual(selected, false);
+    });
+
+    test('Click on the button would set selected state to true', async () => {
+      await testEngine.parts.singleToggle.click();
+      const selected = await testEngine.parts.singleToggle.isSelected();
+      assertEqual(selected, true);
+    });
+
+    test('Set the selected state would yield the correct selected state', async () => {
+      await testEngine.parts.singleToggle.setSelected(true);
+      const selected = await testEngine.parts.singleToggle.isSelected();
+      assertEqual(selected, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-v5-test/src/examples/toggleButton/index.ts
+++ b/packages/component-driver-mui-v5-test/src/examples/toggleButton/index.ts
@@ -1,15 +1,27 @@
+import { JSX } from 'react';
+
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { exclusiveSelectionExample } from './ExclusiveSelection.example';
-import { regularSelectionExample } from './MultipleSelection.example';
-import { singleToggleExample } from './SingleToggle.example';
+import { exclusiveSelectionUIExample } from './ExclusiveSelection.example';
+import { exclusiveSelectionExample, exclusiveSelectionTestSuite } from './ExclusiveSelection.suite';
+import { regularSelectionUIExample } from './MultipleSelection.example';
+import { regularSelectionExample, regularSelectionButtonTestSuite } from './MultipleSelection.suite';
+import { singleToggleUIExample } from './SingleToggle.example';
+import { singleToggleExample, singleToggleButtonTestSuite } from './SingleToggle.suite';
 
-export { exclusiveSelectionTestSuite } from './ExclusiveSelection.example';
-export { regularSelectionButtonTestSuite } from './MultipleSelection.example';
-export { singleToggleButtonTestSuite } from './SingleToggle.example';
-export { regularSelectionExample, singleToggleExample };
+export {
+  singleToggleUIExample,
+  singleToggleExample,
+  singleToggleButtonTestSuite,
+  exclusiveSelectionUIExample,
+  exclusiveSelectionExample,
+  exclusiveSelectionTestSuite,
+  regularSelectionUIExample,
+  regularSelectionExample,
+  regularSelectionButtonTestSuite,
+};
 
-export const toggleButtonExamples = [
+export const toggleButtonExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   singleToggleExample,
   exclusiveSelectionExample,
   regularSelectionExample,

--- a/packages/component-driver-mui-v5-test/src/index.css
+++ b/packages/component-driver-mui-v5-test/src/index.css
@@ -1,17 +1,3 @@
-/* body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-} */
-
 html,
 body {
   height: 100%;

--- a/packages/component-driver-mui-v5-test/vite.config.ts
+++ b/packages/component-driver-mui-v5-test/vite.config.ts
@@ -1,0 +1,24 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+const port = 5115;
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': '/src', // Assuming your source code is in the 'src' directory
+    },
+  },
+  server: {
+    host: true,
+    port,
+    // Having strictPort set to true along with hmr port locked to the same port
+    // would make sure hot-module-reload works properly
+    strictPort: true,
+    hmr: {
+      port,
+    },
+  },
+});

--- a/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
@@ -1,0 +1,82 @@
+import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssSelector,
+  byInputType,
+  byValue,
+  ComponentDriver,
+  IComponentDriverOption,
+  IInputDriver,
+  Interactor,
+  LocatorRelativePosition,
+  locatorUtil,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+export const parts = {
+  choices: {
+    locator: byInputType('radio'),
+    driver: HTMLRadioButtonGroupDriver,
+  },
+} satisfies ScenePart;
+
+export class ProgressDriver extends ComponentDriver<typeof parts> implements IInputDriver<number | null> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  async getValue(): Promise<number | null> {
+    const rawValue = await this.getAttribute('aria-valuenow');
+    const numValue = Number(rawValue);
+    if (rawValue == null || isNaN(numValue)) {
+      return null;
+    }
+    return Number(rawValue);
+  }
+
+  async getType(): Promise<'linear' | 'circular'> {
+    const cssClasses = await this.getAttribute('class');
+    if (cssClasses?.includes('MuiCircularProgress-root')) {
+      return 'circular';
+    }
+    return 'linear';
+  }
+
+  async isDeterminate(): Promise<boolean> {
+    const val = await this.getValue();
+    return val != null;
+  }
+
+  //TODO: Buffer value can be extracted from style="transform: translateX(-15%);" actual value would be 100 - 15 = 85
+  // <span class="MuiLinearProgress-bar MuiLinearProgress-bar2 MuiLinearProgress-colorPrimary MuiLinearProgress-bar2Buffer css-1v1662g-MuiLinearProgress-bar2" style="transform: translateX(-15%);"></span>
+
+  async setValue(value: number | null): Promise<boolean> {
+    // TODO: Setting value to null is not supported.  https://github.com/atomic-testing/atomic-testing/issues/68
+    const currentValue = await this.getValue();
+    if (value === currentValue) {
+      return true;
+    }
+
+    const valueToClick = (value == null ? currentValue : value) as number;
+    const targetLocator = locatorUtil.append(
+      this.parts.choices.locator,
+      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+    );
+
+    const targetExists = await this.interactor.exists(targetLocator);
+    if (targetExists) {
+      const id = await this.interactor.getAttribute(targetLocator, 'id');
+      const labelLocator = locatorUtil.append(this.locator, byCssSelector(`label[for="${id}"]`));
+      await this.interactor.click(labelLocator);
+    }
+    // TODO: throw error if the value does not exist
+    return targetExists;
+  }
+
+  get driverName(): string {
+    return 'MuiV5ProgressDriver';
+  }
+}

--- a/packages/component-driver-mui-v5/src/index.ts
+++ b/packages/component-driver-mui-v5/src/index.ts
@@ -17,6 +17,7 @@ export { ListDriver } from './components/ListDriver';
 export { ListItemDriver } from './components/ListItemDriver';
 export { MenuDriver } from './components/MenuDriver';
 export { MenuItemDriver } from './components/MenuItemDriver';
+export { ProgressDriver } from './components/ProgressDriver';
 export { RatingDriver } from './components/RatingDriver';
 export { SelectDriver } from './components/SelectDriver';
 export { SliderDriver } from './components/SliderDriver';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,18 +241,21 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.7(@types/react@18.3.23)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.0
+        version: 4.5.2(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.1))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
-      react-scripts:
-        specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.1)
 
   packages/component-driver-mui-v6:
     dependencies:
@@ -669,7 +672,7 @@ importers:
         version: 29.7.0
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.4))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.4))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3


### PR DESCRIPTION

Refactors the HTML driver test examples by separating UI markup into “.examples” files and test logic into “.suite” files, enabling the tests to run correctly in Vite.

- Split each example into a UI-only export (`IExampleUIUnit`) and a test suite (`TestSuiteInfo`) in separate `.examples.tsx` and `.suite.ts` files
- Updated all index files and `directory.tsx` to import the new UI-only units, adjusted `ExampleList` to expect `IExampleUIUnit` instead of `IExampleUnit`
