### PR TITLE
Add plop templates for component driver generators

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ pnpm-lock.yaml
 **/dist/**/*
 **/build/**/*
 CNAME
+plop-templates/*

--- a/plop-templates/componentDriver.hbs
+++ b/plop-templates/componentDriver.hbs
@@ -1,0 +1,22 @@
+{{! prettier-ignore-start }}
+import { ComponentDriver{{#if hasParts}}, IComponentDriverOption, Interactor, PartLocator, ScenePart{{/if}} } from '@atomic-testing/core';
+{{#if hasParts}}
+export const parts = {
+  // TODO: define parts
+} satisfies ScenePart;
+{{/if}}
+
+export class {{driverName}} extends ComponentDriver<{{#if hasParts}}typeof parts{{else}}{}{{/if}}> {
+{{#if hasParts}}
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts: parts,
+    });
+  }
+{{/if}}
+  override get driverName(): string {
+    return '{{driverName}}';
+  }
+}
+{{! prettier-ignore-end }}

--- a/plop-templates/containerComponentDriver.hbs
+++ b/plop-templates/containerComponentDriver.hbs
@@ -1,0 +1,21 @@
+{{! prettier-ignore-start }}
+import { ContainerDriver, IContainerDriverOption, Interactor, PartLocator, ScenePart } from '@atomic-testing/core';
+
+export const parts = {
+  // TODO: define parts
+} satisfies ScenePart;
+
+export class {{driverName}}<ContentT extends ScenePart = {}> extends ContainerDriver<ContentT, typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption<ContentT>>) {
+    super(locator, interactor, {
+      ...option,
+      parts: parts,
+      content: (option?.content ?? {}) as ContentT,
+    });
+  }
+
+  override get driverName(): string {
+    return '{{driverName}}';
+  }
+}
+{{! prettier-ignore-end }}

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,0 +1,55 @@
+export default function (plop) {
+  plop.setGenerator('component-driver', {
+    description: 'Create a component driver',
+    prompts: [
+      {
+        type: 'input',
+        name: 'driverName',
+        message: 'Driver name (e.g. ButtonDriver)',
+      },
+      {
+        type: 'input',
+        name: 'path',
+        message: 'Directory for the driver file',
+        default: 'packages/your-package/src/components',
+      },
+      {
+        type: 'confirm',
+        name: 'hasParts',
+        message: 'Does this driver have parts?',
+        default: true,
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: '{{path}}/{{driverName}}.ts',
+        templateFile: 'plop-templates/componentDriver.hbs',
+      },
+    ],
+  });
+
+  plop.setGenerator('container-component-driver', {
+    description: 'Create a container component driver',
+    prompts: [
+      {
+        type: 'input',
+        name: 'driverName',
+        message: 'Driver name (e.g. DialogDriver)',
+      },
+      {
+        type: 'input',
+        name: 'path',
+        message: 'Directory for the driver file',
+        default: 'packages/your-package/src/components',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: '{{path}}/{{driverName}}.ts',
+        templateFile: 'plop-templates/containerComponentDriver.hbs',
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `plopfile.js` defining generators for component drivers
- add Handlebars templates for `ComponentDriver` and `ContainerDriver`
- update `.prettierignore` to exclude template files

## Testing
- `pnpm run check:lint`
- `pnpm run check:style`
- `pnpm run check:type`


------
https://chatgpt.com/codex/tasks/task_b_686b0e9eef3c832bb71528d63b077868