### PR TITLE
core: Improve locator validation and docs

### DIFF
--- a/docs/docs/best-practices.mdx
+++ b/docs/docs/best-practices.mdx
@@ -40,13 +40,17 @@ as Playwright or Cypress.
 
 Assign stable `data-testid` values to the elements you need to interact with. Locators built with `byDataTestId()` are both reliable and easy to read. For a full list of locator helpers see [the API overview](./api-overview.mdx#locator). Avoid relying solely on CSS selectors—they tend to change as the markup evolves.
 
-### 5. Clean Up the Test Engine
+### 5. Choose Semantic Locators When Possible
+
+Use `byRole()` to locate elements with meaningful ARIA roles like `button` or `dialog`. This keeps tests accessible and mirrors how assistive technologies query the DOM. For form fields that will be submitted, `byName()` provides a stable hook that reflects the `name` attribute. Reserve `byCssSelector()` or other low level locators for edge cases where semantic options are unavailable.
+
+### 6. Clean Up the Test Engine
 
 Call `testEngine.cleanUp()` in `afterEach` hooks. Unmounting the rendered
 component prevents cross‑test contamination and matches the pattern used
 throughout the example tests.
 
-### 6. Compose and Reuse Drivers
+### 7. Compose and Reuse Drivers
 
 Complex widgets become easier to test when you encapsulate their
 behaviour in a driver. The signup example composes form drivers that can
@@ -54,14 +58,14 @@ be reused in unit and end‑to‑end scenarios. Implement your own drivers
 when needed and use `satisfies ScenePart` to get strong TypeScript
 support.
 
-### 7. Provide the Necessary Context
+### 8. Provide the Necessary Context
 
 Wrap tested components with any required providers—such as a MUI
 `ThemeProvider`—when creating the test engine. The example project uses a
 `createTestEngineForComponent` helper to inject the theme so tests run in
 a realistic environment.
 
-### 8. Await Driver Actions
+### 9. Await Driver Actions
 
 Most driver methods return promises. Remember to `await` interactions and
 queries so tests wait for state updates before asserting results.

--- a/packages/core/src/locators/byAttribute.ts
+++ b/packages/core/src/locators/byAttribute.ts
@@ -1,4 +1,5 @@
 import { escapeName, escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -27,6 +28,8 @@ export function byAttribute(
   value: string,
   relativeTo: LocatorRelativePosition = 'Descendant'
 ): CssLocator {
+  assertNonEmpty(name, 'attribute name');
+  assertNonEmpty(value, 'attribute value');
   const selector = name === 'id' ? `#${escapeValue(value)}` : `[${escapeName(name)}="${escapeValue(value)}"]`;
   return new CssLocator(selector, {
     relative: relativeTo,

--- a/packages/core/src/locators/byCssClass.ts
+++ b/packages/core/src/locators/byCssClass.ts
@@ -1,4 +1,5 @@
 import { escapeCssClassName } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -29,6 +30,7 @@ export function byCssClass(
   relativeTo: LocatorRelativePosition = 'Descendant'
 ): CssLocator {
   const classNames = Array.isArray(className) ? className : [className];
+  classNames.forEach(name => assertNonEmpty(name, 'className'));
   const selector = classNames.map(cls => `.${escapeCssClassName(cls)}`).join('');
   return new CssLocator(selector, {
     relative: relativeTo,

--- a/packages/core/src/locators/byCssSelector.ts
+++ b/packages/core/src/locators/byCssSelector.ts
@@ -1,3 +1,5 @@
+import { assertNonEmpty } from '../utils/validation';
+
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
@@ -22,6 +24,7 @@ export type ByCssSelectorSource = {
  * ```
  */
 export function byCssSelector(selector: string, relativeTo: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(selector, 'selector');
   return new CssLocator(selector, {
     relative: relativeTo,
     source: {

--- a/packages/core/src/locators/byDataTestId.ts
+++ b/packages/core/src/locators/byDataTestId.ts
@@ -1,4 +1,5 @@
 import { escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -27,6 +28,7 @@ export type ByDataTestIdSource = {
  */
 export function byDataTestId(id: string | string[], relativeTo: LocatorRelativePosition = 'Descendant'): CssLocator {
   const ids = Array.isArray(id) ? id : [id];
+  ids.forEach(value => assertNonEmpty(value, 'data-testid'));
   const selector = ids.map(idVal => `[data-testid="${escapeValue(idVal)}"]`).join(' ');
   return new CssLocator(selector, {
     relative: relativeTo,

--- a/packages/core/src/locators/byInputType.ts
+++ b/packages/core/src/locators/byInputType.ts
@@ -1,5 +1,6 @@
 // TODO: Use descriptive selector instead of css selector so the selector can be reintepreted
 import { escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -24,6 +25,7 @@ export type ByInputTypeSource = {
  * ```
  */
 export function byInputType(type: string, relative: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(type, 'type');
   const selector = `input[type=${escapeValue(type)}]`;
   return new CssLocator(selector, {
     relative,

--- a/packages/core/src/locators/byName.ts
+++ b/packages/core/src/locators/byName.ts
@@ -1,4 +1,5 @@
 import { escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -21,6 +22,7 @@ export type ByNameSource = {
  * ```
  */
 export function byName(value: string, relative: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(value, 'name');
   const sanitized = escapeValue(value);
   return new CssLocator(`[name="${sanitized}"]`, {
     relative,

--- a/packages/core/src/locators/byRole.ts
+++ b/packages/core/src/locators/byRole.ts
@@ -1,4 +1,5 @@
 import { escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -21,6 +22,7 @@ export type ByRoleSource = {
  * ```
  */
 export function byRole(value: string, relative: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(value, 'role');
   const sanitized = escapeValue(value);
   return new CssLocator(`[role="${sanitized}"]`, {
     relative,

--- a/packages/core/src/locators/byTagName.ts
+++ b/packages/core/src/locators/byTagName.ts
@@ -1,3 +1,5 @@
+import { assertNonEmpty } from '../utils/validation';
+
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
 
@@ -22,6 +24,7 @@ export type ByTagNameSource = {
  * ```
  */
 export function byTagName(tagName: string, relative: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(tagName, 'tagName');
   return new CssLocator(tagName, {
     relative,
     source: {

--- a/packages/core/src/locators/byValue.ts
+++ b/packages/core/src/locators/byValue.ts
@@ -1,4 +1,5 @@
 import { escapeValue } from '../utils/escapeUtil';
+import { assertNonEmpty } from '../utils/validation';
 
 import { CssLocator } from './CssLocator';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -21,6 +22,7 @@ export type ByValueSource = {
  * ```
  */
 export function byValue(value: string, relative: LocatorRelativePosition = 'Descendant'): CssLocator {
+  assertNonEmpty(value, 'value');
   const sanitized = escapeValue(value);
   return new CssLocator(`[value="${sanitized}"]`, {
     relative,

--- a/packages/core/src/utils/validation.ts
+++ b/packages/core/src/utils/validation.ts
@@ -1,0 +1,5 @@
+export function assertNonEmpty(value: string, name: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+}


### PR DESCRIPTION
## Summary
- document when to use semantic locators
- validate locator parameters to guard against empty strings

## Testing
- `pnpm run check:type`
- `pnpm run check:lint`
- `pnpm run check:style`


------
https://chatgpt.com/codex/tasks/task_b_68692bcc8c08832ba4b2f12a79ebc0e3