### PR TITLE
doc: Improve docs for component drivers

### DIFF
--- a/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
@@ -31,9 +31,16 @@ export class CheckboxDriver
       parts: checkboxPart,
     });
   }
+  /**
+   * Check whether the checkbox is currently selected.
+   */
   isSelected(): Promise<boolean> {
     return this.parts.checkbox.isSelected();
   }
+  /**
+   * Change the selected state of the checkbox, handling the
+   * indeterminate state when necessary.
+   */
   async setSelected(selected: boolean): Promise<void> {
     const isIndeterminate = await this.isIndeterminate();
     if (isIndeterminate && selected === false) {
@@ -45,23 +52,38 @@ export class CheckboxDriver
     await this.parts.checkbox.setSelected(selected);
   }
 
+  /**
+   * Retrieve the value attribute from the underlying input.
+   */
   getValue(): Promise<string | null> {
     return this.parts.checkbox.getValue();
   }
 
+  /**
+   * Check if the checkbox is in the indeterminate state.
+   */
   async isIndeterminate(): Promise<boolean> {
     const indeterminate = await this.interactor.getAttribute(this.parts.checkbox.locator, 'data-indeterminate');
     return indeterminate === 'true';
   }
 
+  /**
+   * Determine whether the checkbox is disabled.
+   */
   isDisabled(): Promise<boolean> {
     return this.parts.checkbox.isDisabled();
   }
 
+  /**
+   * Determine whether the checkbox is read only.
+   */
   isReadonly(): Promise<boolean> {
     return this.parts.checkbox.isReadonly();
   }
 
+  /**
+   * Identifier for this driver.
+   */
   get driverName(): string {
     return 'MuiV5SelectDriver';
   }

--- a/packages/component-driver-mui-v5/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/InputDriver.ts
@@ -51,6 +51,10 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     throw new Error('Unable to determine input type in TextFieldInput');
   }
 
+  /**
+   * Retrieve the current value of the input element, handling both single line
+   * and multiline configurations.
+   */
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -61,6 +65,11 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Set the value of the underlying input element.
+   *
+   * @param value The text to assign to the input.
+   */
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -71,6 +80,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is disabled.
+   */
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -81,6 +93,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is read only.
+   */
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -91,6 +106,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Identifier for this driver.
+   */
   get driverName(): string {
     return 'MuiV5InputDriver';
   }

--- a/packages/component-driver-mui-v5/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/MenuDriver.ts
@@ -41,6 +41,12 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
     return LocatorRelativePosition.Same;
   }
 
+  /**
+   * Locate a menu item by its visible label.
+   *
+   * @param label The text of the desired menu item.
+   * @returns The matching {@link MenuItemDriver} or `null` when not found.
+   */
   async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {
     for await (const item of listHelper.getListItemIterator(this, menuItemLocator, MenuItemDriver)) {
       const itemLabel = await item.label();
@@ -51,6 +57,11 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
     return null;
   }
 
+  /**
+   * Select a menu item using its visible label.
+   *
+   * @param label The label of the item to activate.
+   */
   async selectByLabel(label: string): Promise<void> {
     const item = await this.getMenuItemByLabel(label);
     if (item) {

--- a/packages/component-driver-mui-v6/src/components/AccordionDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/AccordionDriver.ts
@@ -29,7 +29,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Accordion component.
+ * Driver for Material UI v6 Accordion component.
  * @see https://mui.com/material-ui/react-accordion/
  */
 export class AccordionDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v6/src/components/AlertDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/AlertDriver.ts
@@ -31,7 +31,7 @@ const alertSeverityEvaluators: AlertSeverityEvaluator[] = [
 ];
 
 /**
- * Driver for Material UI v5 Alert component.
+ * Driver for Material UI v6 Alert component.
  * @see https://mui.com/material-ui/react-alert/
  */
 export class AlertDriver<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {

--- a/packages/component-driver-mui-v6/src/components/BadgeDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/BadgeDriver.ts
@@ -16,7 +16,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Badge component.
+ * Driver for Material UI v6 Badge component.
  * @see https://mui.com/material-ui/react-badge/
  */
 export class BadgeDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v6/src/components/ButtonDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ButtonDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
 
 /**
- * Driver for Material UI v5 Button component.
+ * Driver for Material UI v6 Button component.
  * @see https://mui.com/material-ui/react-button/
  */
 export class ButtonDriver extends HTMLButtonDriver {

--- a/packages/component-driver-mui-v6/src/components/ChipDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ChipDriver.ts
@@ -21,7 +21,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Chip component.
+ * Driver for Material UI v6 Chip component.
  * @see https://mui.com/material-ui/react-chip/
  */
 export class ChipDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v6/src/components/FabDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/FabDriver.ts
@@ -1,7 +1,7 @@
 import { ButtonDriver } from './ButtonDriver';
 
 /**
- * Driver for Material UI v5 Floating Action Button component.
+ * Driver for Material UI v6 Floating Action Button component.
  * @see https://mui.com/material-ui/react-floating-action-button/
  */
 export class FabDriver extends ButtonDriver {

--- a/packages/component-driver-mui-v6/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/InputDriver.ts
@@ -26,7 +26,7 @@ enum TextFieldInputType {
 }
 
 /**
- * A driver for the Material UI v5 Input, FilledInput, OutlinedInput, and StandardInput components.
+ * A driver for the Material UI v6 Input, FilledInput, OutlinedInput, and StandardInput components.
  */
 export class InputDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
@@ -51,6 +51,10 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     throw new Error('Unable to determine input type in TextFieldInput');
   }
 
+  /**
+   * Retrieve the current value of the input element, handling both single line
+   * and multiline configurations.
+   */
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -61,6 +65,11 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Set the value of the underlying input element.
+   *
+   * @param value The text to assign to the input.
+   */
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -71,6 +80,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is disabled.
+   */
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -81,6 +93,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is read only.
+   */
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -91,6 +106,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Identifier for this driver.
+   */
   get driverName(): string {
     return 'MuiV6InputDriver';
   }

--- a/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SnackbarDriver.ts
@@ -22,7 +22,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Snackbar component.
+ * Driver for Material UI v6 Snackbar component.
  * @see https://mui.com/material-ui/react-snackbar/
  */
 export class SnackbarDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
@@ -53,7 +53,7 @@ enum TextFieldInputType {
 }
 
 /**
- * A driver for the Material UI v5 TextField component with single line or multiline text input.
+ * A driver for the Material UI v6 TextField component with single line or multiline text input.
  */
 export class TextFieldDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {

--- a/packages/component-driver-mui-v7/src/components/AccordionDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/AccordionDriver.ts
@@ -29,7 +29,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Accordion component.
+ * Driver for Material UI v7 Accordion component.
  * @see https://mui.com/material-ui/react-accordion/
  */
 export class AccordionDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v7/src/components/AlertDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/AlertDriver.ts
@@ -31,7 +31,7 @@ const alertSeverityEvaluators: AlertSeverityEvaluator[] = [
 ];
 
 /**
- * Driver for Material UI v5 Alert component.
+ * Driver for Material UI v7 Alert component.
  * @see https://mui.com/material-ui/react-alert/
  */
 export class AlertDriver<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {

--- a/packages/component-driver-mui-v7/src/components/BadgeDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/BadgeDriver.ts
@@ -16,7 +16,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Badge component.
+ * Driver for Material UI v7 Badge component.
  * @see https://mui.com/material-ui/react-badge/
  */
 export class BadgeDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v7/src/components/ButtonDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ButtonDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
 
 /**
- * Driver for Material UI v5 Button component.
+ * Driver for Material UI v7 Button component.
  * @see https://mui.com/material-ui/react-button/
  */
 export class ButtonDriver extends HTMLButtonDriver {

--- a/packages/component-driver-mui-v7/src/components/ChipDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ChipDriver.ts
@@ -21,7 +21,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Chip component.
+ * Driver for Material UI v7 Chip component.
  * @see https://mui.com/material-ui/react-chip/
  */
 export class ChipDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v7/src/components/FabDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/FabDriver.ts
@@ -1,7 +1,7 @@
 import { ButtonDriver } from './ButtonDriver';
 
 /**
- * Driver for Material UI v5 Floating Action Button component.
+ * Driver for Material UI v7 Floating Action Button component.
  * @see https://mui.com/material-ui/react-floating-action-button/
  */
 export class FabDriver extends ButtonDriver {

--- a/packages/component-driver-mui-v7/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/InputDriver.ts
@@ -26,7 +26,7 @@ enum TextFieldInputType {
 }
 
 /**
- * A driver for the Material UI v5 Input, FilledInput, OutlinedInput, and StandardInput components.
+ * A driver for the Material UI v7 Input, FilledInput, OutlinedInput, and StandardInput components.
  */
 export class InputDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
@@ -51,6 +51,10 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     throw new Error('Unable to determine input type in TextFieldInput');
   }
 
+  /**
+   * Retrieve the current value of the input element, handling both single line
+   * and multiline configurations.
+   */
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -61,6 +65,11 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Set the value of the underlying input element.
+   *
+   * @param value The text to assign to the input.
+   */
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -71,6 +80,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is disabled.
+   */
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -81,6 +93,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Determine whether the input element is read only.
+   */
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
@@ -91,6 +106,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     }
   }
 
+  /**
+   * Identifier for this driver.
+   */
   get driverName(): string {
     return 'MuiV7InputDriver';
   }

--- a/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SnackbarDriver.ts
@@ -22,7 +22,7 @@ export const parts = {
 } satisfies ScenePart;
 
 /**
- * Driver for Material UI v5 Snackbar component.
+ * Driver for Material UI v7 Snackbar component.
  * @see https://mui.com/material-ui/react-snackbar/
  */
 export class SnackbarDriver extends ComponentDriver<typeof parts> {

--- a/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
@@ -53,7 +53,7 @@ enum TextFieldInputType {
 }
 
 /**
- * A driver for the Material UI v5 TextField component with single line or multiline text input.
+ * A driver for the Material UI v7 TextField component with single line or multiline text input.
  */
 export class TextFieldDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {

--- a/packages/component-driver-mui-x-v8/src/components/datagrid/DataGridProDriver.ts
+++ b/packages/component-driver-mui-x-v8/src/components/datagrid/DataGridProDriver.ts
@@ -171,30 +171,48 @@ export class DataGridProDriver extends ComponentDriver<typeof parts> {
   }
 
   //#region Footer
+  /**
+   * Determine if the pagination footer is currently visible.
+   */
   isFooterVisible(): Promise<boolean> {
     return this.parts.footer.isVisible();
   }
 
+  /**
+   * Check whether the "previous page" control is enabled.
+   */
   async isPreviousPageEnabled(): Promise<boolean> {
     await this.enforcePartExistence('footer');
     return this.parts.footer.isPreviousPageEnabled();
   }
 
+  /**
+   * Navigate to the previous page using the grid footer control.
+   */
   async gotoPreviousPage(): Promise<void> {
     await this.enforcePartExistence('footer');
     await this.parts.footer.gotoPreviousPage();
   }
 
+  /**
+   * Check whether the "next page" control is enabled.
+   */
   async isNextPageEnabled(): Promise<boolean> {
     await this.enforcePartExistence('footer');
     return this.parts.footer.isNextPageEnabled();
   }
 
+  /**
+   * Navigate to the next page using the grid footer control.
+   */
   async gotoNextPage(): Promise<void> {
     await this.enforcePartExistence('footer');
     await this.parts.footer.gotoNextPage();
   }
 
+  /**
+   * Read the textual description of the current pagination state.
+   */
   async getPaginationDescription(): Promise<Optional<string>> {
     await this.enforcePartExistence('footer');
     return this.parts.footer.getText();


### PR DESCRIPTION
## Summary
- document `MenuDriver` utility methods
- add jsdocs to `CheckboxDriver` and `InputDriver`
- fix MUI version references in v6 and v7 drivers
- note footer helpers in DataGridPro driver

## Testing
- `pnpm -r check:type`

------
https://chatgpt.com/codex/tasks/task_b_686050ae0b0c832b96bce2ccaba2b5c7