### PR TITLE
Fix driver name

### DIFF
--- a/packages/component-driver-html/__tests__/HTMLRadioButtonGroupDriver.test.ts
+++ b/packages/component-driver-html/__tests__/HTMLRadioButtonGroupDriver.test.ts
@@ -1,0 +1,9 @@
+import { CssLocator } from '@atomic-testing/core';
+import { HTMLRadioButtonGroupDriver } from '../src/components/HTMLRadioButtonGroupDriver';
+
+describe('HTMLRadioButtonGroupDriver', () => {
+  test('should expose correct driverName', () => {
+    const driver = new HTMLRadioButtonGroupDriver(new CssLocator('input[type="radio"]'), {} as any);
+    expect(driver.driverName).toBe('HTMLRadioButtonGroupDriver');
+  });
+});

--- a/packages/component-driver-html/src/components/HTMLRadioButtonGroupDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLRadioButtonGroupDriver.ts
@@ -26,6 +26,6 @@ export class HTMLRadioButtonGroupDriver extends ComponentDriver<{}> implements I
   }
 
   get driverName(): string {
-    throw 'HTMLRadioButtonGroupDriver';
+    return 'HTMLRadioButtonGroupDriver';
   }
 }


### PR DESCRIPTION
## Summary
- return driver name instead of throwing
- add unit test for `HTMLRadioButtonGroupDriver`

## Testing
- `pnpm --filter @atomic-testing/component-driver-html test`
- `pnpm --filter @atomic-testing/core test`


------
https://chatgpt.com/codex/tasks/task_b_68576dfab074832b97e30c1c3ffc2726