### PR TITLE
Add complex Vue form test example

### DIFF
--- a/packages/vue-3-test/__tests__/Form.dom.test.ts
+++ b/packages/vue-3-test/__tests__/Form.dom.test.ts
@@ -1,0 +1,28 @@
+import { TestEngine } from '@atomic-testing/core';
+import { createTestEngine } from '@atomic-testing/vue-3';
+
+import { simpleFormExample } from '../src/Form.example';
+
+describe('SimpleForm', () => {
+  let engine: TestEngine<typeof simpleFormExample.scene>;
+
+  beforeEach(() => {
+    engine = createTestEngine(simpleFormExample.ui, simpleFormExample.scene);
+  });
+
+  afterEach(async () => {
+    await engine.cleanUp();
+  });
+
+  test('fill and submit form', async () => {
+    await engine.parts.nameInput.setValue('John');
+    await engine.parts.colorSelect.selectByLabel('Green');
+    await engine.parts.gender.setValue('female');
+    await engine.parts.agreeCheckbox.setSelected(true);
+
+    await engine.parts.submitButton.click();
+
+    const text = await engine.parts.message.getText();
+    expect(text).toEqual('Name:John;Color:green;Gender:female;Agree:true');
+  });
+});

--- a/packages/vue-3-test/jest.config.js
+++ b/packages/vue-3-test/jest.config.js
@@ -6,4 +6,10 @@ module.exports = {
   displayName: 'vue3-test',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@atomic-testing/vue-3$': '<rootDir>/../vue-3/src',
+    '^@atomic-testing/core$': '<rootDir>/../core/src',
+    '^@atomic-testing/dom-core$': '<rootDir>/../dom-core/src',
+    '^@atomic-testing/component-driver-html$': '<rootDir>/../component-driver-html/src',
+  },
 };

--- a/packages/vue-3-test/src/Form.example.ts
+++ b/packages/vue-3-test/src/Form.example.ts
@@ -1,0 +1,140 @@
+import { defineComponent, h, ref } from 'vue';
+import {
+  HTMLButtonDriver,
+  HTMLCheckboxDriver,
+  HTMLRadioButtonGroupDriver,
+  HTMLSelectDriver,
+  HTMLTextInputDriver,
+  HTMLElementDriver,
+} from '@atomic-testing/component-driver-html';
+import { byDataTestId, byName, IExampleUnit, ScenePart } from '@atomic-testing/core';
+
+export const SimpleFormComponent = defineComponent({
+  name: 'SimpleFormComponent',
+  setup() {
+    const name = ref('');
+    const color = ref('red');
+    const gender = ref('male');
+    const agree = ref(false);
+    const message = ref('');
+
+    const onNameInput = (e: Event) => {
+      name.value = (e.target as HTMLInputElement).value;
+    };
+    const onColorChange = (e: Event) => {
+      color.value = (e.target as HTMLSelectElement).value;
+    };
+    const onGenderChange = (e: Event) => {
+      gender.value = (e.target as HTMLInputElement).value;
+    };
+    const onAgreeChange = (e: Event) => {
+      agree.value = (e.target as HTMLInputElement).checked;
+    };
+    const submit = () => {
+      message.value = `Name:${name.value};Color:${color.value};Gender:${gender.value};Agree:${agree.value}`;
+    };
+
+    return () =>
+      h('div', [
+        h('input', {
+          'data-testid': 'name-input',
+          type: 'text',
+          value: name.value,
+          onInput: onNameInput,
+        }),
+        h(
+          'select',
+          {
+            'data-testid': 'color-select',
+            value: color.value,
+            onChange: onColorChange,
+          },
+          [
+            h('option', { value: 'red' }, 'Red'),
+            h('option', { value: 'green' }, 'Green'),
+            h('option', { value: 'blue' }, 'Blue'),
+          ],
+        ),
+        h('div', { 'data-testid': 'gender-group' }, [
+          h('label', [
+            h('input', {
+              type: 'radio',
+              name: 'gender',
+              value: 'male',
+              'data-testid': 'gender-male',
+              checked: gender.value === 'male',
+              onChange: onGenderChange,
+            }),
+            'Male',
+          ]),
+          h('label', [
+            h('input', {
+              type: 'radio',
+              name: 'gender',
+              value: 'female',
+              'data-testid': 'gender-female',
+              checked: gender.value === 'female',
+              onChange: onGenderChange,
+            }),
+            'Female',
+          ]),
+        ]),
+        h('label', [
+          h('input', {
+            type: 'checkbox',
+            'data-testid': 'agree-checkbox',
+            checked: agree.value,
+            onChange: onAgreeChange,
+          }),
+          'Agree to terms',
+        ]),
+        h(
+          'button',
+          {
+            'data-testid': 'submit-btn',
+            type: 'button',
+            onClick: submit,
+          },
+          'Submit',
+        ),
+        message.value ? h('div', { 'data-testid': 'message-display' }, message.value) : null,
+      ]);
+  },
+});
+
+export const simpleFormUI: IExampleUIUnit<ReturnType<typeof defineComponent>> = {
+  title: 'Simple Form',
+  ui: SimpleFormComponent,
+};
+
+export const simpleFormScene = {
+  nameInput: {
+    locator: byDataTestId('name-input'),
+    driver: HTMLTextInputDriver,
+  },
+  colorSelect: {
+    locator: byDataTestId('color-select'),
+    driver: HTMLSelectDriver,
+  },
+  gender: {
+    locator: byName('gender'),
+    driver: HTMLRadioButtonGroupDriver,
+  },
+  agreeCheckbox: {
+    locator: byDataTestId('agree-checkbox'),
+    driver: HTMLCheckboxDriver,
+  },
+  submitButton: {
+    locator: byDataTestId('submit-btn'),
+    driver: HTMLButtonDriver,
+  },
+  message: {
+    locator: byDataTestId('message-display'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const simpleFormExample: IExampleUnit<typeof simpleFormScene, ReturnType<typeof defineComponent>> = {
+  ...simpleFormUI,
+  scene: simpleFormScene,
+};

--- a/packages/vue-3-test/src/index.ts
+++ b/packages/vue-3-test/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Counter.example';
+export * from './Form.example';


### PR DESCRIPTION
## Summary
- expand Vue test package with a more realistic form example
- export new example and configure jest alias mappings
- add DOM test covering multiple HTML drivers

## Testing
- `pnpm test:dom`

------
https://chatgpt.com/codex/tasks/task_b_68553d55128c832bb5edf0b6e6fe36e1