### PR TITLE
Fix HTMLSelectDriver driverName

### DIFF
--- a/packages/component-driver-html/src/components/HTMLSelectDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLSelectDriver.ts
@@ -111,6 +111,6 @@ export class HTMLSelectDriver extends ComponentDriver<{}> implements IInputDrive
    * Identifier for this driver.
    */
   get driverName(): string {
-    throw 'HTMLSelectDriver';
+    return 'HTMLSelectDriver';
   }
 }


### PR DESCRIPTION
## Summary
- fix `HTMLSelectDriver` to return driver name instead of throwing
- confirm select suite references `HTMLSelectDriver`

## Testing
- `pnpm --filter @atomic-testing/component-driver-html-test test:dom`

------
https://chatgpt.com/codex/tasks/task_b_68576dfb8140832b9dd5ecd499d4a27f