### PR TITLE
refactor: replace enum with string union types

### DIFF
--- a/packages/component-driver-html/src/components/HTMLCheckboxGroupDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLCheckboxGroupDriver.ts
@@ -3,7 +3,6 @@ import {
   collectionUtil,
   ComponentDriver,
   IInputDriver,
-  LocatorRelativePosition,
   locatorUtil,
 } from '@atomic-testing/core';
 
@@ -20,7 +19,7 @@ export class HTMLCheckboxGroupDriver extends ComponentDriver<{}> implements IInp
     const availableValues = await this.interactor.getAttribute(this.locator, 'value', true);
     const value: string[] = [];
     for (const val of availableValues) {
-      const itemLocator = byValue(val, LocatorRelativePosition.Same);
+      const itemLocator = byValue(val, 'Same');
       const locator = locatorUtil.append(this.locator, itemLocator);
       const isChecked = await this.interactor.isChecked(locator);
       if (isChecked) {
@@ -55,7 +54,7 @@ export class HTMLCheckboxGroupDriver extends ComponentDriver<{}> implements IInp
    * with a specific value.
    */
   protected async setSelectedByValue(value: string, selected: boolean): Promise<void> {
-    const itemLocator = byValue(value, LocatorRelativePosition.Same);
+    const itemLocator = byValue(value, 'Same');
     const locator = locatorUtil.append(this.locator, itemLocator);
     const checkBoxDriver = new HTMLCheckboxDriver(locator, this.interactor);
     await checkBoxDriver.setSelected(selected);

--- a/packages/component-driver-html/src/components/HTMLRadioButtonGroupDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLRadioButtonGroupDriver.ts
@@ -3,7 +3,6 @@ import {
   byValue,
   ComponentDriver,
   IInputDriver,
-  LocatorRelativePosition,
   locatorUtil,
 } from '@atomic-testing/core';
 
@@ -27,7 +26,7 @@ export class HTMLRadioButtonGroupDriver extends ComponentDriver<{}> implements I
     if (value == null) {
       throw new Error('Cannot be done');
     }
-    const valueLocator = byValue(value, LocatorRelativePosition.Same);
+    const valueLocator = byValue(value, 'Same');
     const locator = locatorUtil.append(this.locator, valueLocator);
     await this.interactor.click(locator);
     return true;

--- a/packages/component-driver-mui-v5/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/AutoCompleteDriver.ts
@@ -9,7 +9,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -21,8 +20,8 @@ export const parts = {
     driver: HTMLTextInputDriver,
   },
   dropdown: {
-    locator: byLinkedElement(LocatorRelativePosition.Root)
-      .onLinkedElement(byCssSelector('', LocatorRelativePosition.Same))
+    locator: byLinkedElement('Root')
+      .onLinkedElement(byCssSelector('', 'Same'))
       .extractAttribute('aria-owns')
       .toMatchMyAttribute('id'),
     driver: HTMLElementDriver,

--- a/packages/component-driver-mui-v5/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/DialogDriver.ts
@@ -5,7 +5,7 @@ import {
   ContainerDriver,
   IContainerDriverOption,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const dialogRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
 
@@ -40,7 +40,7 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   async getTitle(): Promise<string | null> {

--- a/packages/component-driver-mui-v5/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/MenuDriver.ts
@@ -5,7 +5,7 @@ import {
   IComponentDriverOption,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const menuRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const menuRootLocator: PartLocator = byRole('presentation', 'Root');
 const menuItemLocator = byRole('menuitem');
 
 export class MenuDriver extends ComponentDriver<typeof parts> {
@@ -38,7 +38,7 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   /**

--- a/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -63,7 +63,7 @@ export class ProgressDriver extends ComponentDriver<typeof parts> implements IIn
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v5/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/RatingDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -49,7 +49,7 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v5/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/SelectDriver.ts
@@ -14,7 +14,7 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,
@@ -32,7 +32,7 @@ export const selectPart = {
     driver: HTMLButtonDriver,
   },
   dropdown: {
-    locator: byCssSelector('[role=presentation] [role=listbox]', LocatorRelativePosition.Root),
+    locator: byCssSelector('[role=presentation] [role=listbox]', 'Root'),
     driver: HTMLElementDriver,
   },
   input: {

--- a/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
@@ -7,7 +7,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -19,7 +18,7 @@ export const parts = {
     driver: HTMLTextInputDriver,
   },
   dropdown: {
-    locator: byLinkedElement(LocatorRelativePosition.Root)
+    locator: byLinkedElement('Root')
       .onLinkedElement(byRole('combobox'))
       .extractAttribute('aria-controls')
       .toMatchMyAttribute('id'),

--- a/packages/component-driver-mui-v6/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/DialogDriver.ts
@@ -5,7 +5,7 @@ import {
   ContainerDriver,
   IContainerDriverOption,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const dialogRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
 
@@ -40,7 +40,7 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   async getTitle(): Promise<string | null> {

--- a/packages/component-driver-mui-v6/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/MenuDriver.ts
@@ -5,7 +5,7 @@ import {
   IComponentDriverOption,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const menuRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const menuRootLocator: PartLocator = byRole('presentation', 'Root');
 const menuItemLocator = byRole('menuitem');
 
 export class MenuDriver extends ComponentDriver<typeof parts> {
@@ -38,7 +38,7 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {

--- a/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -63,7 +63,7 @@ export class ProgressDriver extends ComponentDriver<typeof parts> implements IIn
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v6/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/RatingDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -49,7 +49,7 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v6/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SelectDriver.ts
@@ -14,7 +14,7 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,
@@ -32,7 +32,7 @@ export const selectPart = {
     driver: HTMLButtonDriver,
   },
   dropdown: {
-    locator: byCssSelector('[role=presentation] [role=listbox]', LocatorRelativePosition.Root),
+    locator: byCssSelector('[role=presentation] [role=listbox]', 'Root'),
     driver: HTMLElementDriver,
   },
   input: {

--- a/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
@@ -7,7 +7,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -19,7 +18,7 @@ export const parts = {
     driver: HTMLTextInputDriver,
   },
   dropdown: {
-    locator: byLinkedElement(LocatorRelativePosition.Root)
+    locator: byLinkedElement('Root')
       .onLinkedElement(byRole('combobox'))
       .extractAttribute('aria-controls')
       .toMatchMyAttribute('id'),

--- a/packages/component-driver-mui-v7/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/DialogDriver.ts
@@ -5,7 +5,7 @@ import {
   ContainerDriver,
   IContainerDriverOption,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const dialogRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
 
@@ -40,7 +40,7 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   async getTitle(): Promise<string | null> {

--- a/packages/component-driver-mui-v7/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/MenuDriver.ts
@@ -5,7 +5,7 @@ import {
   IComponentDriverOption,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   Optional,
   PartLocator,
   ScenePart,
@@ -22,7 +22,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-const menuRootLocator: PartLocator = byRole('presentation', LocatorRelativePosition.Root);
+const menuRootLocator: PartLocator = byRole('presentation', 'Root');
 const menuItemLocator = byRole('menuitem');
 
 export class MenuDriver extends ComponentDriver<typeof parts> {
@@ -38,7 +38,7 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
   }
 
   override overrideLocatorRelativePosition(): Optional<LocatorRelativePosition> {
-    return LocatorRelativePosition.Same;
+    return 'Same';
   }
 
   async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {

--- a/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -63,7 +63,7 @@ export class ProgressDriver extends ComponentDriver<typeof parts> implements IIn
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v7/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/RatingDriver.ts
@@ -7,7 +7,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,
@@ -49,7 +49,7 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
     const valueToClick = (value == null ? currentValue : value) as number;
     const targetLocator = locatorUtil.append(
       this.parts.choices.locator,
-      byValue(valueToClick.toString(), LocatorRelativePosition.Same)
+      byValue(valueToClick.toString(), 'Same')
     );
 
     const targetExists = await this.interactor.exists(targetLocator);

--- a/packages/component-driver-mui-v7/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SelectDriver.ts
@@ -14,7 +14,7 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,
@@ -32,7 +32,7 @@ export const selectPart = {
     driver: HTMLButtonDriver,
   },
   dropdown: {
-    locator: byCssSelector('[role=presentation] [role=listbox]', LocatorRelativePosition.Root),
+    locator: byCssSelector('[role=presentation] [role=listbox]', 'Root'),
     driver: HTMLElementDriver,
   },
   input: {

--- a/packages/component-driver-mui-x-v5/src/components/datepicker/MobileDatePickerDriver.ts
+++ b/packages/component-driver-mui-x-v5/src/components/datepicker/MobileDatePickerDriver.ts
@@ -6,7 +6,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  LocatorRelativePosition,
+  type LocatorRelativePosition,
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
@@ -19,7 +19,7 @@ const parts = {
     driver: HTMLTextInputDriver,
   },
   entryDialog: {
-    locator: byRole('presentation', LocatorRelativePosition.Root).chain(byRole('dialog')),
+    locator: byRole('presentation', 'Root').chain(byRole('dialog')),
     driver: MobileDatePickerDialogDriver,
   },
 } satisfies ScenePart;

--- a/packages/core/src/drivers/ComponentDriver.ts
+++ b/packages/core/src/drivers/ComponentDriver.ts
@@ -14,7 +14,7 @@ import {
   MouseOutOption,
   MouseUpOption,
 } from '../interactor';
-import { LocatorRelativePosition, PartLocator } from '../locators';
+import type { LocatorRelativePosition, PartLocator } from '../locators';
 import { IComponentDriver, IComponentDriverOption, PartName, ScenePart, ScenePartDriver } from '../partTypes';
 import { WaitUntilOption } from '../utils/timingUtil';
 

--- a/packages/core/src/drivers/listHelper.ts
+++ b/packages/core/src/drivers/listHelper.ts
@@ -1,4 +1,4 @@
-import { byCssSelector, CssLocator, LocatorRelativePosition, PartLocator } from '../locators';
+import { byCssSelector, type CssLocator, type LocatorRelativePosition, type PartLocator } from '../locators';
 import { ComponentDriverCtor, ScenePart } from '../partTypes';
 import { append } from '../utils/locatorUtil';
 
@@ -19,7 +19,7 @@ export async function getListItemByIndex<HostPartT extends ScenePart, ItemT exte
   index: number,
   driverClass: ComponentDriverCtor<ItemT>
 ): Promise<ItemT | null> {
-  const nthLocator: CssLocator = byCssSelector(`:nth-of-type(${index + 1})`, LocatorRelativePosition.Same);
+  const nthLocator: CssLocator = byCssSelector(`:nth-of-type(${index + 1})`, 'Same');
   const itemLocator = append(itemLocatorBase, nthLocator);
   const exists = await host.interactor.exists(itemLocator);
   if (exists) {

--- a/packages/core/src/locators/CssLocator.ts
+++ b/packages/core/src/locators/CssLocator.ts
@@ -2,7 +2,7 @@ import { Optional } from '../dataTypes';
 
 import { CssLocatorSource } from './CssLocatorSource';
 import { LocatorComplexity } from './LocatorComplexity';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 import { LocatorType } from './LocatorType';
 import { CssLocatorChain, PartLocator } from './PartLocator';
 
@@ -12,7 +12,7 @@ export interface CssLocatorInitializer {
 }
 
 export class CssLocator {
-  private _relativePosition: LocatorRelativePosition = LocatorRelativePosition.Descendent;
+  private _relativePosition: LocatorRelativePosition = 'Descendent';
   private _type: LocatorType = 'css';
   private _source?: CssLocatorSource;
 

--- a/packages/core/src/locators/LinkedCssLocator.ts
+++ b/packages/core/src/locators/LinkedCssLocator.ts
@@ -1,6 +1,6 @@
 import { CssLocator, CssLocatorInitializer } from './CssLocator';
 import { LocatorComplexity } from './LocatorComplexity';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 import { PartLocator } from './PartLocator';
 import { byDataTestId } from './byDataTestId';
 

--- a/packages/core/src/locators/LocatorRelativePosition.ts
+++ b/packages/core/src/locators/LocatorRelativePosition.ts
@@ -1,14 +1,4 @@
-export enum LocatorRelativePosition {
-  Root = 'Root',
-
-  /**
-   * Descendent of the base element
-   */
-  Descendent = 'Descendent',
-
-  /**
-   * Locator would be within the same element(s), used for finding
-   * elements' by state or value
-   */
-  Same = 'Same',
-}
+/**
+ * Possible relative positions for a locator in relation to the base element.
+ */
+export type LocatorRelativePosition = 'Root' | 'Descendent' | 'Same';

--- a/packages/core/src/locators/byAttribute.ts
+++ b/packages/core/src/locators/byAttribute.ts
@@ -1,7 +1,7 @@
 import { escapeName, escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByAttributeSource = {
   _id: 'byAttribute';
@@ -16,7 +16,7 @@ export type ByAttributeSource = {
  * @param name - The attribute name.
  * @param value - The attribute value to match.
  * @param relativeTo - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const dialog = byAttribute('role', 'dialog');
@@ -25,7 +25,7 @@ export type ByAttributeSource = {
 export function byAttribute(
   name: string,
   value: string,
-  relativeTo: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relativeTo: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const selector = name === 'id' ? `#${escapeValue(value)}` : `[${escapeName(name)}="${escapeValue(value)}"]`;
   return new CssLocator(selector, {

--- a/packages/core/src/locators/byChecked.ts
+++ b/packages/core/src/locators/byChecked.ts
@@ -1,5 +1,5 @@
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByCheckedSource = {
   _id: 'byChecked';
@@ -12,8 +12,7 @@ export type ByCheckedSource = {
  *
  * @param checked - Whether the element should be checked. Defaults to `true`.
  * @param relative - Relative position for the locator. Defaults to
- * {@link LocatorRelativePosition.Same} so it can be chained with the checkbox
- * locator itself.
+ * `'Same'` so it can be chained with the checkbox locator itself.
  * @example
  * ```ts
  * const unchecked = byChecked(false);
@@ -21,7 +20,7 @@ export type ByCheckedSource = {
  */
 export function byChecked(
   checked = true,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Same
+  relative: LocatorRelativePosition = 'Same'
 ): CssLocator {
   let selector = ':checked';
   if (!checked) {

--- a/packages/core/src/locators/byCssClass.ts
+++ b/packages/core/src/locators/byCssClass.ts
@@ -1,7 +1,7 @@
 import { escapeCssClassName } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByCssClassSource = {
   _id: 'byCssClass';
@@ -17,7 +17,7 @@ export type ByCssClassSource = {
  *
  * @param className - One or more class names to match.
  * @param relativeTo - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const icon = byCssClass('MuiIcon-root');
@@ -26,7 +26,7 @@ export type ByCssClassSource = {
  */
 export function byCssClass(
   className: string | string[],
-  relativeTo: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relativeTo: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const classNames = Array.isArray(className) ? className : [className];
   const selector = classNames.map(cls => `.${escapeCssClassName(cls)}`).join('');

--- a/packages/core/src/locators/byCssSelector.ts
+++ b/packages/core/src/locators/byCssSelector.ts
@@ -1,5 +1,5 @@
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByCssSelectorSource = {
   _id: 'byCssSelector';
@@ -15,7 +15,7 @@ export type ByCssSelectorSource = {
  *
  * @param selector - A CSS selector string.
  * @param relativeTo - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const activeItem = byCssSelector('.menu .item.active');
@@ -23,7 +23,7 @@ export type ByCssSelectorSource = {
  */
 export function byCssSelector(
   selector: string,
-  relativeTo: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relativeTo: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   return new CssLocator(selector, {
     relative: relativeTo,

--- a/packages/core/src/locators/byDataTestId.ts
+++ b/packages/core/src/locators/byDataTestId.ts
@@ -1,7 +1,7 @@
 import { escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByDataTestIdSource = {
   _id: 'byDataTestId';
@@ -18,7 +18,7 @@ export type ByDataTestIdSource = {
  * @param id - Single id or an array of ids to match against the
  * `data-testid` attribute.
  * @param relativeTo - How the locator is related to the current locator in a
- * locator chain. Defaults to {@link LocatorRelativePosition.Descendent}.
+ * locator chain. Defaults to `'Descendent'`.
  * @example
  * ```ts
  * const submitButton = byDataTestId('submit');
@@ -27,7 +27,7 @@ export type ByDataTestIdSource = {
  */
 export function byDataTestId(
   id: string | string[],
-  relativeTo: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relativeTo: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const ids = Array.isArray(id) ? id : [id];
   const selector = ids.map(idVal => `[data-testid="${escapeValue(idVal)}"]`).join(' ');

--- a/packages/core/src/locators/byInputType.ts
+++ b/packages/core/src/locators/byInputType.ts
@@ -2,7 +2,7 @@
 import { escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByInputTypeSource = {
   _id: 'byInputType';
@@ -17,7 +17,7 @@ export type ByInputTypeSource = {
  * @param type - The value of the `type` attribute such as `text`, `checkbox`
  * or `radio`.
  * @param relative - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const passwordField = byInputType('password');
@@ -25,7 +25,7 @@ export type ByInputTypeSource = {
  */
 export function byInputType(
   type: string,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relative: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const selector = `input[type=${escapeValue(type)}]`;
   return new CssLocator(selector, {

--- a/packages/core/src/locators/byLinkedElement.ts
+++ b/packages/core/src/locators/byLinkedElement.ts
@@ -1,5 +1,5 @@
 import { LinkedCssLocator, LinkedCssLocatorValueExtract } from './LinkedCssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 import { PartLocator } from './PartLocator';
 
 /**
@@ -8,7 +8,7 @@ import { PartLocator } from './PartLocator';
  * attributes.
  *
  * @param relative - Relative position for the resulting locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const label = byLinkedElement().onLinkedElement(byDataTestId('input'))
@@ -16,7 +16,7 @@ import { PartLocator } from './PartLocator';
  *   .toMatchMyAttribute('id');
  * ```
  */
-export function byLinkedElement(relative: LocatorRelativePosition = LocatorRelativePosition.Descendent) {
+export function byLinkedElement(relative: LocatorRelativePosition = 'Descendent') {
   return {
     onLinkedElement: (locator: PartLocator) => {
       return {

--- a/packages/core/src/locators/byName.ts
+++ b/packages/core/src/locators/byName.ts
@@ -1,7 +1,7 @@
 import { escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByNameSource = {
   _id: 'byName';
@@ -14,7 +14,7 @@ export type ByNameSource = {
  *
  * @param value - Value of the `name` attribute to match.
  * @param relative - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const searchBox = byName('search');
@@ -22,7 +22,7 @@ export type ByNameSource = {
  */
 export function byName(
   value: string,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relative: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const sanitized = escapeValue(value);
   return new CssLocator(`[name="${sanitized}"]`, {

--- a/packages/core/src/locators/byRole.ts
+++ b/packages/core/src/locators/byRole.ts
@@ -1,7 +1,7 @@
 import { escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByRoleSource = {
   _id: 'byRole';
@@ -14,7 +14,7 @@ export type ByRoleSource = {
  *
  * @param value - The role value to match.
  * @param relative - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const dialog = byRole('dialog');
@@ -22,7 +22,7 @@ export type ByRoleSource = {
  */
 export function byRole(
   value: string,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relative: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const sanitized = escapeValue(value);
   return new CssLocator(`[role="${sanitized}"]`, {

--- a/packages/core/src/locators/byTagName.ts
+++ b/packages/core/src/locators/byTagName.ts
@@ -1,5 +1,5 @@
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByTagNameSource = {
   _id: 'byTagName';
@@ -15,7 +15,7 @@ export type ByTagNameSource = {
  *
  * @param tagName - The tag name to match.
  * @param relative - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const headings = byTagName('h1');
@@ -23,7 +23,7 @@ export type ByTagNameSource = {
  */
 export function byTagName(
   tagName: string,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relative: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   return new CssLocator(tagName, {
     relative,

--- a/packages/core/src/locators/byValue.ts
+++ b/packages/core/src/locators/byValue.ts
@@ -1,7 +1,7 @@
 import { escapeValue } from '../utils/escapeUtil';
 
 import { CssLocator } from './CssLocator';
-import { LocatorRelativePosition } from './LocatorRelativePosition';
+import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
 export type ByValueSource = {
   _id: 'byValue';
@@ -14,7 +14,7 @@ export type ByValueSource = {
  *
  * @param value - The value to match.
  * @param relative - Relative position of the locator. Defaults to
- * {@link LocatorRelativePosition.Descendent}.
+ * `'Descendent'`.
  * @example
  * ```ts
  * const option = byValue('option1');
@@ -22,7 +22,7 @@ export type ByValueSource = {
  */
 export function byValue(
   value: string,
-  relative: LocatorRelativePosition = LocatorRelativePosition.Descendent
+  relative: LocatorRelativePosition = 'Descendent'
 ): CssLocator {
   const sanitized = escapeValue(value);
   return new CssLocator(`[value="${sanitized}"]`, {

--- a/packages/core/src/locators/index.ts
+++ b/packages/core/src/locators/index.ts
@@ -11,7 +11,7 @@ export { byTagName } from './byTagName';
 export { byValue } from './byValue';
 export { CssLocator } from './CssLocator';
 export * from './LinkedCssLocator';
-export { LocatorRelativePosition } from './LocatorRelativePosition';
+export type { LocatorRelativePosition } from './LocatorRelativePosition';
 export type { LocatorType } from './LocatorType';
 export { LocatorTypeLookup } from './LocatorType';
 export type { CssLocatorChain, LocatorChain, PartLocator } from './PartLocator';

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -2,7 +2,7 @@ import { Optional } from '../dataTypes';
 import { Interactor } from '../interactor/Interactor';
 import { CssLocator } from '../locators/CssLocator';
 import { LinkedCssLocator } from '../locators/LinkedCssLocator';
-import { LocatorRelativePosition } from '../locators/LocatorRelativePosition';
+import type { LocatorRelativePosition } from '../locators/LocatorRelativePosition';
 import { CssLocatorChain, PartLocator } from '../locators/PartLocator';
 import { byAttribute } from '../locators/byAttribute';
 
@@ -31,7 +31,7 @@ export function findRootLocatorIndex(locator: PartLocator): number {
   const length = list.length;
   for (let i = length - 1; i >= 0; i--) {
     const loc = list[i];
-    if (loc.relative === LocatorRelativePosition.Root) {
+    if (loc.relative === 'Root') {
       return i;
     }
   }
@@ -72,7 +72,7 @@ export async function toCssSelector(locator: PartLocator, interactor: Interactor
     let statement = '';
     const loc = effectiveLocator[i];
     statement = getLocatorStatement(loc);
-    const separator = loc.relative === LocatorRelativePosition.Same ? '' : ' ';
+    const separator = loc.relative === 'Same' ? '' : ' ';
     statements.push(separator + statement);
   }
 


### PR DESCRIPTION
## Summary
- replace `LocatorRelativePosition` enum with a string literal type
- update call sites and JSDoc to use string values
- clean up imports using `import type`

## Testing
- `pnpm build:packages`
- `pnpm check:type`
- `pnpm -r test:dom`


------
https://chatgpt.com/codex/tasks/task_b_686069f4683c832b9204808be37bc3d1