### PR TITLE
Export ItemNotFoundError from core

### DIFF
--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,4 +1,5 @@
 export { ErrorBase } from './ErrorBase';
+export { ItemNotFoundError, ItemNotFoundErrorId } from './ItemNotFoundError';
 export { MissingPartError, MissingPartErrorId } from './MissingPartError';
 export { TooManyMatchingElementError, TooManyMatchingElementErrorId } from './TooManyMatchingElementError';
 export { WaitForFailureError, WaitForFailureErrorId } from './WaitForFailureError';


### PR DESCRIPTION
## Summary
- expose `ItemNotFoundError` and its id from `@atomic-testing/core`

## Testing
- `pnpm -r check:type`

------
https://chatgpt.com/codex/tasks/task_b_68576e0c0b3c832b915880e8ab31e799