### PR TITLE
Update docs for Vue 3 support

### DIFF
--- a/docs/docs/core-concepts.mdx
+++ b/docs/docs/core-concepts.mdx
@@ -77,6 +77,19 @@ const testEngine = createLegacyTestEngine(<Login />, loginScenePart);
 
 </TabItem>
 
+<TabItem value="vue" label="Vue 3">
+
+```ts
+import { createTestEngine } from '@atomic-testing/vue-3';
+
+import Login from './components/Login.vue';
+import { loginScenePart } from './loginScenePart';
+
+const testEngine = createTestEngine(Login, loginScenePart);
+```
+
+</TabItem>
+
 <TabItem value="playwright" label="Playwright">
 
 ```tsx

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -21,4 +21,4 @@ The core principles of Atomic Testing are:
 
 - **Reusability**: Deliver a standard and reusable method for interacting with components.
 - **Composability**: Enable developers to compose reusable test strategies for testing more complex components.
-- **Adaptability**: Ensure testing strategies can adapt to various test environments, including DOM testing (React, Angular, Vue) and end-to-end testing (Cypress, Playwright, Selenium/WebDriver).
+- **Adaptability**: Ensure testing strategies can adapt to various test environments, including DOM testing (React, Vue&nbsp;3, vanilla&nbsp;JS, Angular) and end-to-end testing (Cypress, Playwright, Selenium/WebDriver).

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -16,8 +16,8 @@ const FeatureList: FeatureItem[] = [
     // Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
     description: (
       <>
-        Seamlessly integrate with top UI frameworks (React, Angular, Vue) and testing tools (Playwright, Cypress, DOM
-        testing) for a streamlined and efficient testing experience
+        Seamlessly integrate with top UI frameworks (React, Vue&nbsp;3, vanilla&nbsp;JS, Angular) and testing tools (Playwright,
+        Cypress, DOM testing) for a streamlined and efficient testing experience
       </>
     ),
   },


### PR DESCRIPTION
## Summary
- mention Vue 3 support alongside React and vanilla JS
- update homepage feature text
- add Vue 3 example in Core Concepts docs

## Testing
- `pnpm run check:lint`
- `pnpm run check:style`
- `pnpm run check:type` *(fails: Cannot find module '@atomic-testing/core' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6854c0d311ec832bbf8b91134cbb6ba3