### PR TITLE
doc: Fix broken docs links

### DIFF
--- a/docs/docs/best-practices.mdx
+++ b/docs/docs/best-practices.mdx
@@ -31,7 +31,7 @@ different environments.
 Atomic Testing Library builds on top of React Testing Library (RTL) for
 DOM interactions, but calling RTL utilities directly couples your tests
 to a specific environment. For a deeper discussion of how Atomic Testing
-relates to RTL, see [Atomic Testing vs React Testing Library](./atomic-testing-vs-rtl.mdx).
+relates to RTL, see [Atomic Testing vs React Testing Library](./advanced-concepts/atomic-testing-vs-rtl.mdx).
 Prefer the methods exposed by component drivers and the `TestEngine` so
 your tests remain predictable and can be run in other environments such
 as Playwright or Cypress.

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -17,7 +17,7 @@ Drivers are provided for popular React frameworks, including Material UI and MUI
 
 ### Does Atomic Testing replace React Testing Library?
 
-No. Atomic Testing uses React Testing Library under the hood for DOM interactions. It layers reusable component drivers and the `TestEngine` on top of RTL. See [Atomic Testing vs React Testing Library](./atomic-testing-vs-rtl.mdx) for details.
+No. Atomic Testing uses React Testing Library under the hood for DOM interactions. It layers reusable component drivers and the `TestEngine` on top of RTL. See [Atomic Testing vs React Testing Library](./advanced-concepts/atomic-testing-vs-rtl.mdx) for details.
 
 ### Can I use it with unit tests and end‑to‑end tests?
 

--- a/docs/docs/first-test.mdx
+++ b/docs/docs/first-test.mdx
@@ -13,8 +13,8 @@ This page will walk you through building a complete, real-world test step-by-ste
 
 For now, check out:
 
-- [Getting Started Tutorial](./tutorial) - Detailed tutorial with login form
-- [Setup Guide](./setup) - Step-by-step setup instructions
-- [Quick Start](./quick-start) - 5-minute framework examples
+- [Getting Started Tutorial](./getting-started-tutorial.mdx) - Detailed tutorial with login form
+- [Setup Guide](./setup.mdx) - Step-by-step setup instructions
+- [Quick Start](./quick-start.mdx) - 5-minute framework examples
 
 We're working on making this the ultimate beginner-friendly guide to Atomic Testing! 🚀

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -216,6 +216,6 @@ Notice how the test logic is **identical across frameworks**:
 
 ## 🤔 Questions?
 
-- **"This seems like extra setup..."** → See [Why Atomic Testing?](./why-atomic-testing) for long-term benefits
-- **"How do I test complex forms?"** → Check out the [Step-by-Step Tutorial](./tutorial)
-- **"What about my existing tests?"** → We're working on a migration guide!
+**"This seems like extra setup..."** → See [Why Atomic Testing?](./why-atomic-testing.mdx) for long-term benefits
+**"How do I test complex forms?"** → Check out the [Step-by-Step Tutorial](./getting-started-tutorial.mdx)
+**"What about my existing tests?"** → We're working on a migration guide!

--- a/packages/core/src/TestEngine.ts
+++ b/packages/core/src/TestEngine.ts
@@ -18,7 +18,7 @@ export class TestEngine<T extends ScenePart> extends ComponentDriver<T> {
    * @param locator     Root locator for the scene.
    * @param interactor  Low level interactor used by drivers.
    * @param option      Optional driver configuration.
-   * @param cleanUp     Hook executed when {@link cleanUp} is called.
+   * @param cleanUp     Hook executed when {@link TestEngine.cleanUp | cleanUp} is called.
    */
   constructor(
     locator: PartLocator,


### PR DESCRIPTION
## Summary
- fix broken relative doc links
- clarify `cleanUp` JSDoc link in `TestEngine`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_b_686493ebacdc832b92d5368f5677303f