### PR TITLE
doc: Fix README imports for React packages

### DIFF
--- a/packages/react-18/README.md
+++ b/packages/react-18/README.md
@@ -71,7 +71,7 @@ package for a dedicated example.
 4. Write a test using `createTestEngine` to render the component and interact with it:
 
    ```ts title="Counter.test.tsx"
-    import { createTestEngine } from '@atomic-testing/react-19';
+    import { createTestEngine } from '@atomic-testing/react-18';
 
     import { Counter } from './Counter';
     import { counterScenePart } from './counterScenePart';

--- a/packages/react-legacy/README.md
+++ b/packages/react-legacy/README.md
@@ -71,7 +71,7 @@ package for a dedicated example.
 4. Write a test using `createTestEngine` to render the component and interact with it:
 
    ```ts title="Counter.test.tsx"
-    import { createTestEngine } from '@atomic-testing/react-19';
+    import { createTestEngine } from '@atomic-testing/react-legacy';
 
     import { Counter } from './Counter';
     import { counterScenePart } from './counterScenePart';


### PR DESCRIPTION
## Summary
- fix import paths for `createTestEngine` in React package READMEs

## Testing
- `pnpm run check:lint`
- `pnpm run check:style`
- `pnpm run check:type`


------
https://chatgpt.com/codex/tasks/task_b_68576e1ea320832bbe6f445934db6489