### PR TITLE
Rename MUI v7 docs folder

### DIFF
--- a/docs/docs/api-docs/_category_.json
+++ b/docs/docs/api-docs/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "API Documentation",
+  "position": 10,
+  "link": {
+    "type": "generated-index",
+    "description": "Component driver API documentation"
+  }
+}

--- a/docs/docs/api-docs/component-driver-mui-v7/_category_.json
+++ b/docs/docs/api-docs/component-driver-mui-v7/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "MUI v7",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "Component drivers for MUI version 7"
+  }
+}

--- a/docs/docs/api-docs/component-driver-mui-v7/text-field.mdx
+++ b/docs/docs/api-docs/component-driver-mui-v7/text-field.mdx
@@ -1,0 +1,42 @@
+---
+id: mui-v7-text-field
+sidebar_position: 1
+title: TextField
+---
+
+The `TextFieldDriver` from `@atomic-testing/component-driver-mui-v7` exposes high level methods to read and set the value of a Material UI `TextField`.
+
+## Basic usage
+
+```ts title="scenePart.ts"
+import { TextFieldDriver } from '@atomic-testing/component-driver-mui-v7';
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const parts = {
+  name: { locator: byDataTestId('name'), driver: TextFieldDriver },
+} satisfies ScenePart;
+```
+
+```ts title="test.ts"
+// Assume engine is created with createTestEngine(..., parts)
+await engine.parts.name.setValue('John Doe');
+expect(await engine.parts.name.getValue()).toBe('John Doe');
+```
+
+## Select field variant
+
+When `TextField` renders a select, the driver delegates to `SelectDriver`.
+
+```ts title="selectPart.ts"
+import { SelectDriver } from '@atomic-testing/component-driver-mui-v7';
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const parts = {
+  country: { locator: byDataTestId('country'), driver: SelectDriver },
+} satisfies ScenePart;
+```
+
+```ts title="selectTest.ts"
+await engine.parts.country.selectByLabel('Australia');
+expect(await engine.parts.country.getSelectedLabel()).toBe('Australia');
+```


### PR DESCRIPTION
## Summary
- rename `docs/api-docs/mui-v7` to `docs/api-docs/component-driver-mui-v7`

## Testing
- `pnpm run check:lint`
- `pnpm run check:style`
- `pnpm run check:type`


------
https://chatgpt.com/codex/tasks/task_b_6860431481e8832bbcd7fba86e88996c