### PR TITLE
doc: Fix mui-x-v8 README

### DIFF
--- a/packages/component-driver-mui-x-v8/README.md
+++ b/packages/component-driver-mui-x-v8/README.md
@@ -1,12 +1,12 @@
-# @atomic-testing/component-driver-mui-x-v7
+# @atomic-testing/component-driver-mui-x-v8
 
-Component drivers for [Material UI X](https://mui.com/x/) v7 components.
+Component drivers for [Material UI X](https://mui.com/x/) v8 components.
 They provide Atomic Testing wrappers for the latest MUI X widgets.
 
 ## Installation
 
 ```bash
-pnpm add @atomic-testing/component-driver-mui-x-v7
+pnpm add @atomic-testing/component-driver-mui-x-v8
 ```
 
 See the [docs](https://atomic-testing.dev/) for usage instructions.


### PR DESCRIPTION

MUI-X-V8 README incorrectly states MUI-X-V7
