### PR TITLE
Fix SnackbarDriver typing

### DIFF
--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "check:type": "tsc --noEmit"
   },
   "author": "Tianzhen Lin <tangent@usa.net>",
   "keywords": [

--- a/packages/component-driver-mui-v5/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/SnackbarDriver.ts
@@ -7,8 +7,8 @@ import {
   locatorUtil,
   PartLocator,
   ScenePart,
+  ComponentDriverCtor,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
 
 export const parts = {
   contentDisplay: {
@@ -51,7 +51,7 @@ export class SnackbarDriver extends ComponentDriver<typeof parts> {
    */
   async getActionComponent<ItemClass extends ComponentDriver>(
     locator: PartLocator,
-    driverClass: ComponentDriverClass<ItemClass>
+    driverClass: ComponentDriverCtor<ItemClass>
   ): Promise<ItemClass | null> {
     await this.enforcePartExistence('actionArea');
     const componentLocator = locatorUtil.append(this.parts.actionArea.locator, locator);

--- a/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
@@ -7,8 +7,8 @@ import {
   locatorUtil,
   PartLocator,
   ScenePart,
+  ComponentDriverCtor,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
 
 export const parts = {
   contentDisplay: {
@@ -51,7 +51,7 @@ export class SnackbarDriver extends ComponentDriver<typeof parts> {
    */
   async getActionComponent<ItemClass extends ComponentDriver>(
     locator: PartLocator,
-    driverClass: ComponentDriverClass<ItemClass>
+    driverClass: ComponentDriverCtor<ItemClass>
   ): Promise<ItemClass | null> {
     await this.enforcePartExistence('actionArea');
     const componentLocator = locatorUtil.append(this.parts.actionArea.locator, locator);

--- a/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
@@ -7,8 +7,8 @@ import {
   locatorUtil,
   PartLocator,
   ScenePart,
+  ComponentDriverCtor,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
 
 export const parts = {
   contentDisplay: {
@@ -51,7 +51,7 @@ export class SnackbarDriver extends ComponentDriver<typeof parts> {
    */
   async getActionComponent<ItemClass extends ComponentDriver>(
     locator: PartLocator,
-    driverClass: ComponentDriverClass<ItemClass>
+    driverClass: ComponentDriverCtor<ItemClass>
   ): Promise<ItemClass | null> {
     await this.enforcePartExistence('actionArea');
     const componentLocator = locatorUtil.append(this.parts.actionArea.locator, locator);

--- a/packages/core/src/drivers/listHelper.ts
+++ b/packages/core/src/drivers/listHelper.ts
@@ -1,5 +1,5 @@
 import { byCssSelector, CssLocator, LocatorRelativePosition, PartLocator } from '../locators';
-import { ComponentDriverClass } from '../partTypes';
+import { ComponentDriverCtor } from '../partTypes';
 import { append } from '../utils/locatorUtil';
 
 import { ComponentDriver } from './ComponentDriver';
@@ -17,7 +17,7 @@ export async function getListItemByIndex<T extends ComponentDriver>(
   host: ComponentDriver<any>,
   itemLocatorBase: PartLocator,
   index: number,
-  driverClass: ComponentDriverClass<T>
+  driverClass: ComponentDriverCtor<T>
 ): Promise<T | null> {
   const nthLocator: CssLocator = byCssSelector(`:nth-of-type(${index + 1})`, LocatorRelativePosition.Same);
   const itemLocator = append(itemLocatorBase, nthLocator);
@@ -39,7 +39,7 @@ export async function getListItemByIndex<T extends ComponentDriver>(
 export async function* getListItemIterator<T extends ComponentDriver<any>>(
   host: ComponentDriver<any>,
   itemLocatorBase: PartLocator,
-  driverClass: ComponentDriverClass<T>,
+  driverClass: ComponentDriverCtor<T>,
   startIndex: number = 0
 ): AsyncGenerator<T, void, unknown> {
   let index = startIndex;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ScenePart,
   ScenePartDefinition,
   ScenePartDriver,
+  ComponentDriverCtor,
 } from './partTypes';
 export * as collectionUtil from './utils/collectionUtil';
 export * as dateUtil from './utils/dateUtil';

--- a/packages/core/src/partTypes.ts
+++ b/packages/core/src/partTypes.ts
@@ -14,6 +14,17 @@ export type ComponentDriverClass<T extends ComponentDriver<any>> = new (
   option?: Partial<IComponentDriverOption<any>>
 ) => T;
 
+/**
+ * Constructor signature for a {@link ComponentDriver}. This mirrors
+ * {@link ComponentDriverClass} but is exported publicly so packages can
+ * reference the type without importing from internal paths.
+ */
+export type ComponentDriverCtor<T extends ComponentDriver<any>> = new (
+  locator: PartLocator,
+  interactor: Interactor,
+  option?: Partial<IComponentDriverOption<any>>
+) => T;
+
 export interface ComponentPartDefinition<T extends ScenePart> {
   /**
    * The locator of the part


### PR DESCRIPTION
## Summary
- promote `ComponentDriverCtor` to core and export it
- use `ComponentDriverCtor` in SnackbarDrivers for MUI v5-v7
- update list helper to use the new constructor type

## Testing
- `pnpm --filter @atomic-testing/core check:type`
- `pnpm --filter @atomic-testing/component-driver-mui-v5 check:type`
- `pnpm --filter @atomic-testing/component-driver-mui-v6 exec tsc --noEmit --listFiles`
- `pnpm --filter @atomic-testing/component-driver-mui-v7 exec tsc --noEmit --listFiles`


------
https://chatgpt.com/codex/tasks/task_b_684f774263c8832bb5aa4f8624a1f2eb