### PR TITLE
Update VSCode recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,10 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "johnpapa.vscode-peacock",
     "nicoespeon.abracadabra",
     "streetsidesoftware.code-spell-checker",
     "tangent.taskasaurus",
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+    "oxc.oxc-vscode"
   ]
 }


### PR DESCRIPTION

Decommision extension related to eslint and prettier in favor of the udpated Oxlint and Oxfmt
