### PR TITLE
Refactor waitUntil loop

### DIFF
--- a/packages/core/src/utils/__tests__/timingUtil.test.ts
+++ b/packages/core/src/utils/__tests__/timingUtil.test.ts
@@ -13,4 +13,22 @@ describe('waitUntil', () => {
     // allow some buffer for timers but ensure it does not wait excessively
     expect(elapsed).toBeLessThan(200);
   });
+
+  test('should resolve early when condition becomes true', async () => {
+    let flag = false;
+    setTimeout(() => {
+      flag = true;
+    }, 50);
+    const start = Date.now();
+    const result = await waitUntil({
+      probeFn: () => flag,
+      terminateCondition: true,
+      timeoutMs: 500,
+    });
+    const elapsed = Date.now() - start;
+    expect(result).toBe(true);
+    // Should wait at least until flag turns true but not until timeout
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+    expect(elapsed).toBeLessThan(200);
+  });
 });

--- a/packages/core/src/utils/timingUtil.ts
+++ b/packages/core/src/utils/timingUtil.ts
@@ -44,10 +44,9 @@ export async function waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
       : currentValue => terminateCondition === currentValue;
 
   const startMs = Date.now();
-  const shouldContinue = true;
   let val: T;
 
-  while (shouldContinue) {
+  while (true) {
     val = await probeFn();
     const hasMetEqCheck = eqCheck(val);
     if (debug) {
@@ -56,22 +55,22 @@ export async function waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
     }
 
     if (hasMetEqCheck) {
-      return val;
+      break;
     }
 
     const currentTime = Date.now();
     const elapsed = currentTime - startMs;
 
     if (elapsed >= timeoutMs) {
-      return val;
+      break;
     }
 
     const nextStart = Math.round(elapsed / intervalMs) * intervalMs;
     if (nextStart >= timeoutMs) {
-      return val;
+      break;
     }
     await wait(nextStart - elapsed);
   }
 
-  return val!;
+  return val;
 }


### PR DESCRIPTION
## Summary
- simplify wait loop logic in timing util
- add a test verifying waitUntil resolves early

## Testing
- `pnpm --filter @atomic-testing/core test`

------
https://chatgpt.com/codex/tasks/task_b_68576e0738e8832b9cca442fecab1858