### PR TITLE
refactor: Refactor MUI-X V5 component tests

### DIFF
--- a/packages/component-driver-mui-x-v5-test/index.html
+++ b/packages/component-driver-mui-x-v5-test/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MUI X V5 Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/component-driver-mui-x-v5-test/package.json
+++ b/packages/component-driver-mui-x-v5-test/package.json
@@ -8,8 +8,8 @@
     "src"
   ],
   "scripts": {
-    "start": "PORT=5125 TSC_COMPILE_ON_ERROR=true react-scripts start",
-    "build:ui": "react-scripts build",
+    "start": "vite --force",
+    "build:ui": "vite build",
     "postbuild": "node ../../scripts/postBuild.mjs",
     "test:dom": "jest",
     "test:e2e": "playwright test",
@@ -62,10 +62,11 @@
     "@types/node": "^22.15.30",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.5.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "react-scripts": "5.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/component-driver-mui-x-v5-test/src/components/ExampleList.tsx
+++ b/packages/component-driver-mui-x-v5-test/src/components/ExampleList.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { JSX } from 'react';
 
-import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { IExampleUIUnit } from '@atomic-testing/core';
 
 export interface ExampleListProps {
-  examples: IExampleUnit<ScenePart, JSX.Element>[];
+  examples: readonly IExampleUIUnit<JSX.Element>[];
 }
 
 export const ExampleList: React.FunctionComponent<ExampleListProps> = props => (

--- a/packages/component-driver-mui-x-v5-test/src/directory.tsx
+++ b/packages/component-driver-mui-x-v5-test/src/directory.tsx
@@ -1,5 +1,7 @@
 import { ExampleList } from './components/ExampleList';
-import { dataGridProExamples, datePickerExamples } from './examples';
+import { basicDataGridProUIExample } from './examples/datagridpro/BasicDataGridPro.examples';
+import { basicDatePickerUIExample } from './examples/datetimepicker/BasicDateTimePicker.examples';
+import { basicDateRangePickerUIExample } from './examples/datetimepicker/DateRangePicker.examples';
 
 interface IToc {
   label: string;
@@ -11,11 +13,11 @@ export const tocs: IToc[] = [
   {
     label: 'DataGrid Pro',
     path: '/datagridpro',
-    ui: <ExampleList examples={dataGridProExamples} />,
+    ui: <ExampleList examples={[basicDataGridProUIExample]} />,
   },
   {
     label: 'DatePicker',
     path: '/datepicker',
-    ui: <ExampleList examples={datePickerExamples} />,
+    ui: <ExampleList examples={[basicDatePickerUIExample, basicDateRangePickerUIExample]} />,
   },
 ];

--- a/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/BasicDataGridPro.examples.tsx
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/BasicDataGridPro.examples.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
+import React, { JSX } from 'react';
 
-import { DataGridProDriver } from '@atomic-testing/component-driver-mui-x-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 
@@ -27,76 +25,11 @@ export const BasicDataGridPro: React.FunctionComponent = () => {
   );
 };
 
-export const basicDataGridProExampleScenePart = {
-  basicGrid: {
-    locator: byDataTestId('basic-grid-pro'),
-    driver: DataGridProDriver,
-  },
-} satisfies ScenePart;
-
 /**
  * Basic DataGridPro example from MUI's website
  * @see https://mui.com/material-ui/react-datagridpro#description
  */
-export const basicDataGridProExample: IExampleUnit<typeof basicDataGridProExampleScenePart, JSX.Element> = {
+export const basicDataGridProUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic DataGridPro',
-  scene: basicDataGridProExampleScenePart,
   ui: <BasicDataGridPro />,
-};
-//#endregion
-
-export const basicDataGridProTestSuite: TestSuiteInfo<typeof basicDataGridProExampleScenePart> = {
-  title: 'Basic DataGridPro',
-  url: '/datagridpro',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicDataGridProExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicDataGridProExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('it should display at least 2 columns', async () => {
-      const count = await testEngine.parts.basicGrid.getColumnCount();
-      assertEqual(count >= 2, true);
-    });
-
-    test('it should display at least 2 rows', async () => {
-      const count = await testEngine.parts.basicGrid.getRowCount();
-      assertEqual(count >= 2, true);
-    });
-
-    test('Get cell should return cell with some text', async () => {
-      const text = await testEngine.parts.basicGrid.getCellText({ rowIndex: 1, columnIndex: 1 });
-      assertEqual((text ?? '').length > 1, true);
-    });
-
-    test('Header Row should contain columns desk, commodity, trader name ...', async () => {
-      const columnText = await testEngine.parts.basicGrid.getHeaderText();
-      const expectedColumns = ['Desk', 'Commodity'];
-      const columnTextSet = new Set(columnText);
-      const columnExists = expectedColumns.every(column => columnTextSet.has(column));
-      assertEqual(columnExists, true);
-    });
-
-    test('Data Row 1 should have content in all cells except the first one because it is a checkbox', async () => {
-      const rowText = await testEngine.parts.basicGrid.getRowText(1);
-      const textCorrect = rowText.every((column, index) => {
-        if (index === 0) {
-          return column === '';
-        }
-        return column.length > 1;
-      });
-      assertEqual(textCorrect, true);
-    });
-  },
 };

--- a/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/BasicDataGridPro.suite.ts
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/BasicDataGridPro.suite.ts
@@ -1,0 +1,79 @@
+import { JSX } from 'react';
+
+import { DataGridProDriver } from '@atomic-testing/component-driver-mui-x-v5';
+import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicDataGridProUIExample } from './BasicDataGridPro.examples';
+
+export const basicDataGridProExampleScenePart = {
+  basicGrid: {
+    locator: byDataTestId('basic-grid-pro'),
+    driver: DataGridProDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic DataGridPro example from MUI's website
+ * @see https://mui.com/material-ui/react-datagridpro#description
+ */
+export const basicDataGridProExample: IExampleUnit<typeof basicDataGridProExampleScenePart, JSX.Element> = {
+  ...basicDataGridProUIExample,
+  scene: basicDataGridProExampleScenePart,
+};
+
+export const basicDataGridProTestSuite: TestSuiteInfo<typeof basicDataGridProExampleScenePart> = {
+  title: 'Basic DataGridPro',
+  url: '/datagridpro',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicDataGridProExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicDataGridProExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('it should display at least 2 columns', async () => {
+      const count = await testEngine.parts.basicGrid.getColumnCount();
+      assertEqual(count >= 2, true);
+    });
+
+    test('it should display at least 2 rows', async () => {
+      const count = await testEngine.parts.basicGrid.getRowCount();
+      assertEqual(count >= 2, true);
+    });
+
+    test('Get cell should return cell with some text', async () => {
+      const text = await testEngine.parts.basicGrid.getCellText({ rowIndex: 1, columnIndex: 1 });
+      assertEqual((text ?? '').length > 1, true);
+    });
+
+    test('Header Row should contain columns desk, commodity ...', async () => {
+      const columnText = await testEngine.parts.basicGrid.getHeaderText();
+      const expectedColumns = ['Desk', 'Commodity'];
+      const columnTextSet = new Set(columnText);
+      const columnExists = expectedColumns.every(column => columnTextSet.has(column));
+      assertEqual(columnExists, true);
+    });
+
+    test('Data Row 1 should have content in all cells except the first one because it is a checkbox', async () => {
+      const rowText = await testEngine.parts.basicGrid.getRowText(1);
+      const textCorrect = rowText.every((column, index) => {
+        if (index === 0) {
+          return column === '';
+        }
+        return column.length > 1;
+      });
+      assertEqual(textCorrect, true);
+    });
+  },
+};

--- a/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/index.ts
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datagridpro/index.ts
@@ -1,8 +1,9 @@
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicDataGridProExample, basicDataGridProTestSuite } from './BasicDataGridPro.examples';
+import { basicDataGridProUIExample } from './BasicDataGridPro.examples';
+import { basicDataGridProExample, basicDataGridProTestSuite } from './BasicDataGridPro.suite';
 
-export { basicDataGridProExample, basicDataGridProTestSuite };
+export { basicDataGridProUIExample, basicDataGridProExample, basicDataGridProTestSuite };
 export const dataGridProExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicDataGridProExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/BasicDateTimePicker.examples.tsx
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/BasicDateTimePicker.examples.tsx
@@ -1,13 +1,6 @@
-import React from 'react';
+import React, { JSX } from 'react';
 
-import {
-  DateTimePickerDriver,
-  DesktopDatePickerDriver,
-  MobileDatePickerDriver,
-  TimePickerDriver,
-} from '@atomic-testing/component-driver-mui-x-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -67,90 +60,11 @@ export const BasicDatePicker: React.FunctionComponent = () => {
   );
 };
 
-export const basicDatePickerExampleScenePart = {
-  desktopPicker: {
-    locator: byDataTestId('desktop-date-picker'),
-    driver: DesktopDatePickerDriver,
-  },
-  mobilePicker: {
-    locator: byDataTestId('mobile-date-picker'),
-    driver: MobileDatePickerDriver,
-  },
-  timePicker: {
-    locator: byDataTestId('time-picker'),
-    driver: TimePickerDriver,
-  },
-  dateTimePicker: {
-    locator: byDataTestId('date-time-picker'),
-    driver: DateTimePickerDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Basic DataGridPro example from MUI's website
- * @see https://mui.com/material-ui/react-datagridpro#description
+ * Basic DatePicker example from MUI's website
+ * @see https://mui.com/material-ui/react-date-pickers/getting-started/
  */
-export const basicDatePickerExample: IExampleUnit<typeof basicDatePickerExampleScenePart, JSX.Element> = {
+export const basicDatePickerUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Basic DatePicker',
-  scene: basicDatePickerExampleScenePart,
   ui: <BasicDatePicker />,
-};
-//#endregion
-
-export const basicDatePickerTestSuite: TestSuiteInfo<typeof basicDatePickerExampleScenePart> = {
-  title: 'Basic DatePicker',
-  url: '/datepicker',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicDatePickerExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicDatePickerExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    describe('DesktopDatePickerDriver', () => {
-      test('Driver should set date correctly', async () => {
-        const date = new Date('2016/03/02');
-        await testEngine.parts.desktopPicker.setValue(date);
-        const retrieved = await testEngine.parts.desktopPicker.getValue();
-        assertEqual(retrieved?.toDateString(), date.toDateString());
-      });
-    });
-
-    describe('MobileDatePickerDriver', () => {
-      test('Driver should set date correctly', async () => {
-        const date = new Date('2018/09/21');
-        await testEngine.parts.mobilePicker.setValue(date);
-        const retrieved = await testEngine.parts.mobilePicker.getValue();
-        assertEqual(retrieved?.toDateString(), date.toDateString());
-      });
-    });
-
-    describe('TimePickerDriver', () => {
-      test('Driver should set time correctly', async () => {
-        const date = new Date('2018/09/21 00:18');
-        await testEngine.parts.timePicker.setValue(date);
-        const retrieved = await testEngine.parts.timePicker.getValue();
-        assertEqual(retrieved?.toLocaleTimeString(), date.toLocaleTimeString());
-      });
-    });
-
-    describe('DateTimePickerDriver', () => {
-      test('Driver should set date/time correctly', async () => {
-        const date = new Date('2018/09/21 00:18');
-        await testEngine.parts.timePicker.setValue(date);
-        const retrieved = await testEngine.parts.timePicker.getValue();
-        assertEqual(retrieved?.toLocaleTimeString(), date.toLocaleTimeString());
-      });
-    });
-  },
 };

--- a/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/BasicDateTimePicker.suite.ts
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/BasicDateTimePicker.suite.ts
@@ -1,0 +1,98 @@
+import { JSX } from 'react';
+
+import {
+  DateTimePickerDriver,
+  DesktopDatePickerDriver,
+  MobileDatePickerDriver,
+  TimePickerDriver,
+} from '@atomic-testing/component-driver-mui-x-v5';
+import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicDatePickerUIExample } from './BasicDateTimePicker.examples';
+
+export const basicDatePickerExampleScenePart = {
+  desktopPicker: {
+    locator: byDataTestId('desktop-date-picker'),
+    driver: DesktopDatePickerDriver,
+  },
+  mobilePicker: {
+    locator: byDataTestId('mobile-date-picker'),
+    driver: MobileDatePickerDriver,
+  },
+  timePicker: {
+    locator: byDataTestId('time-picker'),
+    driver: TimePickerDriver,
+  },
+  dateTimePicker: {
+    locator: byDataTestId('date-time-picker'),
+    driver: DateTimePickerDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic DatePicker example from MUI's website
+ * @see https://mui.com/material-ui/react-date-pickers/getting-started/
+ */
+export const basicDatePickerExample: IExampleUnit<typeof basicDatePickerExampleScenePart, JSX.Element> = {
+  ...basicDatePickerUIExample,
+  scene: basicDatePickerExampleScenePart,
+};
+
+export const basicDatePickerTestSuite: TestSuiteInfo<typeof basicDatePickerExampleScenePart> = {
+  title: 'Basic DatePicker',
+  url: '/datepicker',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicDatePickerExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicDatePickerExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    describe('DesktopDatePickerDriver', () => {
+      test('Driver should set date correctly', async () => {
+        const date = new Date('2016/03/02');
+        await testEngine.parts.desktopPicker.setValue(date);
+        const retrieved = await testEngine.parts.desktopPicker.getValue();
+        assertEqual(retrieved?.toDateString(), date.toDateString());
+      });
+    });
+
+    describe('MobileDatePickerDriver', () => {
+      test('Driver should set date correctly', async () => {
+        const date = new Date('2018/09/21');
+        await testEngine.parts.mobilePicker.setValue(date);
+        const retrieved = await testEngine.parts.mobilePicker.getValue();
+        assertEqual(retrieved?.toDateString(), date.toDateString());
+      });
+    });
+
+    describe('TimePickerDriver', () => {
+      test('Driver should set time correctly', async () => {
+        const date = new Date('2018/09/21 00:18');
+        await testEngine.parts.timePicker.setValue(date);
+        const retrieved = await testEngine.parts.timePicker.getValue();
+        assertEqual(retrieved?.toLocaleTimeString(), date.toLocaleTimeString());
+      });
+    });
+
+    describe('DateTimePickerDriver', () => {
+      test('Driver should set date/time correctly', async () => {
+        const date = new Date('2018/09/21 00:18');
+        await testEngine.parts.timePicker.setValue(date);
+        const retrieved = await testEngine.parts.timePicker.getValue();
+        assertEqual(retrieved?.toLocaleTimeString(), date.toLocaleTimeString());
+      });
+    });
+  },
+};

--- a/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/DateRangePicker.examples.tsx
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/DateRangePicker.examples.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
+import React, { JSX } from 'react';
 
-import { DateRangeInput, DateRangePickerDriver } from '@atomic-testing/component-driver-mui-x-v5';
-import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
-import { TestSuiteInfo } from '@atomic-testing/test-runner';
+import { IExampleUIUnit } from '@atomic-testing/core';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
@@ -34,51 +32,11 @@ export const BasicDateRangePicker: React.FunctionComponent = () => {
   );
 };
 
-export const basicDateRangePickerExampleScenePart = {
-  dateRange: {
-    locator: byDataTestId('date-range-picker'),
-    driver: DateRangePickerDriver,
-  },
-} satisfies ScenePart;
-
 /**
- * Basic DataGridPro example from MUI's website
- * @see https://mui.com/material-ui/react-datagridpro#description
+ * Date Range Picker example from MUI's website
+ * @see https://mui.com/material-ui/react-date-pickers/date-range-picker/
  */
-export const basicDateRangePickerExample: IExampleUnit<typeof basicDateRangePickerExampleScenePart, JSX.Element> = {
+export const basicDateRangePickerUIExample: IExampleUIUnit<JSX.Element> = {
   title: 'Date Range Picker',
-  scene: basicDateRangePickerExampleScenePart,
   ui: <BasicDateRangePicker />,
-};
-//#endregion
-
-export const basicDateRangePickerTestSuite: TestSuiteInfo<typeof basicDateRangePickerExampleScenePart> = {
-  title: 'Date Range Picker',
-  url: '/datepicker',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
-    let testEngine: TestEngine<typeof basicDateRangePickerExample.scene>;
-
-    // Use the following beforeEach to work around the issue of Playwright's page being undefined
-    // @ts-ignore
-    beforeEach(function ({ page }) {
-      // @ts-ignore
-      testEngine = getTestEngine(basicDateRangePickerExample.scene, { page });
-      if (typeof arguments[0] === 'function') {
-        arguments[0]();
-      }
-    });
-
-    afterEach(async () => {
-      await testEngine.cleanUp();
-    });
-
-    test('Driver should set date range correctly', async () => {
-      const end = new Date('2018/09/21');
-      const start = new Date('2016/03/02');
-      const input: DateRangeInput = { start, end, type: 'date' };
-      await testEngine.parts.dateRange.setValue(input);
-      const retrieved = await testEngine.parts.dateRange.getValue();
-      assertEqual(retrieved, input);
-    });
-  },
 };

--- a/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/DateRangePicker.suite.ts
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/DateRangePicker.suite.ts
@@ -1,0 +1,54 @@
+import { JSX } from 'react';
+
+import { DateRangeInput, DateRangePickerDriver } from '@atomic-testing/component-driver-mui-x-v5';
+import { IExampleUnit, ScenePart, TestEngine, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo } from '@atomic-testing/test-runner';
+
+import { basicDateRangePickerUIExample } from './DateRangePicker.examples';
+
+export const basicDateRangePickerExampleScenePart = {
+  dateRange: {
+    locator: byDataTestId('date-range-picker'),
+    driver: DateRangePickerDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Date Range Picker example from MUI's website
+ * @see https://mui.com/material-ui/react-date-pickers/date-range-picker/
+ */
+export const basicDateRangePickerExample: IExampleUnit<typeof basicDateRangePickerExampleScenePart, JSX.Element> = {
+  ...basicDateRangePickerUIExample,
+  scene: basicDateRangePickerExampleScenePart,
+};
+
+export const basicDateRangePickerTestSuite: TestSuiteInfo<typeof basicDateRangePickerExampleScenePart> = {
+  title: 'Date Range Picker',
+  url: '/datepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    let testEngine: TestEngine<typeof basicDateRangePickerExample.scene>;
+
+    // Use the following beforeEach to work around the issue of Playwright's page being undefined
+    // @ts-ignore
+    beforeEach(function ({ page }) {
+      // @ts-ignore
+      testEngine = getTestEngine(basicDateRangePickerExample.scene, { page });
+      if (typeof arguments[0] === 'function') {
+        arguments[0]();
+      }
+    });
+
+    afterEach(async () => {
+      await testEngine.cleanUp();
+    });
+
+    test('Driver should set date range correctly', async () => {
+      const end = new Date('2018/09/21');
+      const start = new Date('2016/03/02');
+      const input: DateRangeInput = { start, end, type: 'date' };
+      await testEngine.parts.dateRange.setValue(input);
+      const retrieved = await testEngine.parts.dateRange.getValue();
+      assertEqual(retrieved, input);
+    });
+  },
+};

--- a/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/index.ts
+++ b/packages/component-driver-mui-x-v5-test/src/examples/datetimepicker/index.ts
@@ -1,10 +1,12 @@
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 
-import { basicDatePickerExample, basicDatePickerTestSuite } from './BasicDateTimePicker.examples';
-import { basicDateRangePickerExample, basicDateRangePickerTestSuite } from './DateRangePicker.examples';
+import { basicDatePickerUIExample } from './BasicDateTimePicker.examples';
+import { basicDatePickerExample, basicDatePickerTestSuite } from './BasicDateTimePicker.suite';
+import { basicDateRangePickerUIExample } from './DateRangePicker.examples';
+import { basicDateRangePickerExample, basicDateRangePickerTestSuite } from './DateRangePicker.suite';
 
-export { basicDatePickerExample, basicDatePickerTestSuite };
-export { basicDateRangePickerExample, basicDateRangePickerTestSuite };
+export { basicDatePickerUIExample, basicDatePickerExample, basicDatePickerTestSuite };
+export { basicDateRangePickerUIExample, basicDateRangePickerExample, basicDateRangePickerTestSuite };
 export const datePickerExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicDatePickerExample,
   basicDateRangePickerExample,

--- a/packages/component-driver-mui-x-v5-test/vite.config.ts
+++ b/packages/component-driver-mui-x-v5-test/vite.config.ts
@@ -1,0 +1,24 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+const port = 5125;
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': '/src', // Assuming your source code is in the 'src' directory
+    },
+  },
+  server: {
+    host: true,
+    port,
+    // Having strictPort set to true along with hmr port locked to the same port
+    // would make sure hot-module-reload works properly
+    strictPort: true,
+    hmr: {
+      port: 5127,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,18 +664,21 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.7(@types/react@18.3.23)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.0
+        version: 4.5.2(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.1))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
-      react-scripts:
-        specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.1)
 
   packages/component-driver-mui-x-v6:
     dependencies:
@@ -806,7 +809,7 @@ importers:
         version: 29.7.0
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.4))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.4))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -11639,7 +11642,7 @@ snapshots:
 
   '@jest/transform@27.5.1':
     dependencies:
-      '@babel/core': 7.27.3
+      '@babel/core': 7.27.4
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -12873,7 +12876,7 @@ snapshots:
 
   '@svgr/plugin-jsx@5.5.0':
     dependencies:
-      '@babel/core': 7.27.3
+      '@babel/core': 7.27.4
       '@svgr/babel-preset': 5.5.0
       '@svgr/hast-util-to-babel-ast': 5.5.0
       svg-parser: 2.0.4
@@ -18160,92 +18163,6 @@ snapshots:
       dotenv-expand: 5.1.0
       eslint: 9.27.0(jiti@1.21.7)
       eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@9.27.0(jiti@1.21.7))(jest@27.5.1(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3)))(typescript@5.8.3)
-      eslint-webpack-plugin: 3.2.0(eslint@9.27.0(jiti@1.21.7))(webpack@5.75.0(@swc/core@1.3.53))
-      file-loader: 6.2.0(webpack@5.75.0(@swc/core@1.3.53))
-      fs-extra: 10.1.0
-      html-webpack-plugin: 5.5.0(webpack@5.75.0(@swc/core@1.3.53))
-      identity-obj-proxy: 3.0.0
-      jest: 27.5.1(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))
-      jest-resolve: 27.5.1
-      jest-watch-typeahead: 1.1.0(jest@27.5.1(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3)))
-      mini-css-extract-plugin: 2.7.3(webpack@5.75.0(@swc/core@1.3.53))
-      postcss: 8.5.3
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.3)
-      postcss-loader: 6.2.1(postcss@8.5.3)(webpack@5.75.0(@swc/core@1.3.53))
-      postcss-normalize: 10.0.1(browserslist@4.24.5)(postcss@8.5.3)
-      postcss-preset-env: 7.8.3(postcss@8.5.3)
-      prompts: 2.4.2
-      react: 18.3.1
-      react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@9.27.0(jiti@1.21.7))(typescript@5.8.3)(webpack@5.75.0(@swc/core@1.3.53))
-      react-refresh: 0.11.0
-      resolve: 1.22.1
-      resolve-url-loader: 4.0.0
-      sass-loader: 12.6.0(webpack@5.75.0(@swc/core@1.3.53))
-      semver: 7.7.2
-      source-map-loader: 3.0.2(webpack@5.75.0(@swc/core@1.3.53))
-      style-loader: 3.3.1(webpack@5.75.0(@swc/core@1.3.53))
-      tailwindcss: 3.2.7(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))
-      terser-webpack-plugin: 5.3.6(@swc/core@1.3.53)(webpack@5.75.0(@swc/core@1.3.53))
-      webpack: 5.75.0(@swc/core@1.3.53)
-      webpack-dev-server: 4.11.1(webpack@5.75.0(@swc/core@1.3.53))
-      webpack-manifest-plugin: 4.1.1(webpack@5.75.0(@swc/core@1.3.53))
-      workbox-webpack-plugin: 6.5.4(@types/babel__core@7.20.5)(webpack@5.75.0(@swc/core@1.3.53))
-    optionalDependencies:
-      fsevents: 2.3.3
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@types/babel__core'
-      - '@types/webpack'
-      - bufferutil
-      - canvas
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - fibers
-      - node-notifier
-      - node-sass
-      - rework
-      - rework-visit
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - ts-node
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.4))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.4))(@swc/core@1.3.53)(@types/babel__core@7.20.5)(eslint@9.27.0(jiti@1.21.7))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3))(type-fest@2.19.0)(typescript@5.8.3):
-    dependencies:
-      '@babel/core': 7.27.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(type-fest@2.19.0)(webpack-dev-server@4.11.1(webpack@5.75.0(@swc/core@1.3.53)))(webpack@5.75.0(@swc/core@1.3.53))
-      '@svgr/webpack': 5.5.0
-      babel-jest: 27.5.1(@babel/core@7.27.3)
-      babel-loader: 8.3.0(@babel/core@7.27.3)(webpack@5.75.0(@swc/core@1.3.53))
-      babel-plugin-named-asset-import: 0.3.8(@babel/core@7.27.3)
-      babel-preset-react-app: 10.0.1
-      bfj: 7.0.2
-      browserslist: 4.24.5
-      camelcase: 6.3.0
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      css-loader: 6.7.3(webpack@5.75.0(@swc/core@1.3.53))
-      css-minimizer-webpack-plugin: 3.4.1(webpack@5.75.0(@swc/core@1.3.53))
-      dotenv: 10.0.0
-      dotenv-expand: 5.1.0
-      eslint: 9.27.0(jiti@1.21.7)
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.21.4(@babel/core@7.27.4))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.4))(eslint@9.27.0(jiti@1.21.7))(jest@27.5.1(ts-node@10.9.2(@swc/core@1.3.53)(@types/node@22.15.30)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-webpack-plugin: 3.2.0(eslint@9.27.0(jiti@1.21.7))(webpack@5.75.0(@swc/core@1.3.53))
       file-loader: 6.2.0(webpack@5.75.0(@swc/core@1.3.53))
       fs-extra: 10.1.0


### PR DESCRIPTION

Refactors the HTML driver test examples by separating UI markup into “.examples” files and test logic into “.suite” files, enabling the tests to run correctly in Vite.

- Split each example into a UI-only export (`IExampleUIUnit`) and a test suite (`TestSuiteInfo`) in separate `.examples.tsx` and `.suite.ts` files
- Updated all index files and `directory.tsx` to import the new UI-only units, adjusted `ExampleList` to expect `IExampleUIUnit` instead of `IExampleUnit`
