### PR TITLE
Refine core typings

### DIFF
--- a/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.examples.tsx
+++ b/packages/component-driver-mui-v5-test/src/examples/dialog/SlideInDialog.examples.tsx
@@ -12,7 +12,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children: React.ReactElement<any, any>;
+    children: React.ReactElement;
   },
   ref: React.Ref<unknown>
 ) {

--- a/packages/component-driver-mui-v5/src/components/ListDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ListDriver.ts
@@ -20,7 +20,7 @@ export class ListDriver<ItemT extends ListItemDriver = ListItemDriver> extends L
     locator: PartLocator,
     interactor: Interactor,
     // @ts-ignore
-    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption<any>> = defaultListDriverOption
+    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption> = defaultListDriverOption
   ) {
     super(locator, interactor, option);
   }

--- a/packages/component-driver-mui-v5/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/SnackbarDriver.ts
@@ -8,7 +8,7 @@ import {
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
+import { ComponentDriverClass } from '@atomic-testing/core';
 
 export const parts = {
   contentDisplay: {

--- a/packages/component-driver-mui-v5/src/errors/MenuItemDisabledError.ts
+++ b/packages/component-driver-mui-v5/src/errors/MenuItemDisabledError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemDisabledError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemDisabledErrorId;

--- a/packages/component-driver-mui-v5/src/errors/MenuItemNotFoundError.ts
+++ b/packages/component-driver-mui-v5/src/errors/MenuItemNotFoundError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemNotFoundError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemNotFoundErrorId;

--- a/packages/component-driver-mui-v6-test/src/examples/dialog/SlideInDialog.examples.tsx
+++ b/packages/component-driver-mui-v6-test/src/examples/dialog/SlideInDialog.examples.tsx
@@ -12,7 +12,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children: React.ReactElement<any, any>;
+    children: React.ReactElement;
   },
   ref: React.Ref<unknown>
 ) {

--- a/packages/component-driver-mui-v6/src/components/ListDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ListDriver.ts
@@ -20,7 +20,7 @@ export class ListDriver<ItemT extends ListItemDriver = ListItemDriver> extends L
     locator: PartLocator,
     interactor: Interactor,
     // @ts-ignore
-    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption<any>> = defaultListDriverOption
+    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption> = defaultListDriverOption
   ) {
     super(locator, interactor, option);
   }

--- a/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
@@ -8,7 +8,7 @@ import {
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
+import { ComponentDriverClass } from '@atomic-testing/core';
 
 export const parts = {
   contentDisplay: {

--- a/packages/component-driver-mui-v6/src/errors/MenuItemDisabledError.ts
+++ b/packages/component-driver-mui-v6/src/errors/MenuItemDisabledError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemDisabledError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemDisabledErrorId;

--- a/packages/component-driver-mui-v6/src/errors/MenuItemNotFoundError.ts
+++ b/packages/component-driver-mui-v6/src/errors/MenuItemNotFoundError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemNotFoundError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemNotFoundErrorId;

--- a/packages/component-driver-mui-v7-test/src/examples/dialog/SlideInDialog.examples.tsx
+++ b/packages/component-driver-mui-v7-test/src/examples/dialog/SlideInDialog.examples.tsx
@@ -12,7 +12,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children: React.ReactElement<any, any>;
+    children: React.ReactElement;
   },
   ref: React.Ref<unknown>
 ) {

--- a/packages/component-driver-mui-v7/src/components/ListDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ListDriver.ts
@@ -20,7 +20,7 @@ export class ListDriver<ItemT extends ListItemDriver = ListItemDriver> extends L
     locator: PartLocator,
     interactor: Interactor,
     // @ts-ignore
-    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption<any>> = defaultListDriverOption
+    option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption> = defaultListDriverOption
   ) {
     super(locator, interactor, option);
   }

--- a/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
@@ -8,7 +8,7 @@ import {
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
-import { ComponentDriverClass } from '@atomic-testing/core/src/partTypes';
+import { ComponentDriverClass } from '@atomic-testing/core';
 
 export const parts = {
   contentDisplay: {

--- a/packages/component-driver-mui-v7/src/errors/MenuItemDisabledError.ts
+++ b/packages/component-driver-mui-v7/src/errors/MenuItemDisabledError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemDisabledError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemDisabledErrorId;

--- a/packages/component-driver-mui-v7/src/errors/MenuItemNotFoundError.ts
+++ b/packages/component-driver-mui-v7/src/errors/MenuItemNotFoundError.ts
@@ -9,7 +9,7 @@ function getErrorMessage(label: string): string {
 export class MenuItemNotFoundError extends ErrorBase {
   constructor(
     public readonly label: string,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(label), driver);
     this.name = MenuItemNotFoundErrorId;

--- a/packages/core/src/drivers/listHelper.ts
+++ b/packages/core/src/drivers/listHelper.ts
@@ -14,7 +14,7 @@ import { ComponentDriver } from './ComponentDriver';
  * @returns
  */
 export async function getListItemByIndex<T extends ComponentDriver>(
-  host: ComponentDriver<any>,
+  host: ComponentDriver,
   itemLocatorBase: PartLocator,
   index: number,
   driverClass: ComponentDriverClass<T>
@@ -36,8 +36,8 @@ export async function getListItemByIndex<T extends ComponentDriver>(
  * @param driverClass The driver class of the list item
  * @param startIndex The starting index of the list item iterator, default is 0
  */
-export async function* getListItemIterator<T extends ComponentDriver<any>>(
-  host: ComponentDriver<any>,
+export async function* getListItemIterator<T extends ComponentDriver>(
+  host: ComponentDriver,
   itemLocatorBase: PartLocator,
   driverClass: ComponentDriverClass<T>,
   startIndex: number = 0

--- a/packages/core/src/errors/ErrorBase.ts
+++ b/packages/core/src/errors/ErrorBase.ts
@@ -3,7 +3,7 @@ import { ComponentDriver } from '../drivers';
 export class ErrorBase extends Error {
   constructor(
     message: string,
-    public readonly drive: ComponentDriver<any>
+    public readonly drive: ComponentDriver
   ) {
     super(message);
   }

--- a/packages/core/src/errors/ItemNotFoundError.ts
+++ b/packages/core/src/errors/ItemNotFoundError.ts
@@ -14,7 +14,7 @@ function getErrorMessage(locator: PartLocator): string {
 export class ItemNotFoundError extends ErrorBase {
   constructor(
     public readonly locator: PartLocator,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super(getErrorMessage(locator), driver);
     this.name = ItemNotFoundErrorId;

--- a/packages/core/src/errors/TooManyMatchingElementError.ts
+++ b/packages/core/src/errors/TooManyMatchingElementError.ts
@@ -8,7 +8,7 @@ export const TooManyMatchingElementErrorId = 'TooManyMatchingElementError';
 export class TooManyMatchingElementError extends ErrorBase {
   constructor(
     public readonly query: PartLocator,
-    public readonly driver: ComponentDriver<any>
+    public readonly driver: ComponentDriver
   ) {
     super('Too many matching element', driver);
     this.name = TooManyMatchingElementErrorId;

--- a/packages/core/src/partTypes.ts
+++ b/packages/core/src/partTypes.ts
@@ -8,10 +8,10 @@ import { PartLocator } from './locators/PartLocator';
 
 export type PartName<T extends ScenePart> = keyof T;
 
-export type ComponentDriverClass<T extends ComponentDriver<any>> = new (
+export type ComponentDriverClass<T extends ComponentDriver = ComponentDriver> = new (
   locator: PartLocator,
   interactor: Interactor,
-  option?: Partial<IComponentDriverOption<any>>
+  option?: Partial<IComponentDriverOption>
 ) => T;
 
 export interface ComponentPartDefinition<T extends ScenePart> {
@@ -53,7 +53,7 @@ export interface ContainerPartDefinition<ContentT extends ScenePart, T extends S
   option: Partial<IContainerDriverOption<ContentT, T>>;
 }
 
-export interface ListComponentPartDefinition<ItemT extends ComponentDriver<any>> {
+export interface ListComponentPartDefinition<ItemT extends ComponentDriver> {
   /**
    * The locator of the part
    */
@@ -67,19 +67,19 @@ export interface ListComponentPartDefinition<ItemT extends ComponentDriver<any>>
     | (new (
         locator: PartLocator,
         interactor: Interactor,
-        option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption<any>>
+        option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption>
       ) => ListComponentDriver<ItemT>);
 
   /**
    * Option for the driver
    */
-  option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption<any>>;
+  option: ListComponentDriverSpecificOption<ItemT> & Partial<IComponentDriverOption>;
 }
 
 export type ScenePartDefinition =
-  | ComponentPartDefinition<any>
-  | ContainerPartDefinition<any, any>
-  | ListComponentPartDefinition<any>;
+  | ComponentPartDefinition<ScenePart>
+  | ContainerPartDefinition<ScenePart, ScenePart>
+  | ListComponentPartDefinition<ComponentDriver>;
 
 /**
  * Part name to driver definition map

--- a/packages/test-runner/src/types.ts
+++ b/packages/test-runner/src/types.ts
@@ -30,7 +30,7 @@ interface Describe {
 }
 
 interface LifeCycleHook {
-  (fn: ProvidesCallback): any;
+  (fn: ProvidesCallback): void;
 }
 
 interface Test {
@@ -56,7 +56,10 @@ export interface TestFrameworkMapper {
   it: Test;
 }
 
-export type GetTestEngine<T extends ScenePart> = (scenePart: T, context?: any) => TestEngine<T>;
+export type GetTestEngine<T extends ScenePart> = (
+  scenePart: T,
+  context?: unknown
+) => TestEngine<T>;
 
 /**
  * Interface for Dom tests which don't involve navigating to a URL
@@ -65,7 +68,7 @@ export type DomTestInterface<T extends ScenePart> = {
   getTestEngine: GetTestEngine<T>;
 };
 
-type GotoReturn = any;
+type GotoReturn = unknown;
 
 /**
  * Interface for E2e tests which involve navigating to a URL


### PR DESCRIPTION
## Summary
- tighten type definitions and drop `any` usage
- update MUI driver imports
- narrow ReactElement generics in dialog examples
- adjust test runner types

## Testing
- `pnpm run check:lint`
- `pnpm run types` *(fails: Cannot find module '@atomic-testing/core')*

------
https://chatgpt.com/codex/tasks/task_b_684f78262814832b91d73178395fa613