### PR TITLE
Enable Vue 3 SFC example

### DIFF
--- a/packages/vue-3-test/jest.config.js
+++ b/packages/vue-3-test/jest.config.js
@@ -5,5 +5,17 @@ module.exports = {
   testRegex: '(/__tests__/.*.dom.(test|spec)).(ts?)$',
   displayName: 'vue3-test',
   testEnvironment: 'jsdom',
+  transform: {
+    ...base.transform,
+    '^.+\\.vue$': '<rootDir>/vue-jest-transform.js',
+  },
+  moduleFileExtensions: [...base.moduleFileExtensions, 'vue'],
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    '^@atomic-testing/vue-3$': '<rootDir>/../vue-3/src/index.ts',
+    '^@atomic-testing/core$': '<rootDir>/../core/src/index.ts',
+    '^@atomic-testing/dom-core$': '<rootDir>/../dom-core/src/index.ts',
+    '^@atomic-testing/component-driver-html$': '<rootDir>/../component-driver-html/src/index.ts',
+  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/packages/vue-3-test/src/Counter.example.ts
+++ b/packages/vue-3-test/src/Counter.example.ts
@@ -1,27 +1,8 @@
-import { defineComponent, h, ref } from 'vue';
+import CounterComponent from './Counter.vue';
 import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
 import { byDataTestId, IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
 
-export const CounterComponent = defineComponent({
-  name: 'CounterComponent',
-  setup() {
-    const count = ref(0);
-    const inc = () => {
-      count.value += 1;
-    };
-    return () =>
-      h(
-        'button',
-        {
-          'data-testid': 'counter',
-          onClick: inc,
-        },
-        `Count: ${count.value}`,
-      );
-  },
-});
-
-export const counterExampleUI: IExampleUIUnit<ReturnType<typeof defineComponent>> = {
+export const counterExampleUI: IExampleUIUnit<typeof CounterComponent> = {
   title: 'Counter',
   ui: CounterComponent,
 };
@@ -33,7 +14,7 @@ export const counterScene = {
   },
 } satisfies ScenePart;
 
-export const counterExample: IExampleUnit<typeof counterScene, ReturnType<typeof defineComponent>> = {
+export const counterExample: IExampleUnit<typeof counterScene, typeof CounterComponent> = {
   ...counterExampleUI,
   scene: counterScene,
 };

--- a/packages/vue-3-test/src/Counter.stories.ts
+++ b/packages/vue-3-test/src/Counter.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
-import { CounterComponent } from './Counter.example';
+import CounterComponent from './Counter.vue';
 
 const meta: Meta<typeof CounterComponent> = {
   component: CounterComponent,

--- a/packages/vue-3-test/src/Counter.vue
+++ b/packages/vue-3-test/src/Counter.vue
@@ -1,0 +1,11 @@
+<template>
+  <button data-testid="counter" @click="inc">Count: {{ count }}</button>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const count = ref(0);
+function inc() {
+  count.value += 1;
+}
+</script>

--- a/packages/vue-3-test/src/main.ts
+++ b/packages/vue-3-test/src/main.ts
@@ -1,6 +1,4 @@
-import { createApp, h } from 'vue';
-import { CounterComponent } from './Counter.example';
+import { createApp } from 'vue';
+import CounterComponent from './Counter.vue';
 
-createApp({
-  render: () => h(CounterComponent),
-}).mount('#app');
+createApp(CounterComponent).mount('#app');

--- a/packages/vue-3-test/src/shims-vue.d.ts
+++ b/packages/vue-3-test/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/packages/vue-3-test/vue-jest-transform.js
+++ b/packages/vue-3-test/vue-jest-transform.js
@@ -1,0 +1,31 @@
+const { compile } = require('@vue/compiler-dom');
+
+module.exports = {
+  process(src) {
+    const templateMatch = src.match(/<template>([\s\S]*?)<\/template>/);
+    const scriptMatch = src.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+    const template = templateMatch ? templateMatch[1].trim() : '';
+    let script = scriptMatch ? scriptMatch[1].trim() : '';
+
+    // Convert ES imports from vue to requires
+    script = script.replace(/import\s+\{([^}]*)\}\s+from\s+'vue';?/g, (m, g1) => {
+      return `const {${g1}} = require('vue');`;
+    });
+
+    // Collect variable and function names for return
+    const names = [];
+    const varRegex = /(?:const|let|var)\s+([a-zA-Z_$][\w$]*)/g;
+    const funcRegex = /function\s+([a-zA-Z_$][\w$]*)/g;
+    let m;
+    while ((m = varRegex.exec(script))) names.push(m[1]);
+    while ((m = funcRegex.exec(script))) names.push(m[1]);
+
+    const returnBlock = names.length ? `return { ${names.join(', ')} };` : '';
+
+    let { code: render } = compile(template, { mode: 'function' });
+    render = render.replace(/^return\s+/m, '');
+    const output = `const { defineComponent } = require('vue');\n${script}\n${render}\nmodule.exports = defineComponent({ render, setup() {\n${returnBlock}\n} });`;
+
+    return { code: output };
+  },
+};

--- a/packages/vue-3/src/createTestEngine.ts
+++ b/packages/vue-3/src/createTestEngine.ts
@@ -5,6 +5,10 @@ import { App, Component, createApp } from 'vue';
 import { VueInteractor } from './VueInteractor';
 import { IVueTestEngineOption } from './types';
 
+function unwrapComponent(component: Component | { default: Component }): Component {
+  return (component as any).default ?? (component as Component);
+}
+
 let _rootId = 0;
 function getNextRootElementId() {
   return `${_rootId++}`;
@@ -13,7 +17,7 @@ function getNextRootElementId() {
 const rootElementAttributeName = 'data-atomic-testing-vue';
 
 export function createTestEngine<T extends ScenePart>(
-  component: Component,
+  component: Component | { default: Component },
   partDefinitions: T,
   option?: Readonly<Partial<IVueTestEngineOption>>
 ): TestEngine<T> {
@@ -24,13 +28,13 @@ export function createTestEngine<T extends ScenePart>(
   
   let unmount: () => void;
   let app: App;
-  
+
   try {
-    const renderResult = render(component, { container });
+    const renderResult = render(unwrapComponent(component), { container });
     unmount = renderResult.unmount;
   } catch (_error) {
     // Fallback to manual Vue app creation if render fails
-    app = createApp(component);
+    app = createApp(unwrapComponent(component));
     app.mount(container);
     unmount = () => {
       if (app) {


### PR DESCRIPTION
## Summary
- switch Counter example to .vue SFC
- add a simple Vue SFC transformer for Jest
- update Jest config for SFC support and source mappings
- support default-exported components in Vue test engine

## Testing
- `pnpm build` in `packages/vue-3`
- `pnpm exec jest --clearCache` in `packages/vue-3-test`
- `pnpm test:dom` in `packages/vue-3-test`

------
https://chatgpt.com/codex/tasks/task_b_68554a865c5c832bb332e898761be6df