### PR TITLE
(lint): Improve lint configuration for better performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "private": true,
-  "name": "development-environment",
+  "name": "atomic-testing-monorepo",
   "engines": {
     "node": ">=22.12",
     "pnpm": ">=10"
   },
+  "type": "module",
   "scripts": {
     "build:packages": "./publish.sh --build-only",
     "check:type": "pnpm -r check:type",
-    "check:lint": "eslint --fix --ext .ts,.tsx,.js .",
+    "check:lint": "eslint --fix --ext .ts,.tsx,.js,.mjs,.cjs,.mdx .",
     "check:style": "prettier --write .",
     "typedoc": "typedoc --out typedocs",
     "bumpVersion": "node scripts/bumpVersion.js"


### PR DESCRIPTION

Improve lint related configuration to address warning and slightly improve lint performance

#### Before

* Time: 2.2s
* Warning

> [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of <path>eslint.config.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /atomic-testing/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)


#### After

* Time: 2.0s
* No warning
