### PR TITLE
refactor: Replace TextFieldInputType enums with string literal types

### DIFF
--- a/packages/component-driver-mui-v5/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/InputDriver.ts
@@ -20,10 +20,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-}
+type TextFieldInputType = 'singleLine' | 'multiline';
 
 /**
  * A driver for the Material UI v5 Input, FilledInput, OutlinedInput, and StandardInput components.
@@ -40,12 +37,12 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     // TODO: Detection of both input types can be done in parallel.
     const textInputExists = await this.interactor.exists(this.parts.singlelineInput.locator);
     if (textInputExists) {
-      return TextFieldInputType.Singleline;
+      return 'singleLine';
     }
 
     const multilineExists = await this.interactor.exists(this.parts.multilineInput.locator);
     if (multilineExists) {
-      return TextFieldInputType.Multiline;
+      return 'multiline';
     }
 
     throw new Error('Unable to determine input type in TextFieldInput');
@@ -58,9 +55,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -73,9 +70,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -86,9 +83,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -99,9 +96,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/ProgressDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v5/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/RatingDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v5/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/SelectDriver.ts
@@ -14,7 +14,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,

--- a/packages/component-driver-mui-v5/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/TextFieldDriver.ts
@@ -46,11 +46,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-  Select = 'select',
-}
+type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 
 /**
  * A driver for the Material UI v5 TextField component with single line or multiline text input.
@@ -71,13 +67,13 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       this.parts.multilineInput.exists(),
     ]).then(([singlelineExists, richSelectExists, nativeSelectExists, multilineExists]) => {
       if (singlelineExists) {
-        return TextFieldInputType.Singleline;
+        return 'singleLine';
       }
       if (richSelectExists || nativeSelectExists) {
-        return TextFieldInputType.Select;
+        return 'select';
       }
       if (multilineExists) {
-        return TextFieldInputType.Multiline;
+        return 'multiline';
       }
 
       throw new Error('Unable to determine input type in TextFieldInput');
@@ -89,11 +85,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -101,11 +97,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -124,11 +120,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -136,11 +132,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.interactor.hasCssClass(this.parts.selectInput.locator, 'MuiInputBase-readOnly');
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-v6/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/InputDriver.ts
@@ -20,10 +20,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-}
+type TextFieldInputType = 'singleLine' | 'multiline';
 
 /**
  * A driver for the Material UI v6 Input, FilledInput, OutlinedInput, and StandardInput components.
@@ -40,12 +37,12 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     // TODO: Detection of both input types can be done in parallel.
     const textInputExists = await this.interactor.exists(this.parts.singlelineInput.locator);
     if (textInputExists) {
-      return TextFieldInputType.Singleline;
+      return 'singleLine';
     }
 
     const multilineExists = await this.interactor.exists(this.parts.multilineInput.locator);
     if (multilineExists) {
-      return TextFieldInputType.Multiline;
+      return 'multiline';
     }
 
     throw new Error('Unable to determine input type in TextFieldInput');
@@ -58,9 +55,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -73,9 +70,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -86,9 +83,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -99,9 +96,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v6/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/RatingDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v6/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SelectDriver.ts
@@ -14,7 +14,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,

--- a/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
@@ -46,11 +46,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-  Select = 'select',
-}
+type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 
 /**
  * A driver for the Material UI v6 TextField component with single line or multiline text input.
@@ -71,13 +67,13 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       this.parts.multilineInput.exists(),
     ]).then(([singlelineExists, richSelectExists, nativeSelectExists, multilineExists]) => {
       if (singlelineExists) {
-        return TextFieldInputType.Singleline;
+        return 'singleLine';
       }
       if (richSelectExists || nativeSelectExists) {
-        return TextFieldInputType.Select;
+        return 'select';
       }
       if (multilineExists) {
-        return TextFieldInputType.Multiline;
+        return 'multiline';
       }
 
       throw new Error('Unable to determine input type in TextFieldInput');
@@ -89,11 +85,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -101,11 +97,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -124,11 +120,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -136,11 +132,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.interactor.hasCssClass(this.parts.selectInput.locator, 'MuiInputBase-readOnly');
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-v7/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/InputDriver.ts
@@ -20,10 +20,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-}
+type TextFieldInputType = 'singleLine' | 'multiline';
 
 /**
  * A driver for the Material UI v7 Input, FilledInput, OutlinedInput, and StandardInput components.
@@ -40,12 +37,12 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
     // TODO: Detection of both input types can be done in parallel.
     const textInputExists = await this.interactor.exists(this.parts.singlelineInput.locator);
     if (textInputExists) {
-      return TextFieldInputType.Singleline;
+      return 'singleLine';
     }
 
     const multilineExists = await this.interactor.exists(this.parts.multilineInput.locator);
     if (multilineExists) {
-      return TextFieldInputType.Multiline;
+      return 'multiline';
     }
 
     throw new Error('Unable to determine input type in TextFieldInput');
@@ -58,9 +55,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -73,9 +70,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -86,9 +83,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -99,9 +96,9 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v7/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/RatingDriver.ts
@@ -7,7 +7,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   locatorUtil,
   PartLocator,
   ScenePart,

--- a/packages/component-driver-mui-v7/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SelectDriver.ts
@@ -14,7 +14,6 @@ import {
   IInputDriver,
   Interactor,
   listHelper,
-  type LocatorRelativePosition,
   locatorUtil,
   Nullable,
   PartLocator,

--- a/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
@@ -46,11 +46,7 @@ export const parts = {
   },
 } satisfies ScenePart;
 
-enum TextFieldInputType {
-  Singleline = 'singleLine',
-  Multiline = 'multiline',
-  Select = 'select',
-}
+type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 
 /**
  * A driver for the Material UI v7 TextField component with single line or multiline text input.
@@ -71,13 +67,13 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       this.parts.multilineInput.exists(),
     ]).then(([singlelineExists, richSelectExists, nativeSelectExists, multilineExists]) => {
       if (singlelineExists) {
-        return TextFieldInputType.Singleline;
+        return 'singleLine';
       }
       if (richSelectExists || nativeSelectExists) {
-        return TextFieldInputType.Select;
+        return 'select';
       }
       if (multilineExists) {
-        return TextFieldInputType.Multiline;
+        return 'multiline';
       }
 
       throw new Error('Unable to determine input type in TextFieldInput');
@@ -89,11 +85,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async getValue(): Promise<string | null> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.getValue();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.getValue();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.getValue();
     }
   }
@@ -101,11 +97,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async setValue(value: string | null): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.setValue(value);
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.setValue(value);
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.setValue(value);
     }
   }
@@ -124,11 +120,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isDisabled(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isDisabled();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.parts.selectInput.isDisabled();
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isDisabled();
     }
   }
@@ -136,11 +132,11 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
   async isReadonly(): Promise<boolean> {
     const inputType = await this.getInputType();
     switch (inputType) {
-      case TextFieldInputType.Singleline:
+      case 'singleLine':
         return this.parts.singlelineInput.isReadonly();
-      case TextFieldInputType.Select:
+      case 'select':
         return this.interactor.hasCssClass(this.parts.selectInput.locator, 'MuiInputBase-readOnly');
-      case TextFieldInputType.Multiline:
+      case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
   }

--- a/packages/component-driver-mui-x-v5/src/components/datepicker/MobileDatePickerDriver.ts
+++ b/packages/component-driver-mui-x-v5/src/components/datepicker/MobileDatePickerDriver.ts
@@ -6,7 +6,6 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
-  type LocatorRelativePosition,
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';

--- a/packages/core/src/drivers/listHelper.ts
+++ b/packages/core/src/drivers/listHelper.ts
@@ -1,4 +1,4 @@
-import { byCssSelector, type CssLocator, type LocatorRelativePosition, type PartLocator } from '../locators';
+import { byCssSelector, type CssLocator, type PartLocator } from '../locators';
 import { ComponentDriverCtor, ScenePart } from '../partTypes';
 import { append } from '../utils/locatorUtil';
 


### PR DESCRIPTION

## Summary
This PR replaces enum-based input type definitions with string literal union types across Material UI v5, v6, and v7 driver packages, and updates all usages to return and pattern-match on the new union values.

- Removed `TextFieldInputType` enums and introduced `type TextFieldInputType = 'singleLine' | 'multiline' | ['select']?` aliases.
- Updated `getInputType()` to return bare string literals and updated all switch/case branches accordingly.
- Applied changes consistently across `TextFieldDriver.ts` and `InputDriver.ts` in v5, v6, and v7 packages.
