### PR TITLE
Add Vue 3 test engine and example

### DIFF
--- a/packages/vue-3/README.md
+++ b/packages/vue-3/README.md
@@ -1,0 +1,9 @@
+# @atomic-testing/vue-3
+
+Adapter for integrating Atomic Testing with [Vue 3](https://vuejs.org).
+
+## Installation
+
+```bash
+pnpm add @atomic-testing/vue-3
+```

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@atomic-testing/vue-3",
+  "version": "0.70.0",
+  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check:type": "tsc --noEmit"
+  },
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "keywords": [
+    "testing",
+    "vue",
+    "unit",
+    "integration"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git",
+    "directory": "packages/vue-3"
+  },
+  "dependencies": {
+    "@atomic-testing/core": "workspace:*",
+    "@atomic-testing/dom-core": "workspace:*",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/vue": "^9.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.30",
+    "jest": "^29.7.0",
+    "vue": "^3.4.0"
+  },
+  "peerDependencies": {
+    "@testing-library/dom": ">=10.4.0",
+    "@testing-library/vue": ">=9.4.0",
+    "@testing-library/user-event": ">=14.0.0",
+    "vue": ">=3.0.0"
+  }
+}

--- a/packages/vue-3/src/VueInteractor.ts
+++ b/packages/vue-3/src/VueInteractor.ts
@@ -1,0 +1,142 @@
+import {
+  ClickOption,
+  defaultWaitForOption,
+  EnterTextOption,
+  FocusOption,
+  HoverOption,
+  Interactor,
+  MouseDownOption,
+  MouseEnterOption,
+  MouseLeaveOption,
+  MouseMoveOption,
+  MouseOutOption,
+  MouseUpOption,
+  PartLocator,
+  WaitForOption,
+  WaitUntilOption,
+} from '@atomic-testing/core';
+import { DOMInteractor } from '@atomic-testing/dom-core';
+import { nextTick } from 'vue';
+
+export class VueInteractor extends DOMInteractor {
+  private async flush() {
+    await nextTick();
+  }
+
+  override async enterText(
+    locator: PartLocator,
+    text: string,
+    option?: Partial<EnterTextOption>,
+  ): Promise<void> {
+    await super.enterText(locator, text, option);
+    await this.flush();
+  }
+
+  override async click(
+    locator: PartLocator,
+    option?: Partial<ClickOption>,
+  ): Promise<void> {
+    await super.click(locator, option);
+    await this.flush();
+  }
+
+  override async hover(
+    locator: PartLocator,
+    option?: Partial<HoverOption>,
+  ): Promise<void> {
+    await super.hover(locator, option);
+    await this.flush();
+  }
+
+  async mouseMove(
+    locator: PartLocator,
+    option?: Partial<MouseMoveOption>,
+  ): Promise<void> {
+    await super.mouseMove(locator, option);
+    await this.flush();
+  }
+
+  async mouseDown(
+    locator: PartLocator,
+    option?: Partial<MouseDownOption>,
+  ): Promise<void> {
+    await super.mouseDown(locator, option);
+    await this.flush();
+  }
+
+  async mouseUp(
+    locator: PartLocator,
+    option?: Partial<MouseUpOption>,
+  ): Promise<void> {
+    await super.mouseUp(locator, option);
+    await this.flush();
+  }
+
+  async mouseOver(
+    locator: PartLocator,
+    option?: Partial<HoverOption>,
+  ): Promise<void> {
+    await super.mouseOver(locator, option);
+    await this.flush();
+  }
+
+  async mouseOut(
+    locator: PartLocator,
+    option?: Partial<MouseOutOption>,
+  ): Promise<void> {
+    await super.mouseOut(locator, option);
+    await this.flush();
+  }
+
+  async mouseEnter(
+    locator: PartLocator,
+    option?: Partial<MouseEnterOption>,
+  ): Promise<void> {
+    await super.mouseEnter(locator, option);
+    await this.flush();
+  }
+
+  async mouseLeave(
+    locator: PartLocator,
+    option?: Partial<MouseLeaveOption>,
+  ): Promise<void> {
+    await super.mouseLeave(locator, option);
+    await this.flush();
+  }
+
+  async focus(locator: PartLocator, option?: Partial<FocusOption>): Promise<void> {
+    await super.focus(locator, option);
+    await this.flush();
+  }
+
+  override async selectOptionValue(
+    locator: PartLocator,
+    values: string[],
+  ): Promise<void> {
+    await super.selectOptionValue(locator, values);
+    await this.flush();
+  }
+
+  override async wait(ms: number): Promise<void> {
+    await super.wait(ms);
+    await this.flush();
+  }
+
+  override async waitUntilComponentState(
+    locator: PartLocator,
+    option: Partial<Readonly<WaitForOption>> = defaultWaitForOption,
+  ): Promise<void> {
+    await super.waitUntilComponentState(locator, option);
+    await this.flush();
+  }
+
+  override async waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
+    const result = await super.waitUntil(option);
+    await this.flush();
+    return result;
+  }
+
+  override clone(): Interactor {
+    return new VueInteractor();
+  }
+}

--- a/packages/vue-3/src/createTestEngine.ts
+++ b/packages/vue-3/src/createTestEngine.ts
@@ -1,0 +1,64 @@
+import { Component } from 'vue';
+import { render } from '@testing-library/vue';
+
+import { byAttribute, ScenePart, TestEngine } from '@atomic-testing/core';
+
+import { VueInteractor } from './VueInteractor';
+import { IVueTestEngineOption } from './types';
+
+let _rootId = 0;
+function getNextRootElementId() {
+  return `${_rootId++}`;
+}
+
+const rootElementAttributeName = 'data-atomic-testing-vue';
+
+export function createTestEngine<T extends ScenePart>(
+  component: Component,
+  partDefinitions: T,
+  option?: Readonly<Partial<IVueTestEngineOption>>,
+): TestEngine<T> {
+  const rootEl = option?.rootElement ?? document.body;
+  const container = rootEl.appendChild(document.createElement('div'));
+  const rootId = getNextRootElementId();
+  container.setAttribute(rootElementAttributeName, rootId);
+  const { unmount } = render(component, { container });
+
+  const cleanup = () => {
+    unmount();
+    rootEl.removeChild(container);
+    return Promise.resolve();
+  };
+
+  return new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
+    new VueInteractor(),
+    {
+      parts: partDefinitions,
+    },
+    cleanup,
+  );
+}
+
+export function createRenderedTestEngine<T extends ScenePart>(
+  rootElement: HTMLElement,
+  partDefinitions: T,
+  _option?: Readonly<Partial<IVueTestEngineOption>>,
+): TestEngine<T> {
+  const rootId = getNextRootElementId();
+  rootElement.setAttribute(rootElementAttributeName, rootId);
+
+  const cleanup = () => {
+    rootElement.removeAttribute(rootElementAttributeName);
+    return Promise.resolve();
+  };
+
+  return new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
+    new VueInteractor(),
+    {
+      parts: partDefinitions,
+    },
+    cleanup,
+  );
+}

--- a/packages/vue-3/src/index.ts
+++ b/packages/vue-3/src/index.ts
@@ -1,0 +1,3 @@
+export { createRenderedTestEngine, createTestEngine } from './createTestEngine';
+export { VueInteractor } from './VueInteractor';
+export type { IVueTestEngineOption } from './types';

--- a/packages/vue-3/src/types.ts
+++ b/packages/vue-3/src/types.ts
@@ -1,0 +1,5 @@
+import { IComponentDriverOption } from '@atomic-testing/core';
+
+export interface IVueTestEngineOption extends IComponentDriverOption {
+  rootElement?: Element;
+}

--- a/packages/vue-3/tsconfig.json
+++ b/packages/vue-3/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "declaration",
+    "generator-build",
+    "runtime"
+  ],
+  "include": [
+    "./src"
+  ],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/packages/vue-3/tsdown.config.ts
+++ b/packages/vue-3/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsdown';
+
+import commonConfig from '../../tsdown.config.base';
+
+export default defineConfig({
+  ...commonConfig,
+});

--- a/packages/vue-3/typedoc.json
+++ b/packages/vue-3/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/vue3-test/.storybook/main.ts
+++ b/packages/vue3-test/.storybook/main.ts
@@ -1,0 +1,14 @@
+import type { StorybookConfig } from '@storybook/vue3-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-themes'],
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+};
+export default config;

--- a/packages/vue3-test/.storybook/preview.ts
+++ b/packages/vue3-test/.storybook/preview.ts
@@ -1,0 +1,9 @@
+import type { Preview } from '@storybook/vue3';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+  },
+};
+
+export default preview;

--- a/packages/vue3-test/README.md
+++ b/packages/vue3-test/README.md
@@ -1,3 +1,11 @@
 # Vue 3 Test
 
 This package contains a simple Vue 3 example and unit tests demonstrating usage of `@atomic-testing/vue-3`.
+
+## Key commands
+
+| Command | Description |
+| --- | --- |
+| `pnpm dev` | Run the application locally |
+| `pnpm storybook` | Launch Storybook for the components |
+| `pnpm test` | Run unit tests |

--- a/packages/vue3-test/README.md
+++ b/packages/vue3-test/README.md
@@ -1,0 +1,3 @@
+# Vue 3 Test
+
+This package contains a simple Vue 3 example and unit tests demonstrating usage of `@atomic-testing/vue-3`.

--- a/packages/vue3-test/__tests__/Counter.dom.test.ts
+++ b/packages/vue3-test/__tests__/Counter.dom.test.ts
@@ -1,0 +1,36 @@
+import { jestTestAdapter } from '@atomic-testing/jest';
+import { createTestEngine } from '@atomic-testing/vue-3';
+import { testRunner } from '@atomic-testing/test-runner';
+
+import { counterExample } from '../src';
+
+// Define test suite
+const counterExampleTestSuite = {
+  title: 'Counter Example',
+  url: '/',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe('Counter', () => {
+      let engine: ReturnType<typeof getTestEngine>;
+
+      beforeEach(() => {
+        engine = getTestEngine(counterExample.scene);
+      });
+
+      afterEach(async () => {
+        await engine.cleanUp();
+      });
+
+      test('increments count', async () => {
+        await engine.parts.button.click();
+        const text = await engine.parts.button.getText();
+        assertEqual(text, 'Count: 1');
+      });
+    });
+  },
+};
+
+testRunner(counterExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof counterExample.scene) => {
+    return createTestEngine(counterExample.ui, scenePart);
+  },
+});

--- a/packages/vue3-test/index.html
+++ b/packages/vue3-test/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vue 3 Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/packages/vue3-test/jest.config.js
+++ b/packages/vue3-test/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  testRegex: '(/__tests__/.*.dom.(test|spec)).(jsx?|tsx?)$',
+  displayName: 'vue3-test',
+  testEnvironment: 'jsdom',
+};

--- a/packages/vue3-test/package.json
+++ b/packages/vue3-test/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@atomic-testing/vue3-test",
+  "version": "0.0.0",
+  "description": "Example and tests for @atomic-testing/vue-3",
+  "main": "dist/index.js",
+  "files": ["dist", "src"],
+  "scripts": {
+    "test": "jest"
+  },
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "license": "MIT",
+  "dependencies": {
+    "@atomic-testing/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@atomic-testing/jest": "workspace:*",
+    "@atomic-testing/vue-3": "workspace:*",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/vue": "^9.4.0",
+    "@types/jest": "^29.5.6",
+    "@types/node": "^22.15.30",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "typescript": "^5.8.3",
+    "vue": "^3.4.0"
+  }
+}

--- a/packages/vue3-test/package.json
+++ b/packages/vue3-test/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.0",
   "description": "Example and tests for @atomic-testing/vue-3",
   "main": "dist/index.js",
+  "private": true,
   "files": ["dist", "src"],
   "scripts": {
+    "dev": "vite",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
     "test": "jest"
   },
   "author": "Tianzhen Lin <tangent@usa.net>",
@@ -22,7 +26,15 @@
     "@types/node": "^22.15.30",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "storybook": "^8.0.5",
+    "@storybook/vue3": "^8.0.5",
+    "@storybook/vue3-vite": "^8.0.5",
+    "@storybook/addon-essentials": "^8.0.5",
+    "@storybook/addon-themes": "^8.0.5",
+    "@storybook/test": "^8.0.5",
     "typescript": "^5.8.3",
+    "vite": "^5.4.19",
     "vue": "^3.4.0"
   }
 }

--- a/packages/vue3-test/src/Counter.example.ts
+++ b/packages/vue3-test/src/Counter.example.ts
@@ -1,0 +1,39 @@
+import { defineComponent, h, ref } from 'vue';
+import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
+
+export const CounterComponent = defineComponent({
+  name: 'CounterComponent',
+  setup() {
+    const count = ref(0);
+    const inc = () => {
+      count.value += 1;
+    };
+    return () =>
+      h(
+        'button',
+        {
+          'data-testid': 'counter',
+          onClick: inc,
+        },
+        `Count: ${count.value}`,
+      );
+  },
+});
+
+export const counterExampleUI: IExampleUIUnit<ReturnType<typeof defineComponent>> = {
+  title: 'Counter',
+  ui: CounterComponent,
+};
+
+export const counterScene = {
+  button: {
+    locator: byDataTestId('counter'),
+    driver: HTMLButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const counterExample: IExampleUnit<typeof counterScene, ReturnType<typeof defineComponent>> = {
+  ...counterExampleUI,
+  scene: counterScene,
+};

--- a/packages/vue3-test/src/Counter.stories.ts
+++ b/packages/vue3-test/src/Counter.stories.ts
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { CounterComponent } from './Counter.example';
+
+const meta: Meta<typeof CounterComponent> = {
+  component: CounterComponent,
+};
+
+export default meta;
+export type Story = StoryObj<typeof CounterComponent>;
+
+export const Default: Story = {};

--- a/packages/vue3-test/src/index.ts
+++ b/packages/vue3-test/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Counter.example';

--- a/packages/vue3-test/src/main.ts
+++ b/packages/vue3-test/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp, h } from 'vue';
+import { CounterComponent } from './Counter.example';
+
+createApp({
+  render: () => h(CounterComponent),
+}).mount('#app');

--- a/packages/vue3-test/tsconfig.json
+++ b/packages/vue3-test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "declaration",
+    "generator-build",
+    "runtime"
+  ],
+  "include": [
+    "./src"
+  ],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/packages/vue3-test/tsconfig.test.json
+++ b/packages/vue3-test/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src", "__tests__/**/**.ts", "__tests__/**/**.tsx"]
+}

--- a/packages/vue3-test/vite.config.ts
+++ b/packages/vue3-test/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  base: './',
+  plugins: [vue()],
+});


### PR DESCRIPTION
## Summary
- implement `@atomic-testing/vue-3` with `VueInteractor` and Vue test engine
- add a `vue3-test` example package demonstrating usage with a counter component

## Testing
- `npx jest --runTestsByPath __tests__/Counter.dom.test.ts` *(fails: E403 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_68522ca52ec0832b8c3d80790806c555