### PR TITLE
Add Angular 20 adapter and example test

### DIFF
--- a/package-tests/angular-20-test/README.md
+++ b/package-tests/angular-20-test/README.md
@@ -1,0 +1,10 @@
+# Angular 20 Test
+
+This package contains a simple Angular 20 example and unit tests demonstrating usage of `@atomic-testing/angular-20`.
+
+## Key commands
+
+| Command      | Description        |
+| ------------ | ------------------ |
+| `pnpm dev`   | Run the application |
+| `pnpm test`  | Run unit tests      |

--- a/package-tests/angular-20-test/__tests__/Form.dom.test.ts
+++ b/package-tests/angular-20-test/__tests__/Form.dom.test.ts
@@ -1,0 +1,24 @@
+import { TestEngine } from '@atomic-testing/core';
+import { createTestEngine } from '@atomic-testing/angular-20';
+
+import { formExample } from '../src/Form.example';
+
+describe('FormComponent', () => {
+  let engine: TestEngine<typeof formExample.scene>;
+
+  beforeEach(() => {
+    engine = createTestEngine(formExample.ui, formExample.scene);
+  });
+
+  afterEach(async () => {
+    await engine.cleanUp();
+  });
+
+  test('updates values', async () => {
+    await engine.parts.textInput.enterText('hello');
+    await engine.parts.checkbox.click();
+    await engine.parts.select.setValue('two');
+    const text = await engine.parts.result.getText();
+    expect(text).toEqual('hello - true - two');
+  });
+});

--- a/package-tests/angular-20-test/index.html
+++ b/package-tests/angular-20-test/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Angular 20 Test</title>
+  </head>
+  <body>
+    <app-root></app-root>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/package-tests/angular-20-test/jest.config.js
+++ b/package-tests/angular-20-test/jest.config.js
@@ -1,0 +1,9 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  testRegex: '(/__tests__/.*.dom.(test|spec)).(ts?)$',
+  displayName: 'angular20-test',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/package-tests/angular-20-test/jest.setup.js
+++ b/package-tests/angular-20-test/jest.setup.js
@@ -1,0 +1,6 @@
+require('zone.js');
+require('zone.js/testing');
+const { getTestBed } = require('@angular/core/testing');
+const { BrowserDynamicTestingModule, platformBrowserDynamicTesting } = require('@angular/platform-browser-dynamic/testing');
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/package-tests/angular-20-test/package.json
+++ b/package-tests/angular-20-test/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@atomic-testing/angular-20-test",
+  "version": "0.0.0",
+  "description": "Example and tests for @atomic-testing/angular-20",
+  "main": "dist/index.js",
+  "private": true,
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "test:dom": "jest"
+  },
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "license": "MIT",
+  "devDependencies": {
+    "@atomic-testing/angular-20": "workspace:*",
+    "@atomic-testing/component-driver-html": "workspace:*",
+    "@atomic-testing/core": "workspace:*",
+    "@storybook/addon-essentials": "^8.0.5",
+    "@storybook/addon-themes": "^8.0.5",
+    "@storybook/angular": "^8.0.5",
+    "@storybook/test": "^8.0.5",
+    "@testing-library/angular": "^14.1.0",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
+    "zone.js": "^0.14.0",
+    "storybook": "^8.0.5"
+  }
+}

--- a/package-tests/angular-20-test/src/Form.example.ts
+++ b/package-tests/angular-20-test/src/Form.example.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HTMLCheckboxDriver, HTMLSelectDriver, HTMLTextInputDriver, HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, IExampleUnit, IExampleUIUnit, ScenePart } from '@atomic-testing/core';
+
+@Component({
+  selector: 'app-form',
+  standalone: true,
+  imports: [FormsModule],
+  template: `
+    <form>
+      <input data-testid="text" [(ngModel)]="text" name="text" />
+      <input type="checkbox" data-testid="check" [(ngModel)]="checked" name="check" />
+      <select data-testid="select" [(ngModel)]="selected" name="select">
+        <option value="one">One</option>
+        <option value="two">Two</option>
+      </select>
+    </form>
+    <div data-testid="result">{{ text }} - {{ checked }} - {{ selected }}</div>
+  `,
+})
+export class FormComponent {
+  text = '';
+  checked = false;
+  selected = 'one';
+}
+
+export const formExampleUI: IExampleUIUnit<typeof FormComponent> = {
+  title: 'Form',
+  ui: FormComponent,
+};
+
+export const formScene = {
+  textInput: { locator: byDataTestId('text'), driver: HTMLTextInputDriver },
+  checkbox: { locator: byDataTestId('check'), driver: HTMLCheckboxDriver },
+  select: { locator: byDataTestId('select'), driver: HTMLSelectDriver },
+  result: { locator: byDataTestId('result'), driver: HTMLElementDriver },
+} satisfies ScenePart;
+
+export const formExample: IExampleUnit<typeof formScene, typeof FormComponent> = {
+  ...formExampleUI,
+  scene: formScene,
+};

--- a/package-tests/angular-20-test/src/index.ts
+++ b/package-tests/angular-20-test/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Form.example';

--- a/package-tests/angular-20-test/src/main.ts
+++ b/package-tests/angular-20-test/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { FormComponent } from './Form.example';
+
+bootstrapApplication(FormComponent);

--- a/package-tests/angular-20-test/tsconfig.json
+++ b/package-tests/angular-20-test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "declaration", "generator-build", "runtime"],
+  "include": ["./src", "__tests__"],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/package-tests/angular-20-test/tsconfig.test.json
+++ b/package-tests/angular-20-test/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src", "__tests__/**/**.ts"]
+}

--- a/package-tests/angular-20-test/vite.config.ts
+++ b/package-tests/angular-20-test/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+});

--- a/packages/angular-20/README.md
+++ b/packages/angular-20/README.md
@@ -1,0 +1,9 @@
+# @atomic-testing/angular-20
+
+Adapter for integrating Atomic Testing with Angular 20 applications.
+
+## Installation
+
+```bash
+pnpm add @atomic-testing/angular-20
+```

--- a/packages/angular-20/package.json
+++ b/packages/angular-20/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@atomic-testing/angular-20",
+  "version": "0.76.0",
+  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check:type": "tsc --noEmit"
+  },
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "keywords": [
+    "testing",
+    "angular",
+    "unit",
+    "integration"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git",
+    "directory": "packages/angular-20"
+  },
+  "dependencies": {
+    "@atomic-testing/core": "workspace:*",
+    "@atomic-testing/dom-core": "workspace:*",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/angular": "^14.1.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
+    "zone.js": "^0.14.0"
+  },
+  "peerDependencies": {
+    "@angular/common": ">=20.0.0",
+    "@angular/compiler": ">=20.0.0",
+    "@angular/compiler-cli": ">=20.0.0",
+    "@angular/core": ">=20.0.0",
+    "@angular/platform-browser": ">=20.0.0",
+    "@angular/platform-browser-dynamic": ">=20.0.0",
+    "@testing-library/angular": ">=14.1.0",
+    "@testing-library/dom": ">=10.4.0",
+    "@testing-library/user-event": ">=14.0.0",
+    "zone.js": ">=0.14.0"
+  }
+}

--- a/packages/angular-20/src/AngularInteractor.ts
+++ b/packages/angular-20/src/AngularInteractor.ts
@@ -1,0 +1,114 @@
+import {
+  ClickOption,
+  defaultWaitForOption,
+  EnterTextOption,
+  FocusOption,
+  HoverOption,
+  Interactor,
+  MouseDownOption,
+  MouseEnterOption,
+  MouseLeaveOption,
+  MouseMoveOption,
+  MouseOutOption,
+  MouseUpOption,
+  PartLocator,
+  WaitForOption,
+  WaitUntilOption,
+} from '@atomic-testing/core';
+import { DOMInteractor } from '@atomic-testing/dom-core';
+import { ComponentFixture } from '@angular/core/testing';
+
+export class AngularInteractor extends DOMInteractor {
+  constructor(private readonly fixture?: ComponentFixture<any>) {
+    super(fixture?.nativeElement);
+  }
+
+  private detect() {
+    if (this.fixture) {
+      this.fixture.detectChanges();
+    }
+  }
+
+  override async enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void> {
+    await super.enterText(locator, text, option);
+    this.detect();
+  }
+
+  override async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
+    await super.click(locator, option);
+    this.detect();
+  }
+
+  override async hover(locator: PartLocator, option?: Partial<HoverOption>): Promise<void> {
+    await super.hover(locator, option);
+    this.detect();
+  }
+
+  async mouseMove(locator: PartLocator, option?: Partial<MouseMoveOption>): Promise<void> {
+    await super.mouseMove(locator, option);
+    this.detect();
+  }
+
+  async mouseDown(locator: PartLocator, option?: Partial<MouseDownOption>): Promise<void> {
+    await super.mouseDown(locator, option);
+    this.detect();
+  }
+
+  async mouseUp(locator: PartLocator, option?: Partial<MouseUpOption>): Promise<void> {
+    await super.mouseUp(locator, option);
+    this.detect();
+  }
+
+  async mouseOver(locator: PartLocator, option?: Partial<HoverOption>): Promise<void> {
+    await super.mouseOver(locator, option);
+    this.detect();
+  }
+
+  async mouseOut(locator: PartLocator, option?: Partial<MouseOutOption>): Promise<void> {
+    await super.mouseOut(locator, option);
+    this.detect();
+  }
+
+  async mouseEnter(locator: PartLocator, option?: Partial<MouseEnterOption>): Promise<void> {
+    await super.mouseEnter(locator, option);
+    this.detect();
+  }
+
+  async mouseLeave(locator: PartLocator, option?: Partial<MouseLeaveOption>): Promise<void> {
+    await super.mouseLeave(locator, option);
+    this.detect();
+  }
+
+  async focus(locator: PartLocator, option?: Partial<FocusOption>): Promise<void> {
+    await super.focus(locator, option);
+    this.detect();
+  }
+
+  override async selectOptionValue(locator: PartLocator, values: string[]): Promise<void> {
+    await super.selectOptionValue(locator, values);
+    this.detect();
+  }
+
+  override async wait(ms: number): Promise<void> {
+    await super.wait(ms);
+    this.detect();
+  }
+
+  override async waitUntilComponentState(
+    locator: PartLocator,
+    option: Partial<Readonly<WaitForOption>> = defaultWaitForOption
+  ): Promise<void> {
+    await super.waitUntilComponentState(locator, option);
+    this.detect();
+  }
+
+  override async waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
+    const result = await super.waitUntil(option);
+    this.detect();
+    return result;
+  }
+
+  override clone(): Interactor {
+    return new AngularInteractor(this.fixture);
+  }
+}

--- a/packages/angular-20/src/createTestEngine.ts
+++ b/packages/angular-20/src/createTestEngine.ts
@@ -1,0 +1,67 @@
+import { Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { byAttribute, ScenePart, TestEngine } from '@atomic-testing/core';
+
+import { AngularInteractor } from './AngularInteractor';
+import { IAngularTestEngineOption } from './types';
+
+let _rootId = 0;
+function getNextRootElementId() {
+  return `${_rootId++}`;
+}
+
+const rootElementAttributeName = 'data-atomic-testing-angular';
+
+export function createTestEngine<T extends ScenePart>(
+  component: Type<any>,
+  partDefinitions: T,
+  option?: Readonly<Partial<IAngularTestEngineOption>>
+): TestEngine<T> {
+  const rootEl = option?.rootElement ?? document.body;
+  const container = rootEl.appendChild(document.createElement('div'));
+  const rootId = getNextRootElementId();
+  container.setAttribute(rootElementAttributeName, rootId);
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [component] });
+  const fixture = TestBed.createComponent(component);
+  fixture.detectChanges();
+
+  const cleanup = () => {
+    fixture.destroy();
+    rootEl.removeChild(container);
+    return Promise.resolve();
+  };
+
+  return new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
+    new AngularInteractor(fixture),
+    {
+      parts: partDefinitions,
+    },
+    cleanup
+  );
+}
+
+export function createRenderedTestEngine<T extends ScenePart>(
+  rootElement: HTMLElement,
+  partDefinitions: T,
+  _option?: Readonly<Partial<IAngularTestEngineOption>>
+): TestEngine<T> {
+  const rootId = getNextRootElementId();
+  rootElement.setAttribute(rootElementAttributeName, rootId);
+
+  const cleanup = () => {
+    rootElement.removeAttribute(rootElementAttributeName);
+    return Promise.resolve();
+  };
+
+  return new TestEngine(
+    byAttribute(rootElementAttributeName, rootId),
+    new AngularInteractor(undefined),
+    {
+      parts: partDefinitions,
+    },
+    cleanup
+  );
+}

--- a/packages/angular-20/src/index.ts
+++ b/packages/angular-20/src/index.ts
@@ -1,0 +1,3 @@
+export { createTestEngine, createRenderedTestEngine } from './createTestEngine';
+export { AngularInteractor } from './AngularInteractor';
+export type { IAngularTestEngineOption } from './types';

--- a/packages/angular-20/src/types.ts
+++ b/packages/angular-20/src/types.ts
@@ -1,0 +1,5 @@
+import { IComponentDriverOption } from '@atomic-testing/core';
+
+export interface IAngularTestEngineOption extends IComponentDriverOption {
+  rootElement?: Element;
+}

--- a/packages/angular-20/tsconfig.json
+++ b/packages/angular-20/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "declaration", "generator-build", "runtime"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/packages/angular-20/tsdown.config.ts
+++ b/packages/angular-20/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsdown';
+
+import commonConfig from '../../tsdown.config.base';
+
+export default defineConfig({
+  ...commonConfig,
+});

--- a/packages/angular-20/typedoc.json
+++ b/packages/angular-20/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}


### PR DESCRIPTION
## Summary
- add new `@atomic-testing/angular-20` package
- implement `AngularInteractor` and `createTestEngine`
- provide Angular example app and tests under `angular-20-test`

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... Forbidden)*
- `pnpm build:packages`
- `pnpm test:dom` in `angular-20-test` *(fails: Cannot find module 'zone.js')*

------
https://chatgpt.com/codex/tasks/task_b_685b5971c0ac832b91541f950ac6b852