### PR TITLE
Add agent-facing documentation set for the packages workspace

### DIFF
--- a/agent-docs/AGENTS.md
+++ b/agent-docs/AGENTS.md
@@ -1,0 +1,112 @@
+# Atomic Testing — Agent Playbook
+
+> Read this file first. It tells you what to read next for any task, and the conventions to follow. These docs describe `packages/` (the library). The repo-root `docs/` folder is the separate user-facing Docusaurus site — don't confuse them.
+
+## Quick start
+
+1. [INDEX.md](INDEX.md) — full doc map.
+2. [DOMAIN.md](DOMAIN.md) — vocabulary & type system (driver, interactor, locator, scene part).
+3. [ARCHITECTURE.md](ARCHITECTURE.md) — layer stack, interactor inheritance, dependency graph, shared-test pattern.
+4. The relevant `modules/*.md` for your task (see routing below).
+
+## Quick lookup
+
+| If you need to… | Start here |
+|------------------|-----------|
+| Understand the vocabulary / types | [DOMAIN.md](DOMAIN.md) |
+| See how data/control flows end-to-end | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Understand the core types/classes/locators/errors | [modules/core.md](modules/core.md) |
+| Work on the base DOM interactor / `getElement` / events | [modules/dom-core.md](modules/dom-core.md) |
+| Work on React/Vue rendering or reactivity flushing | [modules/framework-adapters.md](modules/framework-adapters.md) |
+| Work on browser/E2E behavior | [modules/playwright.md](modules/playwright.md) |
+| Understand how one suite runs in Jest/Vitest/Playwright | [modules/test-runner.md](modules/test-runner.md) |
+| Add/fix an HTML element driver | [modules/component-driver-html.md](modules/component-driver-html.md) |
+| Add/fix a MUI core driver (v5/v6/v7) | [modules/component-driver-mui.md](modules/component-driver-mui.md) |
+| Add/fix a MUI-X grid/picker driver | [modules/component-driver-mui-x.md](modules/component-driver-mui-x.md) |
+| Know *why* something is shaped this way | [adr/](adr/) (001 drivers · 002 interactor · 003 version packages · 004 shared tests) |
+| Add a new locator | [modules/core.md → Locators](modules/core.md#locators) |
+| Handle a portal/overlay component (dialog/menu) | [ARCHITECTURE.md → Cross-cutting](ARCHITECTURE.md#cross-cutting-concerns); `MenuDriver`/`DialogDriver` |
+
+## Fresh repo tree
+
+Do **not** rely on a static file listing. Generate the current tree on demand:
+
+```bash
+bash /Users/tangent.lin/.claude/skills/doc-gen/repo-tree.sh /Users/tangent.lin/Development/os/atomic-testing/packages
+```
+
+## Build / test / run
+
+From `CLAUDE.md` (toolchain: pnpm ≥10, Node ≥22.12; type-check via `tsgo`, lint via oxlint, format via oxfmt):
+
+| Action | Command |
+|--------|---------|
+| Install | `pnpm install` |
+| Type-check all | `pnpm run check:type` |
+| Lint (autofix) | `pnpm run check:lint` |
+| Format | `pnpm run check:style` |
+| Unit (DOM/Jest) | `pnpm test:dom` (in a package dir) |
+| E2E (Playwright) | `pnpm test:e2e` (needs dev server running) |
+| Build a package | `pnpm run build` (tsdown) |
+| Build docs site | `cd docs && pnpm build` |
+
+E2E setup (from `CLAUDE.md`): in `package-tests/component-driver-html-test`, run `pnpm start &` (Vite dev server) then `pnpm test:e2e` (or `pnpm test:e2e:chrome` for fast iteration). Test all browsers before merging.
+
+## Conventions
+
+### Directory structure
+
+| Directory | Purpose | Conventions |
+|-----------|---------|-------------|
+| `packages/core/src` | types, base drivers, interactor interface, locators, errors, utils | utils exported as namespaces; locators are `byX.ts` files |
+| `packages/dom-core/src` | `DOMInteractor` base impl | one class per environment behavior |
+| `packages/{react-*,vue-3}/src` | adapter `createTestEngine` + interactor subclass | `createTestEngine.ts`, `types.ts`, `index.ts` |
+| `packages/playwright/src` | `PlaywrightInteractor` + runner glue | not a `DOMInteractor` subclass |
+| `packages/internal-test-runner*/src` | suite orchestration + adapters | `internal-` = workspace-private |
+| `packages/component-driver-*/src/components` | one driver per file | `XDriver.ts`, plus `errors/` where needed |
+| `package-tests/*` | suites validating drivers | three-file pattern (`*.suite.ts` / `*.dom.test.ts` / `*.e2e.test.ts`) |
+
+### Naming & patterns
+
+- Driver classes end in `Driver`; `driverName` getter returns a stable id (`HTMLTextInput`, `MuiV7SelectDriver`, …).
+- Scene parts use `satisfies ScenePart` to preserve literal key types.
+- Each package's public API is its `src/index.ts` barrel — discover exports there, don't enumerate them in docs.
+- Version-mirrored packages (`mui-v5/6/7`, `react-18/19/legacy`) keep matching file/export names; differences are selectors/roles/`driverName` only ([ADR-003](adr/003-version-specific-packages.md)).
+- Locator-override hooks (`overriddenParentLocator`, `overrideLocatorRelativePosition`) must be pure (run before construction).
+
+## Change workflows
+
+### Add a component driver
+1. Pick the package (`component-driver-html` for native, `component-driver-mui-v*` for MUI). 2. Create `src/components/XDriver.ts` extending `ComponentDriver`/`ContainerDriver`/`ListComponentDriver`. 3. Declare `parts` (`satisfies ScenePart`), composing existing leaf drivers. 4. Implement semantic methods + `driverName`. 5. For portals, override the locator hooks. 6. Export from `index.ts`. 7. Mirror across version packages if MUI. 8. Add a `*.suite.ts` + `.dom`/`.e2e` adapters under `package-tests/`. → [modules/component-driver-html.md](modules/component-driver-html.md), [modules/component-driver-mui.md](modules/component-driver-mui.md).
+
+### Add a locator
+Add `packages/core/src/locators/byX.ts` returning a `CssLocator` (use `byCssSelector` internally), export from `locators/index.ts`. → [modules/core.md](modules/core.md#locators).
+
+### Add a framework adapter / new React major
+Copy `react-18`; adjust render/unmount API, `act` source, `data-*` attribute, and peer ranges; reuse or subclass `DOMInteractor`. → [modules/framework-adapters.md](modules/framework-adapters.md).
+
+### Add an interactor method
+Add it to the `Interactor` interface ([core/src/interactor/Interactor.ts](../packages/core/src/interactor/Interactor.ts)), implement in `DOMInteractor` (React/Vue inherit), and **also implement in `PlaywrightInteractor`** (it doesn't inherit). → [ADR-002](adr/002-interactor-abstraction.md).
+
+### Add a test runner
+Implement a `TestFrameworkMapper` for it (copy `vitestAdapter`). → [modules/test-runner.md](modules/test-runner.md).
+
+### Fix a MUI-version bug
+Reproduce against the specific `component-driver-mui-v*`; fix there; replicate to the other versions only if the same DOM/role applies. → [ADR-003](adr/003-version-specific-packages.md).
+
+## Documentation update rules
+
+| When you change… | Update… |
+|------------------|---------|
+| A domain type, driver option, or `Interactor` method | [DOMAIN.md](DOMAIN.md) glossary/types + relevant `modules/*.md` |
+| A package's public surface (`index.ts`) | that package's `modules/*.md` Public Surface table |
+| User-visible driver behavior | the relevant `modules/component-driver-*.md` |
+| File/folder structure | this file's Conventions table (and re-run `repo-tree.sh`) |
+| A consequential design decision | the relevant `adr/*.md` (or add a new one) |
+
+## Context-minimizing guidance
+
+- Most driver tasks: [DOMAIN.md](DOMAIN.md) + the one relevant `modules/component-driver-*.md` is enough.
+- Interactor/environment tasks: [ARCHITECTURE.md → Interactor inheritance](ARCHITECTURE.md#interactor-inheritance) + [modules/dom-core.md](modules/dom-core.md) (+ [modules/playwright.md](modules/playwright.md) if browser).
+- Test-infra tasks: [modules/test-runner.md](modules/test-runner.md) + [ADR-004](adr/004-shared-three-file-test-pattern.md).
+- Always verify a cited symbol still exists before acting — code is the source of truth.

--- a/agent-docs/ARCHITECTURE.md
+++ b/agent-docs/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Atomic Testing — Architecture
+
+How the pieces connect at runtime. Terms are defined in [DOMAIN.md](DOMAIN.md). Source citations point at `../packages/...`.
+
+## Entry points
+
+A test always starts by building a `TestEngine` with an environment-specific factory. All factories produce the same `TestEngine<T>` type; they differ only in which `Interactor` they inject and how they render/clean up.
+
+| Factory | Environment | Interactor injected | File |
+|---------|-------------|---------------------|------|
+| `createDomTestEngine(element, parts)` | Raw DOM (pre-rendered) | `DOMInteractor` | [dom-core/createDomTestEngine.ts](../packages/dom-core/src/createDomTestEngine.ts#L13) |
+| `createTestEngine(node, parts, opt?)` | React 18 / 19 | `ReactInteractor` (`createRoot`) | [react-18/createTestEngine.ts](../packages/react-18/src/createTestEngine.ts#L25) |
+| `createTestEngine(node, parts, opt?)` | React ≤17 | `ReactInteractor` (`ReactDOM.render`) | [react-legacy/createTestEngine.ts](../packages/react-legacy/src/createTestEngine.ts#L25) |
+| `createTestEngine(component, parts, opt?)` | Vue 3 | `VueInteractor` | [vue-3/createTestEngine.ts](../packages/vue-3/src/createTestEngine.ts#L50) |
+| `createTestEngine(page, parts)` | Playwright (browser) | `PlaywrightInteractor` | [playwright/createTestEngine.ts](../packages/playwright/src/createTestEngine.ts#L14) |
+| `createRenderedTestEngine(rootEl, parts)` | React/Vue, already rendered (e.g. Storybook) | React/Vue interactor | [react-18](../packages/react-18/src/createTestEngine.ts#L65), [vue-3](../packages/vue-3/src/createTestEngine.ts#L98) |
+
+`TestEngine`'s constructor is `(locator, interactor, option?, cleanUp?)` ([TestEngine.ts#L23-L31](../packages/core/src/TestEngine.ts#L23-L31)). DOM/Playwright engines use an empty `[]` root locator; React/Vue engines tag their mount container with a `data-*` attribute and use `byAttribute(...)` as the root.
+
+## Layer stack
+
+```mermaid
+flowchart TD
+    Test["Test code"] --> Engine["TestEngine&lt;T&gt;<br/>(root ComponentDriver + cleanUp)"]
+    Engine --> Driver["ComponentDriver&lt;T&gt;<br/>semantic API: click / getValue / getText / waitUntil…"]
+    Driver --> Interactor["Interactor (interface)<br/>environment adapter"]
+    Driver --> Locator["PartLocator<br/>CSS selector chain"]
+    Interactor --> Env["DOM · React · Vue · Browser"]
+    Locator -. "locatorUtil.toCssSelector()" .-> Interactor
+```
+
+A driver never touches the environment directly — it delegates every action to its injected `Interactor`, passing a `PartLocator`. The interactor resolves the locator to a runtime CSS selector via `locatorUtil.toCssSelector(locator, this)` and acts on it ([ComponentDriver.ts#L138-L251](../packages/core/src/drivers/ComponentDriver.ts#L138-L251), [DOMInteractor.ts#L379-L391](../packages/dom-core/src/DOMInteractor.ts#L379-L391)).
+
+### Part tree construction
+
+When a driver is constructed, `getPartFromDefinition` walks its `ScenePart` and instantiates a child driver per entry, chaining each child's locator onto the parent's ([driverUtil.ts](../packages/core/src/drivers/driverUtil.ts#L7-L48)):
+
+1. `locatorContext = driver.prototype.overriddenParentLocator() ?? parentLocator` — lets portal components escape their parent.
+2. `actualLocator = overrideLocatorRelativePosition()` applied if the driver overrides it.
+3. `componentLocator = locatorUtil.append(locatorContext, actualLocator)`.
+4. `new DriverCtor(componentLocator, interactor, option)`.
+
+This is eager and synchronous: the entire driver tree exists after `createTestEngine` returns.
+
+## Interactor inheritance
+
+```mermaid
+flowchart TD
+    I["interface Interactor"]
+    DOM["DOMInteractor<br/>(@testing-library/dom + user-event + FakeMouseEvent)"]
+    React["ReactInteractor<br/>wraps each method in act()"]
+    Vue["VueInteractor<br/>awaits nextTick() after each method"]
+    PW["PlaywrightInteractor<br/>page.locator(css).&lt;action&gt;()"]
+    I -. implements .-> DOM
+    I -. implements .-> PW
+    DOM --> React
+    DOM --> Vue
+```
+
+- **`DOMInteractor`** implements `Interactor` over `@testing-library/dom`'s `fireEvent`, `@testing-library/user-event`, and a `FakeMouseEvent` polyfill (testing-library drops `pageX/pageY`). `getElement` runs `rootEl.querySelector(All)` on the resolved selector ([DOMInteractor.ts#L32-L391](../packages/dom-core/src/DOMInteractor.ts#L32-L391)).
+- **`ReactInteractor extends DOMInteractor`** and `override`s every interactive method to wrap `super.*` in `act(async () => …)`, flushing React state updates ([ReactInteractor.ts](../packages/react-core/src/ReactInteractor.ts#L22-L127)).
+- **`VueInteractor extends DOMInteractor`** and `override`s each method to call `super.*` then `await nextTick()`, flushing Vue reactivity ([VueInteractor.ts](../packages/vue-3/src/VueInteractor.ts#L22-L114)).
+- **`PlaywrightInteractor implements Interactor` directly** — it does **not** extend `DOMInteractor`. Every method resolves the locator to CSS and calls `page.locator(css).<action>()`; Playwright handles waiting/retrying natively, so there is no `act()`/`nextTick()` ([PlaywrightInteractor.ts](../packages/playwright/src/PlaywrightInteractor.ts#L31-L324)). See [ADR-002](adr/002-interactor-abstraction.md).
+
+Key behavior differences to remember:
+- React/Vue interactors `clone()` to their own subclass (`new ReactInteractor(this.rootEl)`); the base `rootEl` is `protected` ([DOMInteractor.ts#L33](../packages/dom-core/src/DOMInteractor.ts#L33), [ReactInteractor.ts#L124-L126](../packages/react-core/src/ReactInteractor.ts#L124-L126)).
+- `PlaywrightInteractor.isVisible` wraps style reads in try/catch to tolerate elements detaching mid-animation ([PlaywrightInteractor.ts#L259-L297](../packages/playwright/src/PlaywrightInteractor.ts#L259-L297)); `DOMInteractor.isVisible` does not ([DOMInteractor.ts#L456-L478](../packages/dom-core/src/DOMInteractor.ts#L456-L478)).
+
+## createTestEngine variants — what actually differs
+
+| Aspect | react-18 / react-19 | react-legacy | vue-3 |
+|--------|---------------------|--------------|-------|
+| Render API | `createRoot(container).render(node)` in `act()` | `ReactDOM.render(node, container)` in `act()` | `@testing-library/vue` `render()`, falls back to `createApp().mount()` |
+| `act` source | `@testing-library/react` | `react-dom/test-utils` | n/a (uses `nextTick`) |
+| Unmount | `root.unmount()` in `act()` | `ReactDOM.unmountComponentAtNode` | `renderResult.unmount()` / `app.unmount()` |
+| Root marker attribute | `data-atomic-testing-react` | `data-atomic-testing-react-legacy` | `data-atomic-testing-vue` |
+| Input node type | `ReactNode` | `ReactElement` | `Component \| VueSFCLikeComponent` |
+
+`react-18` and `react-19` are byte-for-byte equivalent in implementation (both target the `createRoot` API); they exist as separate packages only to pin different React peer ranges. See [ADR-003](adr/003-version-specific-packages.md). Option types `IReactTestEngineOption` / `IVueTestEngineOption` both add an optional `rootElement` mount target ([react-18/types.ts](../packages/react-18/src/types.ts#L3), [vue-3/types.ts](../packages/vue-3/src/types.ts#L3)).
+
+## Package dependency graph
+
+```mermaid
+flowchart TD
+    core["core"]
+    domcore["dom-core"]
+    reactcore["react-core"]
+    r18["react-18"]
+    r19["react-19"]
+    rlegacy["react-legacy"]
+    vue["vue-3"]
+    pw["playwright"]
+    itr["internal-test-runner"]
+    jest["…-jest-adapter"]
+    vitest["…-vitest-adapter"]
+    html["component-driver-html"]
+    mui["component-driver-mui-v5/6/7"]
+    muix["component-driver-mui-x-v5..v8"]
+
+    core --> domcore
+    domcore --> reactcore
+    reactcore --> r18
+    reactcore --> r19
+    reactcore --> rlegacy
+    core --> vue
+    domcore --> vue
+    core --> pw
+    itr --> pw
+    core --> itr
+    itr --> jest
+    itr --> vitest
+    core --> html
+    html --> mui
+    domcore --> mui
+    r18 --> mui
+    html --> muix
+    mui --> muix
+```
+
+Edges are "depends on" (arrow points from dependency to dependent). Notable real edges from `package.json`:
+- `component-driver-mui-v7` depends on `react-18` (and `@mui/material@^7`, `component-driver-html`, `core`, `dom-core`) ([mui-v7/package.json#L25-L33](../packages/component-driver-mui-v7/package.json#L25-L33)).
+- `component-driver-mui-x-v8` depends on `component-driver-mui-v6` (plus `component-driver-html`, `core`) ([mui-x-v8/package.json#L40-L45](../packages/component-driver-mui-x-v8/package.json#L40-L45)). [inferred] other mui-x versions pair with their contemporaneous mui-v* package — confirm in each `package.json`.
+- `playwright` depends on `internal-test-runner` and `core` only; `@playwright/test` is a peer ([playwright/package.json#L31-L37](../packages/playwright/package.json#L31-L37)).
+
+## The shared three-file test pattern
+
+One test suite runs unchanged in Jest (jsdom), Vitest, and Playwright. This is the project's signature pattern (see [ADR-004](adr/004-shared-three-file-test-pattern.md)).
+
+```mermaid
+flowchart LR
+    suite["*.suite.ts<br/>TestSuiteInfo: title, url, tests(getTestEngine, mapper)"]
+    suite --> dom["*.dom.test.ts<br/>testRunner(suite, jestTestAdapter, { getTestEngine: react createTestEngine })"]
+    suite --> e2e["*.e2e.test.ts<br/>testRunner(suite, playWrightTestFrameworkMapper, getTestRunnerInterface())"]
+    dom --> jestmap["jestTestAdapter / vitestAdapter"]
+    e2e --> pwmap["playWrightTestFrameworkMapper"]
+    jestmap --> react["ReactInteractor → DOM"]
+    pwmap --> pwi["PlaywrightInteractor → Browser"]
+```
+
+Mechanism:
+- **`TestSuiteInfo<T>`** = `{ title?, url, tests(getTestEngine, mapper) }` ([types.ts#L114-L121](../packages/internal-test-runner/src/types.ts#L114-L121)). `url` is where the E2E runner navigates in `beforeEach`; DOM runs ignore it.
+- **`testRunner(suite|suites, mapper, interactionInterface)`** wraps each suite in `mapper.describe`, installs a `beforeEach` that detects Jest's done-callback vs Playwright's fixture by inspecting `arguments[0]`, and calls `goto(url)` for E2E interfaces before invoking `suite.tests(getTestEngine, mapper)` ([testRunner.ts](../packages/internal-test-runner/src/testRunner.ts#L7-L50)).
+- **`TestFrameworkMapper`** normalizes assertions + lifecycle across runners: `assertEqual/assertNotEqual/assertTrue/assertFalse/assertApproxEqual`, `describe/test/it`, `beforeEach/afterEach/beforeAll/afterAll` ([types.ts#L72-L88](../packages/internal-test-runner/src/types.ts#L72-L88)). Adapters: `jestTestAdapter` (`@jest/globals`), `vitestAdapter` (`vitest`), `playWrightTestFrameworkMapper` (`@playwright/test`).
+- **`useTestEngine(scenePart, getTestEngine, { beforeEach, afterEach })`** builds the engine in `beforeEach` (passing `{ page }` for E2E) and calls `cleanUp()` in `afterEach`; returns a getter `engine()` ([useTestEngine.ts](../packages/internal-test-runner/src/useTestEngine.ts#L21-L46)).
+
+See [modules/test-runner.md](modules/test-runner.md) for the worked three-file example and the `CLAUDE.md` quickstart.
+
+## Cross-cutting concerns
+
+- **Reactivity sync** — handled per-environment by the interactor (`act()` / `nextTick()` / Playwright auto-wait), so test code stays identical. See interactor inheritance above.
+- **Waiting / timing** — two tools: `waitUntilComponentState` (state-based, throws on timeout) and `waitUntil` (probe-based, returns last value). Probe interval = `timeoutMs / probeCount` (default 10 probes) ([timingUtil.ts#L42-L81](../packages/core/src/utils/timingUtil.ts#L42-L81)).
+- **Portal / overlay components** — modeled with `overriddenParentLocator()` + `overrideLocatorRelativePosition()` returning a `Root` locator, e.g. `byRole('presentation', 'Root')` in `MenuDriver`/`DialogDriver` ([MenuDriver.ts#L24-L41](../packages/component-driver-mui-v7/src/components/MenuDriver.ts#L24-L41), [DialogDriver.ts#L25-L44](../packages/component-driver-mui-v7/src/components/DialogDriver.ts#L25-L44)).
+- **Error reporting** — failures throw typed errors carrying the locator or driver (see [DOMAIN.md → Failure modes](DOMAIN.md#failure-modes-error-catalog)); `driverName` identifies the offending driver.
+
+## Key design decisions
+
+| Decision | Rationale | ADR |
+|----------|-----------|-----|
+| Semantic component-driver API over raw queries | Tests read in domain terms; selectors live in one place | [ADR-001](adr/001-component-driver-pattern.md) |
+| `Interactor` abstraction | One driver runs across DOM/React/Vue/Playwright | [ADR-002](adr/002-interactor-abstraction.md) |
+| Version-specific packages (mui-v5/6/7, react-18/19/legacy) | Isolate framework-major DOM/API differences from consumers | [ADR-003](adr/003-version-specific-packages.md) |
+| Shared `*.suite.ts` + `TestFrameworkMapper` | Author once, run in Jest/Vitest/Playwright | [ADR-004](adr/004-shared-three-file-test-pattern.md) |

--- a/agent-docs/DOMAIN.md
+++ b/agent-docs/DOMAIN.md
@@ -1,0 +1,128 @@
+# Atomic Testing — Domain
+
+Vocabulary, type system, and invariants for the `atomic-testing` library. Read this first; every other doc uses these terms. Source citations point at `../packages/...`.
+
+## Glossary
+
+| Term | Definition | Code Reference |
+|------|-----------|----------------|
+| **TestEngine** | Root driver for a test scene. A `ComponentDriver` plus a `cleanUp()` hook. Created per-environment by a `createTestEngine` factory. | [TestEngine.ts](../packages/core/src/TestEngine.ts#L12) |
+| **ComponentDriver** | Base class exposing a semantic API (`click`, `getText`, `exists`, `hover`, `waitUntilComponentState`, …) over one component, plus typed access to its child `parts`. | [ComponentDriver.ts](../packages/core/src/drivers/ComponentDriver.ts#L25) |
+| **ContainerDriver** | A `ComponentDriver` that also exposes `content` parts — for components whose inner DOM is dynamic or portal-rendered (dialogs, popovers). | [ContainerDriver.ts](../packages/core/src/drivers/ContainerDriver.ts#L13) |
+| **ListComponentDriver** | A `ComponentDriver` for repeated, indefinite-length item collections; iterates items by `:nth-of-type`. | [ListComponentDriver.ts](../packages/core/src/drivers/ListComponentDriver.ts#L16) |
+| **Interactor** | Environment adapter interface. Performs the low-level actions a driver requests, against DOM, React, Vue, or Playwright. | [Interactor.ts](../packages/core/src/interactor/Interactor.ts#L26) |
+| **PartLocator** | How to find an element. Either a single `CssLocator` or a `CssLocator[]` chain. | [PartLocator.ts](../packages/core/src/locators/PartLocator.ts) |
+| **CssLocator** | A primitive selector + its relative position (`Root`/`Descendant`/`Same`) + source metadata. | [CssLocator.ts](../packages/core/src/locators/CssLocator.ts#L13) |
+| **LinkedCssLocator** | Experimental relational locator: match an element by an attribute extracted from another element. | [LinkedCssLocator.ts](../packages/core/src/locators/LinkedCssLocator.ts), [byLinkedElement.ts](../packages/core/src/locators/byLinkedElement.ts#L19) |
+| **ScenePart** | `Record<string, ScenePartDefinition>` — the declarative map of a component's named child parts. | [partTypes.ts](../packages/core/src/partTypes.ts#L119) |
+| **ScenePartDefinition** | One entry in a `ScenePart`: a `{ locator, driver, option? }` triple (component, container, or list variant). | [partTypes.ts](../packages/core/src/partTypes.ts#L111-L114) |
+| **`ScenePartDriver<T>`** | Computed type mapping each part name to its instantiated driver (`InstanceType<T[name]['driver']>`). | [partTypes.ts](../packages/core/src/partTypes.ts#L121-L123) |
+| **`IInputDriver<V>`** | Form-field driver contract: `getValue(): Promise<V>` + `setValue(v): Promise<boolean>`. | [driverTypes.ts](../packages/core/src/drivers/driverTypes.ts#L7) |
+| **driverName** | Abstract getter every driver implements; a human-readable id used in error messages and debugging. | [ComponentDriver.ts](../packages/core/src/drivers/ComponentDriver.ts#L253) |
+| **Interactor (clone)** | Interactors are cloneable (`clone()`), so a driver subtree can be re-bound to a fresh adapter. | [Interactor.ts](../packages/core/src/interactor/Interactor.ts#L152) |
+
+## Type system
+
+The whole library is organized around one idea: a **ScenePart declares structure**, and a
+**driver tree mirrors it**.
+
+```mermaid
+classDiagram
+    class ScenePart {
+      <<map of part definitions>>
+    }
+    class ScenePartDefinition {
+      <<union>>
+      ComponentPartDefinition
+      ContainerPartDefinition
+      ListComponentPartDefinition
+    }
+    class ComponentDriver~T~ {
+      +parts: ScenePartDriver~T~
+      +locator: PartLocator
+      +interactor: Interactor
+      +driverName: string
+    }
+    class ContainerDriver~ContentT,T~ {
+      +content: ScenePartDriver~ContentT~
+    }
+    class ListComponentDriver~ItemT~ {
+      +getItemByIndex()
+      +getItemByLabel()
+      +getItems()
+      +getItemCount()
+    }
+    class TestEngine~T~ {
+      +cleanUp()
+    }
+    ScenePart "1" o-- "*" ScenePartDefinition
+    ComponentDriver <|-- ContainerDriver
+    ComponentDriver <|-- ListComponentDriver
+    ComponentDriver <|-- TestEngine
+    ComponentDriver ..> ScenePart : typed by
+```
+
+- **`ScenePart`** is `Record<string, ScenePartDefinition>` ([partTypes.ts#L119](../packages/core/src/partTypes.ts#L119)). Author scene parts with `satisfies ScenePart` so literal key types are preserved.
+- **Three part-definition shapes** ([partTypes.ts#L41-L114](../packages/core/src/partTypes.ts#L41-L114)):
+  - `ComponentPartDefinition<T>` — `{ locator, driver, option? }`
+  - `ContainerPartDefinition<ContentT, T>` — adds required `content` (nested parts) + `option`
+  - `ListComponentPartDefinition<ItemT>` — adds `itemClass` + `itemLocator` via `ListComponentDriverSpecificOption`
+- **`ScenePartDriver<T>`** maps part names to driver instances using `InstanceType<T[partName]['driver']>` ([partTypes.ts#L121-L123](../packages/core/src/partTypes.ts#L121-L123)). This is why `engine.parts.email` is typed as the concrete driver you declared.
+- **Driver option types**: `IComponentDriverOption<T> = { parts: T }`; `IContainerDriverOption<ContentT,T>` adds `content: ContentT` ([partTypes.ts#L125-L134](../packages/core/src/partTypes.ts#L125-L134)).
+- **`ITestEngine<T> extends IComponentDriver<T>`** and adds `cleanUp()` ([partTypes.ts#L183-L185](../packages/core/src/partTypes.ts#L183-L185)).
+- **Intentional `any`**: `ComponentDriverClass`/`ComponentDriverCtor` constrain `T extends ComponentDriver<any>` for variance reasons — concrete driver classes must be assignable regardless of their `ScenePart` parameter ([partTypes.ts#L11-L39](../packages/core/src/partTypes.ts#L11-L39)). Do not "fix" these to stricter types.
+
+### Driver contracts (mixins)
+
+Drivers implement small capability interfaces from [driverTypes.ts](../packages/core/src/drivers/driverTypes.ts):
+
+| Interface | Members | Implemented by (example) |
+|-----------|---------|--------------------------|
+| `IFormFieldDriver<T>` | `getValue()` | base of input drivers |
+| `IInputDriver<T>` | `getValue()`, `setValue()` | `HTMLTextInputDriver`, `HTMLSelectDriver`, mui `SelectDriver` |
+| `IToggleDriver` | `isSelected()`, `setSelected()` | checkbox/switch drivers |
+| `IClickableDriver` | `click()` | `HTMLButtonDriver` |
+| `IMouseInteractableDriver` | `hover()` | `HTMLButtonDriver` |
+
+## Locator vocabulary
+
+A `PartLocator` is a `CssLocator` or an array of them ([PartLocator.ts](../packages/core/src/locators/PartLocator.ts)). Each `CssLocator` carries:
+
+- **`selector`** — the raw CSS string.
+- **`relative`** — `'Root' | 'Descendant' | 'Same'` ([LocatorRelativePosition.ts](../packages/core/src/locators/LocatorRelativePosition.ts#L4)), default `'Descendant'` ([CssLocator.ts#L14](../packages/core/src/locators/CssLocator.ts#L14)):
+  - `Descendant` → element is nested inside the parent (CSS descendant combinator).
+  - `Same` → the selector applies to the same element / no descendant hop (e.g. `:checked`, `:nth-of-type(n)`).
+  - `Root` → **resets** the chain; selectors from the `Root` element onward are used, ignoring the parent context. Used by portal-rendered components (dialog/menu) to escape their declared parent.
+- **`type`** — `'css'` (the only supported `LocatorType` today).
+- **`complexity`** — `'primitive'` for `CssLocator`, `'linked'` for `LinkedCssLocator`.
+
+Builders (all in [locators/](../packages/core/src/locators/index.ts)) produce `CssLocator`s — see [modules/core.md](modules/core.md#locators) for the full `by*` catalog.
+
+## Invariants
+
+- **Missing-element actions throw.** Every mutative `DOMInteractor` method (`click`, `enterText`, `focus`, mouse events, `selectOptionValue`) throws `ElementNotFoundError(locator, action)` when the element resolves to `null` ([DOMInteractor.ts#L82-L85](../packages/dom-core/src/DOMInteractor.ts#L82-L85)).
+- **`waitUntilComponentState` throws on timeout** (via `interactorUtil.interactorWaitUtil` → `WaitForFailureError`); **`waitUntil` does not** — it returns the last probed value even if the condition never matched ([timingUtil.ts#L42-L81](../packages/core/src/utils/timingUtil.ts#L42-L81)).
+- **`enforcePartExistence(names)` throws `MissingPartError`** if any named part is absent from the DOM ([ComponentDriver.ts#L97-L102](../packages/core/src/drivers/ComponentDriver.ts#L97-L102)).
+- **Locator-override hooks run before construction.** `overriddenParentLocator()` and `overrideLocatorRelativePosition()` are invoked on `driver.prototype` while building the part tree, so they **must not reference instance state** ([driverUtil.ts#L26-L30](../packages/core/src/drivers/driverUtil.ts#L26-L30), [ComponentDriver.ts#L57-L76](../packages/core/src/drivers/ComponentDriver.ts#L57-L76)).
+- **List items are positional.** `ListComponentDriver` / `listHelper` locate the *n*th item with `byCssSelector(':nth-of-type(n)', 'Same')` and stop at the first gap; non-item siblings between items break counting ([listHelper.ts#L21-L79](../packages/core/src/drivers/listHelper.ts#L21-L79)).
+- **Default wait** is `{ condition: 'attached', timeoutMs: 30000, debug: false }` ([WaitForOption.ts#L28-L32](../packages/core/src/drivers/WaitForOption.ts#L28-L32)). `waitUntilVisible()` defaults to a 10s timeout ([ComponentDriver.ts#L210](../packages/core/src/drivers/ComponentDriver.ts#L210)).
+- **Date-typed inputs are format-validated** before typing. `enterText` on an `<input type=date|datetime-local|time>` validates the string and throws a descriptive `Error` on mismatch ([DOMInteractor.ts#L325-L336](../packages/dom-core/src/DOMInteractor.ts#L325-L336), [dateUtil.ts](../packages/core/src/utils/dateUtil.ts#L86-L105)).
+
+## Failure modes (error catalog)
+
+All errors are exported from [core/src/errors/index.ts](../packages/core/src/errors/index.ts); each has a matching string id constant.
+
+| Error | Thrown when | Base |
+|-------|-------------|------|
+| `ElementNotFoundError` | a mutative interactor action targets a non-existent element | `InteractorErrorBase` (locator-scoped) |
+| `WaitForFailureError` | `waitUntilComponentState` times out before reaching the condition | `InteractorErrorBase` |
+| `MissingPartError` | `enforcePartExistence` finds a declared part absent | `ErrorBase` (driver-scoped) |
+| `TooManyMatchingElementError` | a single-element query matches more than one element | `ErrorBase` |
+| `ItemNotFoundError` | a list/item lookup fails | `ErrorBase` |
+| `MenuItemNotFoundError` / `MenuItemDisabledError` | MUI menu/select item missing or disabled | `ErrorBase` (in the mui driver packages) |
+
+## See also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — how these types connect at runtime (layer stack, interactor inheritance, shared-test pattern).
+- [modules/core.md](modules/core.md) — the full export surface and the `by*` locator catalog.
+- [adr/001-component-driver-pattern.md](adr/001-component-driver-pattern.md) — why drivers + scene parts.

--- a/agent-docs/INDEX.md
+++ b/agent-docs/INDEX.md
@@ -1,0 +1,51 @@
+# Atomic Testing — Documentation Index
+
+LLM-optimized docs for the `packages/` workspace of `atomic-testing` — a portable UI-testing library built on the component-driver pattern. Generated for future agents; source-cited throughout. (The repo-root `docs/` folder is the separate user-facing Docusaurus site.)
+
+| Document | Description |
+|----------|-------------|
+| [AGENTS.md](AGENTS.md) | Agent playbook — **read first**. Routing table, conventions, change workflows, build/test commands. |
+| [DOMAIN.md](DOMAIN.md) | Vocabulary, type system, invariants, error catalog. |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Entry points, layer stack, interactor inheritance, dependency graph, shared three-file test pattern. |
+
+## Modules
+
+| Module | Covers | Description |
+|--------|--------|-------------|
+| [core](modules/core.md) | `@atomic-testing/core` | Types, base drivers, `Interactor` interface, locators, errors, utils. |
+| [dom-core](modules/dom-core.md) | `@atomic-testing/dom-core` | `DOMInteractor` base implementation + `createDomTestEngine`. |
+| [framework-adapters](modules/framework-adapters.md) | `react-core`, `react-18`, `react-19`, `react-legacy`, `vue-3` | `ReactInteractor`/`VueInteractor` + per-environment `createTestEngine`. |
+| [playwright](modules/playwright.md) | `@atomic-testing/playwright` | `PlaywrightInteractor` + E2E runner glue. |
+| [test-runner](modules/test-runner.md) | `internal-test-runner` (+ jest/vitest adapters, `internal-react-example`) | `testRunner`, `useTestEngine`, `TestFrameworkMapper`. |
+| [component-driver-html](modules/component-driver-html.md) | `@atomic-testing/component-driver-html` | Native HTML element drivers; the canonical driver pattern. |
+| [component-driver-mui](modules/component-driver-mui.md) | `component-driver-mui-v5/v6/v7` | MUI core drivers (v7 reference; version-diff notes). |
+| [component-driver-mui-x](modules/component-driver-mui-x.md) | `component-driver-mui-x-v5..v8` (+ `internal-mui-x-test-fixture`) | DataGrid (all) + Date/Time pickers (v5 only). |
+
+## ADRs
+
+| ADR | Decision |
+|-----|----------|
+| [001](adr/001-component-driver-pattern.md) | Component-driver pattern with declarative scene parts. |
+| [002](adr/002-interactor-abstraction.md) | `Interactor` abstraction for environment portability. |
+| [003](adr/003-version-specific-packages.md) | Version-specific packages for React and MUI majors. |
+| [004](adr/004-shared-three-file-test-pattern.md) | Shared three-file test pattern via `TestFrameworkMapper`. |
+
+## Fresh repo tree
+
+```bash
+bash /Users/tangent.lin/.claude/skills/doc-gen/repo-tree.sh /Users/tangent.lin/Development/os/atomic-testing/packages
+```
+
+---
+
+### BRIEF vs CODE differences
+No `BRIEF.md` was provided for this run, so there is nothing to reconcile. All content is derived directly from source (cited as `../packages/...`).
+
+### Open questions
+Residual ambiguities documentation could not fully resolve from code alone:
+
+1. **MUI-X version → MUI-core dependency mapping** — confirmed only for `mui-x-v8 → mui-v6` ([package.json](../packages/component-driver-mui-x-v8/package.json#L40-L45)); the pairing for v5/v6/v7 is [inferred]. Verify each `package.json` if it matters.
+2. **Why datepicker drivers stop at MUI-X v5** — only v5 exports them; intent (deprecation? not-yet-ported?) is not stated in code.
+3. **`react-legacy` `act` import** — it uses `react-dom/test-utils` rather than `@testing-library/react`; presumably for React ≤17 compatibility, but the reason isn't documented in-repo.
+4. **`DataGridProDriver` exact method set per MUI-X version** — characterized at a high level; confirm precise signatures in each version's `DataGridProDriver.ts` before relying on a specific method.
+5. **`internal-test-runner` stability** — treated as workspace-private/experimental; the intended stable public API (if any) is not declared.

--- a/agent-docs/adr/001-component-driver-pattern.md
+++ b/agent-docs/adr/001-component-driver-pattern.md
@@ -1,0 +1,41 @@
+# ADR-001: Component-driver pattern with declarative scene parts
+
+## Status
+
+Accepted (describes the existing design; reconstructed from code).
+
+## Context
+
+UI tests that query the DOM directly (raw selectors, `getByTestId` scattered through test bodies) are brittle and duplicate selector knowledge across every test. Selector churn forces edits in many places, and tests read in DOM terms rather than domain terms.
+
+## Decision
+
+Model each component as a **driver** exposing a semantic API, and declare a component's structure as a **`ScenePart`** map of named child parts. A driver:
+
+- extends `ComponentDriver<T>` (or `ContainerDriver`/`ListComponentDriver`) ([ComponentDriver.ts](../../packages/core/src/drivers/ComponentDriver.ts#L25)),
+- declares `parts` via `{ locator, driver }` entries (`satisfies ScenePart`) ([partTypes.ts](../../packages/core/src/partTypes.ts#L111-L123)),
+- exposes intent-level methods (`getValue`, `selectByLabel`, `isOpen`, …),
+- and implements `driverName` for diagnostics.
+
+The driver tree is built eagerly from the scene parts at construction (`getPartFromDefinition`) so `engine.parts.x.parts.y` is fully typed and ready ([driverUtil.ts](../../packages/core/src/drivers/driverUtil.ts#L7-L48)).
+
+## Consequences
+
+- ✅ Tests read in domain terms; selectors live in one driver, not in every test.
+- ✅ Composability: complex drivers (MUI `SelectDriver`) reuse leaf drivers (`HTMLButtonDriver`, `HTMLTextInputDriver`).
+- ✅ Strong typing end-to-end via `ScenePartDriver<T>` mapped types.
+- ⚠️ Some `any` is unavoidable in driver-class generics for variance ([partTypes.ts#L11-L39](../../packages/core/src/partTypes.ts#L11-L39)).
+- ⚠️ The part tree is eager — every declared part is instantiated even if a test never touches it (cheap: construction does no DOM work, only locator chaining).
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| Raw queries / Testing-Library calls inline | Selector duplication, DOM-level test reading, brittle to markup change |
+| Page Object Model (hand-rolled per app) | No shared abstraction or typing; reinvented per project; no cross-environment reuse |
+| Snapshot testing | Doesn't express interaction/intent; noisy diffs |
+
+## Related
+
+- [DOMAIN.md → Type system](../DOMAIN.md#type-system), [modules/core.md](../modules/core.md), [modules/component-driver-html.md](../modules/component-driver-html.md).
+- Enables [ADR-002](002-interactor-abstraction.md) (the driver delegates to a swappable interactor).

--- a/agent-docs/adr/002-interactor-abstraction.md
+++ b/agent-docs/adr/002-interactor-abstraction.md
@@ -1,0 +1,39 @@
+# ADR-002: `Interactor` abstraction for environment portability
+
+## Status
+
+Accepted (describes the existing design).
+
+## Context
+
+The same component drivers should run in multiple environments — jsdom (Jest), React/Vue rendering, and a real browser (Playwright) — without rewriting test logic. Each environment performs low-level actions (click, type, query) differently and has different async/reactivity semantics.
+
+## Decision
+
+Define a single `Interactor` interface ([Interactor.ts](../../packages/core/src/interactor/Interactor.ts#L26)) covering all low-level operations (mutative, read-only, debug). Drivers depend only on this interface and pass a `PartLocator`; they never touch the environment. Each environment provides an implementation:
+
+- `DOMInteractor implements Interactor` — testing-library/user-event over jsdom ([DOMInteractor.ts](../../packages/dom-core/src/DOMInteractor.ts#L32)).
+- `ReactInteractor extends DOMInteractor` — wraps each action in `act()` ([ReactInteractor.ts](../../packages/react-core/src/ReactInteractor.ts#L22)).
+- `VueInteractor extends DOMInteractor` — awaits `nextTick()` after each action ([VueInteractor.ts](../../packages/vue-3/src/VueInteractor.ts#L22)).
+- `PlaywrightInteractor implements Interactor` **directly** (not a `DOMInteractor` subclass) — uses Playwright's auto-waiting locator API ([PlaywrightInteractor.ts](../../packages/playwright/src/PlaywrightInteractor.ts#L31)).
+
+The right implementation is injected by the environment's `createTestEngine`.
+
+## Consequences
+
+- ✅ One driver codebase runs across DOM/React/Vue/Playwright; a shared `*.suite.ts` runs as both DOM and E2E ([ADR-004](004-shared-three-file-test-pattern.md)).
+- ✅ Reactivity handling is centralized in the interactor, keeping tests identical.
+- ⚠️ The interface is the contract: a **new `Interactor` method must be implemented in every standalone implementation** — `DOMInteractor` subclasses inherit it, but `PlaywrightInteractor` does not and must add it explicitly.
+- ⚠️ Behavioral parity isn't free: e.g. `isVisible` has extra detach-handling in Playwright but not DOM ([PlaywrightInteractor.ts#L259-L297](../../packages/playwright/src/PlaywrightInteractor.ts#L259-L297) vs [DOMInteractor.ts#L456-L478](../../packages/dom-core/src/DOMInteractor.ts#L456-L478)); some events are emulated differently per environment.
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| One implementation per environment with no shared interface | No driver reuse; logic duplicated per environment |
+| Make Playwright extend `DOMInteractor` | Playwright's model (browser-side, auto-wait) doesn't match jsdom's synchronous DOM; forcing inheritance would fight both |
+| Compile-time environment switch | Loses runtime flexibility (same suite, two runners) and complicates packaging |
+
+## Related
+
+- [ARCHITECTURE.md → Interactor inheritance](../ARCHITECTURE.md#interactor-inheritance), [modules/dom-core.md](../modules/dom-core.md), [modules/playwright.md](../modules/playwright.md).

--- a/agent-docs/adr/003-version-specific-packages.md
+++ b/agent-docs/adr/003-version-specific-packages.md
@@ -1,0 +1,44 @@
+# ADR-003: Version-specific packages for React and MUI
+
+## Status
+
+Accepted (describes the existing design).
+
+## Context
+
+Two dependencies make breaking changes across major versions in ways that affect this library:
+
+- **React** changes its render/unmount API (React ≤17 `ReactDOM.render`; React 18+ `createRoot`) and which module exports `act`.
+- **MUI** changes rendered DOM: class names, ARIA roles (e.g. Select's trigger role changed from `button` to `combobox` at 5.12, noted in [SelectDriver.ts#L29](../../packages/component-driver-mui-v7/src/components/SelectDriver.ts#L29)), and nesting.
+
+A single package trying to support all majors would need runtime branching on framework version and would couple consumers to versions they don't use.
+
+## Decision
+
+Ship one package per major version:
+
+- React adapters: `react-legacy` (≤17), `react-18`, `react-19` ([createTestEngine variants](../ARCHITECTURE.md#createtestengine-variants--what-actually-differs)).
+- MUI-core drivers: `component-driver-mui-v5` / `-v6` / `-v7`.
+- MUI-X drivers: `component-driver-mui-x-v5` … `-v8`.
+
+Consumers install the package matching their framework major; each pins the appropriate peer range.
+
+## Consequences
+
+- ✅ No runtime version branching; selectors/APIs are correct for one major.
+- ✅ Consumers pull only the version they use.
+- ✅ A MUI-major DOM change is fixed in one package without risk to others.
+- ⚠️ **Code duplication**: mui-v5/v6/v7 are ~95% identical; a cross-cutting fix or new driver must be replicated across version packages. `react-18` and `react-19` are implementation-identical.
+- ⚠️ Cross-package coupling exists where a driver package depends on a specific adapter (`mui-v7` → `react-18`; `mui-x-v8` → `mui-v6`) — see [ARCHITECTURE.md dependency graph](../ARCHITECTURE.md#package-dependency-graph).
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| Single package + runtime version detection | Branchy, fragile selector logic; ships dead code for unused majors |
+| Single package + peer-dep range spanning majors | Cannot encode per-major DOM/role/class differences |
+| Codegen one source → version variants | Added build complexity; not adopted (variants are maintained directly) |
+
+## Related
+
+- [modules/framework-adapters.md](../modules/framework-adapters.md), [modules/component-driver-mui.md](../modules/component-driver-mui.md), [modules/component-driver-mui-x.md](../modules/component-driver-mui-x.md).

--- a/agent-docs/adr/004-shared-three-file-test-pattern.md
+++ b/agent-docs/adr/004-shared-three-file-test-pattern.md
@@ -1,0 +1,38 @@
+# ADR-004: Shared three-file test pattern via `TestFrameworkMapper`
+
+## Status
+
+Accepted (describes the existing design).
+
+## Context
+
+The library must prove its drivers behave the same in unit (jsdom) and end-to-end (browser) environments. Writing two separate test suites for the same component would double maintenance and risk drift between what unit and E2E tests assert.
+
+## Decision
+
+Author each component's tests **once** as a framework-agnostic `TestSuiteInfo` in a `*.suite.ts`, then run it through thin adapters:
+
+- `*.suite.ts` — `TestSuiteInfo<T>` with `{ title, url, tests(getTestEngine, mapper) }` ([types.ts#L114](../../packages/internal-test-runner/src/types.ts#L114)). Test bodies use the normalized `TestFrameworkMapper` assertions/hooks and a `getTestEngine` callback.
+- `*.dom.test.ts` — `testRunner(suite, jestTestAdapter, { getTestEngine: react createTestEngine })`.
+- `*.e2e.test.ts` — `testRunner(suite, playWrightTestFrameworkMapper, getTestRunnerInterface())`.
+
+`TestFrameworkMapper` ([types.ts#L72](../../packages/internal-test-runner/src/types.ts#L72)) normalizes assertions (`assertEqual`, `assertApproxEqual`, …) and lifecycle (`describe`/`test`/hooks) across Jest, Vitest, and Playwright. `testRunner` ([testRunner.ts](../../packages/internal-test-runner/src/testRunner.ts#L7)) installs a `beforeEach` that distinguishes Jest's done-callback from Playwright's fixture at runtime (via `arguments[0]`) and navigates to `url` for E2E. `useTestEngine` ([useTestEngine.ts](../../packages/internal-test-runner/src/useTestEngine.ts#L21)) manages per-test engine creation + `cleanUp`.
+
+## Consequences
+
+- ✅ One suite verifies both unit and E2E behavior — no drift, half the maintenance.
+- ✅ Adding a runner (Vitest was added) is one new adapter, no suite changes.
+- ⚠️ Runner signatures genuinely differ, so adapters/`testRunner` carry intentional `@ts-ignore`/`@ts-expect-error` and `arguments`-based dispatch — these are load-bearing; preserve them ([jest-adapter](../../packages/internal-test-runner-jest-adapter/src/index.ts#L20-L29), [testRunnerAdapter.ts#L41-L69](../../packages/playwright/src/testRunnerAdapter.ts#L41-L69)).
+- ⚠️ Suite code is constrained to the mapper's surface (no runner-specific matchers).
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| Separate Jest and Playwright suites | Duplication; unit/E2E assertions drift |
+| Standardize on one runner | Loses either fast jsdom unit runs or real-browser fidelity |
+| A heavier cross-runner framework | Overkill; the mapper is a few dozen lines and dependency-free |
+
+## Related
+
+- [ARCHITECTURE.md → shared three-file test pattern](../ARCHITECTURE.md#the-shared-three-file-test-pattern), [modules/test-runner.md](../modules/test-runner.md), [modules/playwright.md](../modules/playwright.md). The project `CLAUDE.md` documents this pattern for contributors.

--- a/agent-docs/modules/component-driver-html.md
+++ b/agent-docs/modules/component-driver-html.md
@@ -1,0 +1,75 @@
+# Module: component-driver-html (`@atomic-testing/component-driver-html`)
+
+## Purpose
+
+Drivers for native HTML elements. These are the lowest-level concrete drivers and the building blocks the MUI drivers compose (the mui packages import `HTMLButtonDriver`, `HTMLElementDriver`, etc.). Depends only on `@atomic-testing/core`.
+
+## Public surface
+
+Barrel: [component-driver-html/src/index.ts](../../packages/component-driver-html/src/index.ts).
+
+| Driver | Targets | Implements |
+|--------|---------|------------|
+| `HTMLElementDriver` | any element (generic `div`/`span`/container) | `ComponentDriver<{}>` |
+| `HTMLAnchorDriver` | `<a>` | clickable link |
+| `HTMLButtonDriver` | `<button>` | `IClickableDriver`, `IMouseInteractableDriver` |
+| `HTMLTextInputDriver` | `<input>` (text/date/time/etc.) | `IInputDriver<string \| null>` |
+| `HTMLTextAreaDriver` | `<textarea>` | `IInputDriver<string \| null>` |
+| `HTMLSelectDriver` | `<select>` (native) | `IInputDriver<Nullable<string \| readonly string[]>>` |
+| `HTMLOptionDriver` | `<option>` | label/value reads |
+| `HTMLCheckboxDriver` | `<input type=checkbox>` | toggle |
+| `HTMLCheckboxGroupDriver` | a set of checkboxes | group selection |
+| `HTMLRadioButtonGroupDriver` | a set of radios | group selection |
+| `HTMLHiddenInputDriver` | `<input type=hidden>` | value read |
+
+## Responsibilities
+
+- Wrap a single native element/group with a semantic API.
+- Delegate every operation to the injected `Interactor` (so they run unchanged in DOM/React/Vue/Playwright).
+
+## Non-goals
+
+- No framework-component knowledge (that's the MUI packages).
+- No rendering — drivers operate on whatever the test engine resolves.
+
+## How it works — the canonical driver pattern
+
+A driver extends `ComponentDriver<parts>`, optionally implements a capability interface, passes `parts` to `super`, and implements `driverName`.
+
+**Leaf input driver** — `HTMLTextInputDriver` ([HTMLTextInputDriver.ts](../../packages/component-driver-html/src/components/HTMLTextInputDriver.ts#L3-L54)):
+```ts
+export class HTMLTextInputDriver extends ComponentDriver<{}> implements IInputDriver<string | null> {
+  constructor(locator, interactor, option?) { super(locator, interactor, { ...option, parts: {} }); }
+  async getValue() { return (await this.interactor.getInputValue(this.locator)) ?? null; }
+  async setValue(v) { await this.interactor.enterText(this.locator, v ?? ''); return true; }
+  isDisabled() { return this.interactor.isDisabled(this.locator); }
+  isReadonly() { return this.interactor.isReadonly(this.locator); }
+  get driverName() { return 'HTMLTextInput'; }
+}
+```
+
+**Driver that iterates children** — `HTMLSelectDriver` ([HTMLSelectDriver.ts](../../packages/component-driver-html/src/components/HTMLSelectDriver.ts#L16-L116)): implements `IInputDriver`, plus `isMultiple`, `getValuesByLabels`, `selectByLabel`, `getSelectedLabel` (overloaded for single/multi). It iterates `<option>`s with `listHelper.getListItemIterator(this, append(locator, byTagName('option')), HTMLOptionDriver)` and reads each via `HTMLOptionDriver` ([L56-L68](../../packages/component-driver-html/src/components/HTMLSelectDriver.ts#L56-L68)).
+
+**Pure capability driver** — `HTMLButtonDriver` implements `IClickableDriver`, `IMouseInteractableDriver` (inheriting `click`/`hover` from `ComponentDriver`) and adds `isDisabled` ([HTMLButtonDriver.ts](../../packages/component-driver-html/src/components/HTMLButtonDriver.ts#L3-L20)).
+
+## Key types
+
+Drivers extend `ComponentDriver` and implement contracts from [driverTypes.ts](../../packages/core/src/drivers/driverTypes.ts) — see [DOMAIN.md → Driver contracts](../DOMAIN.md#driver-contracts-mixins).
+
+## Invariants & failure modes
+
+- `setValue` on a date-typed input must use the documented format (`yyyy-MM-dd`, `HH:mm`, `yyyy-MM-ddTHH:mm`); the interactor validates and throws otherwise ([HTMLTextInputDriver.ts#L23-L32](../../packages/component-driver-html/src/components/HTMLTextInputDriver.ts#L23-L32), [DOMAIN.md invariants](../DOMAIN.md#invariants)).
+- `HTMLSelectDriver.getValue` returns an array when the `<select multiple>`, else the first value, else `null` ([L31-L36](../../packages/component-driver-html/src/components/HTMLSelectDriver.ts#L31-L36)).
+
+## Extension points — add an HTML driver
+
+1. Create `src/components/HTMLXDriver.ts`, `extends ComponentDriver<{}>` (or declare `parts` if it has children).
+2. Implement the relevant capability interface(s) and `driverName`.
+3. Delegate to `this.interactor` / `this.parts`; reuse `listHelper` for repeated children.
+4. Export from [index.ts](../../packages/component-driver-html/src/index.ts).
+
+## Related files
+
+- [HTMLSelectDriver.ts](../../packages/component-driver-html/src/components/HTMLSelectDriver.ts) — child-iteration example.
+- [modules/core.md](core.md) — `ComponentDriver`, `listHelper`, locators.
+- [adr/001-component-driver-pattern.md](../adr/001-component-driver-pattern.md) — the pattern's rationale.

--- a/agent-docs/modules/component-driver-mui-x.md
+++ b/agent-docs/modules/component-driver-mui-x.md
@@ -1,0 +1,61 @@
+# Module group: MUI-X component drivers (v5 / v6 / v7 / v8)
+
+Drivers for Material-UI X components (DataGrid, and Date/Time Pickers), one package per MUI-X major:
+
+| Package | DataGrid | Date/Time pickers |
+|---------|----------|-------------------|
+| `@atomic-testing/component-driver-mui-x-v5` | ✅ | ✅ ([datepicker/](../../packages/component-driver-mui-x-v5/src/components/datepicker/index.ts)) |
+| `@atomic-testing/component-driver-mui-x-v6` | ✅ | — |
+| `@atomic-testing/component-driver-mui-x-v7` | ✅ | — |
+| `@atomic-testing/component-driver-mui-x-v8` | ✅ | — |
+
+> Only **v5** ships datepicker drivers; v6–v8 are DataGrid-only ([v5/index.ts](../../packages/component-driver-mui-x-v5/src/index.ts) re-exports both `datagrid` and `datepicker`; [v8/index.ts](../../packages/component-driver-mui-x-v8/src/index.ts) re-exports only `datagrid`). [inferred] datepicker drivers were not carried forward past v5.
+
+## Public surface
+
+DataGrid (all versions) — barrel `components/datagrid/index.ts`, e.g. [v8](../../packages/component-driver-mui-x-v8/src/components/datagrid/index.ts):
+- `DataGridProDriver` — the grid driver
+- `DataGridDataRowDriver` — a data row
+- `DataGridHeaderRowDriver` — the header row
+- `DataGridCellQuery` — cell-location query helper (by row + column index/field)
+
+Date/Time pickers (v5 only) — [datepicker/index.ts](../../packages/component-driver-mui-x-v5/src/components/datepicker/index.ts): `DateRangePickerDriver`, `DateTimePickerDriver`, `DesktopDatePickerDriver`, `MobileDatePickerDriver`, `MobileDatePickerDialogDriver`, `TimePickerDriver`, plus a `dateUtil` namespace and shared `types`.
+
+## Responsibilities
+
+- Drive virtualized/complex MUI-X widgets (grids render only visible rows; cells are located positionally).
+- Provide column/row/cell read helpers over the DataGrid DOM.
+
+## Non-goals
+
+- No grid data modeling — test data comes from the fixture package (below).
+- Pickers are v5-only; do not assume them in v6+.
+
+## How it works
+
+`DataGridProDriver extends ComponentDriver` with header-row and loading parts; it exposes `isLoading`/`waitForLoad`, `getColumnCount`/`getHeaderText`, `getRowCount`/`getRow`/`getRowText`, and `getCell`/`getCellText`, locating cells via `DataGridCellQuery` and iterating visible rows with `listHelper` (handles virtualization). [inferred from cross-version structure; confirm exact methods in the target version's `DataGridProDriver.ts`.]
+
+## Test fixture — `@atomic-testing/internal-mui-x-test-fixture`
+
+Shared grid config + data for DataGrid driver tests/examples ([src/index.ts](../../packages/internal-mui-x-test-fixture/src/index.ts) re-exports `gridConfig` + `gridData`):
+- `gridConfig` — `initialState` (column visibility) and `basicGridColumnConfig` (field, headerName, type, valueOptions, width, editable) ([gridConfig.ts](../../packages/internal-mui-x-test-fixture/src/gridConfig.ts)).
+- `gridData` — a commodity-trading dataset (desk, commodity, trader, quantity, status, prices, dates, broker, counterparty, etc.) ([gridData.ts](../../packages/internal-mui-x-test-fixture/src/gridData.ts)).
+
+This is a workspace-private dev dependency, not a published consumer API.
+
+## Invariants & failure modes
+
+- DataGrid is virtualized: only rendered rows are queryable; scroll/paginate before asserting off-screen rows.
+- Picker drivers exist only in v5 — referencing them from v6+ will not resolve.
+
+## Extension points
+
+- **Port DataGrid to a new MUI-X major** → copy the `datagrid/` folder, adjust selectors/classes for the new grid DOM, re-export from the package `index.ts`.
+- **New cell/row helper** → add to `DataGridProDriver`/`DataGridDataRowDriver` and reuse `DataGridCellQuery`.
+
+## Related files
+
+- [v8 datagrid barrel](../../packages/component-driver-mui-x-v8/src/components/datagrid/index.ts)
+- [v5 datepicker barrel](../../packages/component-driver-mui-x-v5/src/components/datepicker/index.ts)
+- [internal-mui-x-test-fixture](../../packages/internal-mui-x-test-fixture/src/index.ts)
+- [modules/component-driver-mui.md](component-driver-mui.md) — sibling MUI-core drivers; same version-split rationale ([ADR-003](../adr/003-version-specific-packages.md)).

--- a/agent-docs/modules/component-driver-mui.md
+++ b/agent-docs/modules/component-driver-mui.md
@@ -1,0 +1,72 @@
+# Module group: MUI component drivers (v5 / v6 / v7)
+
+Drivers for Material-UI core components, one package per MUI major:
+
+| Package | Targets | MUI peer |
+|---------|---------|----------|
+| `@atomic-testing/component-driver-mui-v5` | MUI v5 | `@mui/material@^5` |
+| `@atomic-testing/component-driver-mui-v6` | MUI v6 | `@mui/material@^6` |
+| `@atomic-testing/component-driver-mui-v7` | MUI v7 | `@mui/material@^7` |
+
+> The three packages are ~95% identical at the code level — same exports, same APIs. They diverge only where a MUI major changes DOM structure, roles, or class names. See [ADR-003](../adr/003-version-specific-packages.md). This doc uses **v7** as the reference; the catalog and patterns apply to v5/v6 too.
+
+Each mui package depends on `component-driver-html`, `core`, `dom-core`, and a React package (`mui-v7` → `react-18`) plus `@mui/material` and `@emotion/*` ([mui-v7/package.json#L25-L33](../../packages/component-driver-mui-v7/package.json#L25-L33)).
+
+## Public surface (v7)
+
+Barrel: [component-driver-mui-v7/src/index.ts](../../packages/component-driver-mui-v7/src/index.ts).
+
+Drivers: `AccordionDriver`, `AlertDriver`, `AutoCompleteDriver` (+ `defaultAutoCompleteDriverOption`, option types), `BadgeDriver`, `ButtonDriver`, `CheckboxDriver`, `ChipDriver`, `DialogDriver`, `FabDriver`, `InputDriver`, `ListDriver`, `ListItemDriver`, `MenuDriver`, `MenuItemDriver`, `ProgressDriver`, `RatingDriver`, `SelectDriver`, `SliderDriver`, `SnackbarDriver`, `SwitchDriver`, `TextFieldDriver`, `ToggleButtonDriver`, `ToggleButtonGroupDriver`, `ExclusiveToggleButtonGroupDriver`.
+
+Errors: `MenuItemDisabledError`, `MenuItemNotFoundError` (+ `*Id`) ([index.ts#L29-L30](../../packages/component-driver-mui-v7/src/index.ts#L29-L30)).
+
+## Responsibilities
+
+- Map MUI's rendered DOM (roles, `Mui*` classes, portals) to semantic driver APIs, composing HTML drivers for leaf elements.
+- Encapsulate MUI quirks (portal rendering, native-vs-custom select, transition timing) so test authors don't.
+
+## Non-goals
+
+- Not a re-implementation of MUI behavior — drivers only *observe and act on* rendered MUI DOM.
+- No cross-version abstraction layer — each major is its own package.
+
+## How it works — three representative drivers
+
+### Portal/list driver — `MenuDriver`
+MUI menus render in a portal outside the trigger's DOM. The driver escapes its declared parent via the locator-override hooks ([MenuDriver.ts](../../packages/component-driver-mui-v7/src/components/MenuDriver.ts#L24-L65)):
+```ts
+override overriddenParentLocator() { return byRole('presentation', 'Root'); }
+override overrideLocatorRelativePosition() { return 'Same'; }
+```
+It iterates `byRole('menuitem')` with `listHelper.getListItemIterator(..., MenuItemDriver)`; `selectByLabel` clicks the match or throws `MenuItemNotFoundError`.
+
+### Container driver — `DialogDriver`
+`DialogDriver<ContentT> extends ContainerDriver<ContentT, typeof parts>` with `parts = { title, dialogContainer }` and a generic `content` for the dialog body ([DialogDriver.ts](../../packages/component-driver-mui-v7/src/components/DialogDriver.ts#L29-L97)). It also uses `overriddenParentLocator() → byRole('presentation','Root')`, and adds `getTitle`, `isOpen`, and transition-aware `waitForOpen`/`waitForClose` (built on `interactor.waitUntil`).
+
+### Composite input — `SelectDriver`
+Handles both native `<select>` and MUI's custom dropdown via a four-part scene (`trigger`, `dropdown`, `input`, `nativeSelect`) ([SelectDriver.ts](../../packages/component-driver-mui-v7/src/components/SelectDriver.ts#L27-L223)). Notable: `trigger` uses `byRole('combobox')` with an inline comment that MUI changed the role from `button` to `combobox` at 5.12 — **this kind of selector difference is exactly why versions are split**. Methods: `getValue`, `setValue`, `selectByLabel`, `getSelectedLabel`, `openDropdown`/`closeDropdown`, `isNative`, `isDropdownOpen`, `isDisabled`.
+
+## Version differences (v5 → v6 → v7)
+
+- **API-identical**: the exported driver set and public methods match across versions.
+- **What changes**: CSS class names (`.Mui*`), ARIA roles (the `combobox` example), occasional DOM nesting, and the `driverName` string (`MuiV5*`/`MuiV6*`/`MuiV7*`). [inferred] from sampling identical structure across versions and the role-change comment in `SelectDriver`.
+- **Practical rule**: when fixing a driver bug caused by a MUI change, fix it in the affected version package only; if it affects all, replicate across v5/v6/v7.
+
+## Errors
+
+`MenuItemNotFoundError(label, driver)` / `MenuItemDisabledError(label, driver)` extend core `ErrorBase`; thrown by `MenuDriver.selectByLabel` and `SelectDriver.selectByLabel` when an item is missing/disabled ([MenuDriver.ts#L53-L60](../../packages/component-driver-mui-v7/src/components/MenuDriver.ts#L53-L60), [SelectDriver.ts#L142-L146](../../packages/component-driver-mui-v7/src/components/SelectDriver.ts#L142-L146)).
+
+## Extension points — add/port a MUI driver
+
+1. Create `src/components/XDriver.ts` extending `ComponentDriver`/`ContainerDriver`/`ListComponentDriver`.
+2. Declare `parts` with `satisfies ScenePart`, composing HTML drivers for leaves.
+3. For portal components, override `overriddenParentLocator()`/`overrideLocatorRelativePosition()`.
+4. Set `driverName` to `MuiV<N><Name>Driver`; export from the package `index.ts`.
+5. Replicate into the other version packages, adjusting selectors/roles per MUI major.
+
+## Related files
+
+- [SelectDriver.ts](../../packages/component-driver-mui-v7/src/components/SelectDriver.ts) — native/custom + role-change example.
+- [DialogDriver.ts](../../packages/component-driver-mui-v7/src/components/DialogDriver.ts) — container + transition waiting.
+- [modules/component-driver-html.md](component-driver-html.md) — the leaf drivers these compose.
+- [adr/003-version-specific-packages.md](../adr/003-version-specific-packages.md) — the version-split decision.

--- a/agent-docs/modules/core.md
+++ b/agent-docs/modules/core.md
@@ -1,0 +1,109 @@
+# Module: core (`@atomic-testing/core`)
+
+## Purpose
+
+The framework-agnostic foundation: all types, base driver classes, the `Interactor` interface, the locator system, errors, and utilities. Every other package depends on it; it depends on nothing internal.
+
+## Public surface
+
+Barrel: [core/src/index.ts](../../packages/core/src/index.ts). Highlights:
+
+| Export | Kind | File |
+|--------|------|------|
+| `TestEngine` | class | [TestEngine.ts](../../packages/core/src/TestEngine.ts#L12) |
+| `ComponentDriver`, `ContainerDriver`, `ListComponentDriver` | classes | [drivers/index.ts](../../packages/core/src/drivers/index.ts) |
+| `IInputDriver`, `IFormFieldDriver`, `IToggleDriver`, `IClickableDriver`, `IMouseInteractableDriver` | interfaces | [driverTypes.ts](../../packages/core/src/drivers/driverTypes.ts) |
+| `Interactor` | interface | [interactor/Interactor.ts](../../packages/core/src/interactor/Interactor.ts#L26) |
+| `ScenePart`, `ScenePartDefinition`, `ScenePartDriver`, `IComponentDriverOption`, `IContainerDriverOption`, `ComponentDriverCtor` | types | [partTypes.ts](../../packages/core/src/partTypes.ts) |
+| `by*` locator builders, `CssLocator`, `LinkedCssLocator`, `PartLocator` | functions/types | [locators/index.ts](../../packages/core/src/locators/index.ts) |
+| `WaitForOption`, `WaitForCondition`, `defaultWaitForOption`, `WaitUntilOption` | types/const | [WaitForOption.ts](../../packages/core/src/drivers/WaitForOption.ts), [timingUtil.ts](../../packages/core/src/utils/timingUtil.ts#L14) |
+| errors: `ElementNotFoundError`, `WaitForFailureError`, `MissingPartError`, `TooManyMatchingElementError`, `ItemNotFoundError` (+ `*Id`) | classes | [errors/index.ts](../../packages/core/src/errors/index.ts) |
+| `Point` | type | [geometry/index.ts](../../packages/core/src/geometry/index.ts) |
+| `collectionUtil`, `dateUtil`, `escapeUtil`, `locatorUtil`, `timingUtil`, `interactorUtil` | namespaces | [index.ts#L17-L30](../../packages/core/src/index.ts#L17-L30) |
+| `Nullable`, `Optional` | type helpers | [dataTypes.ts](../../packages/core/src/dataTypes.ts) |
+| `IExampleUIUnit`, `IExampleUnit` | types (example harness) | [example/types.ts](../../packages/core/src/example/types.ts) |
+
+> Utilities are exported as **namespaces** (`export * as locatorUtil`), so call them as `locatorUtil.append(...)`, `timingUtil.waitUntil(...)`, etc.
+
+## Responsibilities
+
+- Define the type contracts (`ScenePart`, driver options, `Interactor`) that bind the whole system. See [DOMAIN.md](../DOMAIN.md#type-system).
+- Provide the `ComponentDriver` base + `Container`/`List` specializations and the `TestEngine` root.
+- Provide the locator builders and the `locatorUtil` resolution logic that turns a `PartLocator` into a runtime CSS selector.
+- Define the error hierarchy and timing/wait primitives.
+
+## Non-goals
+
+- No environment implementation — `Interactor` is only an interface here (implemented in `dom-core`, `playwright`).
+- No component-specific drivers — those live in `component-driver-*`.
+- No rendering — `createTestEngine` factories live in the adapter packages.
+
+## How it works
+
+`ComponentDriver` holds a `locator`, an `interactor`, and an eagerly-built `parts` tree (via `getPartFromDefinition`). Its public methods (`click`, `getText`, `exists`, `isVisible`, `hover`, `enterText`, `waitUntilComponentState`, `waitUntilVisible`, `runtimeCssSelector`, …) are thin delegations to `this.interactor.<method>(this.locator, …)` ([ComponentDriver.ts](../../packages/core/src/drivers/ComponentDriver.ts#L138-L251)). Subclasses add component-specific semantics and implement the abstract `driverName` getter.
+
+## Key types
+
+See [DOMAIN.md → Type system](../DOMAIN.md#type-system) for the full picture. The driver class hierarchy:
+
+- `ComponentDriver<T extends ScenePart>` — base ([ComponentDriver.ts#L25](../../packages/core/src/drivers/ComponentDriver.ts#L25)).
+- `ContainerDriver<ContentT, T>` — adds `content` ([ContainerDriver.ts#L13](../../packages/core/src/drivers/ContainerDriver.ts#L13)).
+- `ListComponentDriver<ItemT>` — adds `getItemByIndex/getItemByLabel/getItems/getItemCount` ([ListComponentDriver.ts#L16](../../packages/core/src/drivers/ListComponentDriver.ts#L16)).
+- `TestEngine<T>` — adds `cleanUp()` ([TestEngine.ts#L12](../../packages/core/src/TestEngine.ts#L12)).
+
+### Interactor interface surface
+
+The contract every environment implements ([Interactor.ts](../../packages/core/src/interactor/Interactor.ts#L26-L153)):
+
+- **Mutative**: `click`, `mouseMove/Down/Up/Over/Out/Enter/Leave`, `focus`, `blur`, `enterText`, `selectOptionValue`, `hover`, `wait`, `waitUntilComponentState`, `waitUntil<T>`.
+- **Read-only**: `getInputValue`, `getSelectValues`, `getSelectLabels`, `getAttribute` (3 overloads incl. `isMultiple`), `getStyleValue`, `getText`, `exists`, `isChecked`, `isDisabled`, `isReadonly`, `isVisible`, `hasCssClass`, `hasAttribute`.
+- **Debug**: `innerHTML`, `clone()`.
+
+## Locators
+
+Builders in [locators/](../../packages/core/src/locators/index.ts), each returning a `CssLocator` (and accepting an optional `relative` position):
+
+| Builder | Selects | File |
+|---------|---------|------|
+| `byDataTestId(id)` | `[data-testid="id"]` | [byDataTestId.ts](../../packages/core/src/locators/byDataTestId.ts) |
+| `byAttribute(name, value)` | `[name="value"]` (special-cases `id`) | [byAttribute.ts](../../packages/core/src/locators/byAttribute.ts) |
+| `byRole(role)` | `[role="role"]` | [byRole.ts](../../packages/core/src/locators/byRole.ts) |
+| `byCssClass(...names)` | `.a.b` | [byCssClass.ts](../../packages/core/src/locators/byCssClass.ts) |
+| `byTagName(tag)` | `tag` | [byTagName.ts](../../packages/core/src/locators/byTagName.ts) |
+| `byName(name)` | `[name="name"]` | [byName.ts](../../packages/core/src/locators/byName.ts) |
+| `byValue(value)` | `[value="value"]` | [byValue.ts](../../packages/core/src/locators/byValue.ts) |
+| `byInputType(type)` | `input[type="type"]` | [byInputType.ts](../../packages/core/src/locators/byInputType.ts) |
+| `byChecked(state?)` | `:checked` / `:not(:checked)` | [byChecked.ts](../../packages/core/src/locators/byChecked.ts) |
+| `byCssSelector(sel, relative?)` | raw CSS (escape hatch) | [byCssSelector.ts](../../packages/core/src/locators/byCssSelector.ts) |
+| `byLinkedElement()` | fluent → `LinkedCssLocator` | [byLinkedElement.ts](../../packages/core/src/locators/byLinkedElement.ts#L19) |
+
+Composition lives in `locatorUtil` ([utils/locatorUtil.ts](../../packages/core/src/utils/locatorUtil.ts)): `append(...locators)` chains while respecting `Root` boundaries; `toCssSelector(locator, interactor)` resolves to a runtime selector (awaiting linked-locator resolution); `overrideLocatorRelativePosition(...)` rewrites a locator's relative position.
+
+## Utilities
+
+| Namespace | Notable members | File |
+|-----------|-----------------|------|
+| `timingUtil` | `wait(ms)`, `waitUntil(option)` (probe loop, interval = `timeoutMs/probeCount`, default 10) | [timingUtil.ts](../../packages/core/src/utils/timingUtil.ts) |
+| `interactorUtil` | `interactorWaitUtil(locator, interactor, option)` → throws `WaitForFailureError` | [interactorUtil.ts](../../packages/core/src/utils/interactorUtil.ts) |
+| `locatorUtil` | `append`, `toCssSelector`, `overrideLocatorRelativePosition`, chain helpers | [locatorUtil.ts](../../packages/core/src/utils/locatorUtil.ts) |
+| `escapeUtil` | `escapeValue` (CSS escape, LRU-cached), `escapeCssClassName`, `escapeName` | [escapeUtil.ts](../../packages/core/src/utils/escapeUtil.ts) |
+| `dateUtil` | `isHtmlDateInputType`, `validateHtmlDateInput`, `isHtmlInput{Date,Time,DateTime}Format`, `htmlInputDateTypes` | [dateUtil.ts](../../packages/core/src/utils/dateUtil.ts) |
+| `collectionUtil` | `toArray`, `getDifference` | [collectionUtil.ts](../../packages/core/src/utils/collectionUtil.ts) |
+| `listHelper` | `getListItemByIndex`, `getListItemIterator`, `getListItemCount` (exported via `drivers`) | [listHelper.ts](../../packages/core/src/drivers/listHelper.ts) |
+
+## Invariants & failure modes
+
+See [DOMAIN.md → Invariants](../DOMAIN.md#invariants) and [Failure modes](../DOMAIN.md#failure-modes-error-catalog). Core-specific: locator-override hooks run on the prototype before construction, so they cannot use instance state ([driverUtil.ts#L26-L30](../../packages/core/src/drivers/driverUtil.ts#L26-L30)).
+
+## Extension points
+
+- **New locator builder** → add `byX.ts` in `locators/`, export from `locators/index.ts`. Return a `CssLocator` (use `byCssSelector` internally).
+- **New base driver capability** → extend `ComponentDriver` or add a capability interface in `driverTypes.ts`.
+- **New error** → add under `errors/`, extend `ErrorBase` (driver-scoped) or `InteractorErrorBase` (locator-scoped), export with an id constant.
+
+## Related files
+
+- [TestEngine.ts](../../packages/core/src/TestEngine.ts) — root driver.
+- [drivers/driverUtil.ts](../../packages/core/src/drivers/driverUtil.ts) — part-tree builder.
+- [drivers/listHelper.ts](../../packages/core/src/drivers/listHelper.ts) — `:nth-of-type` iteration.
+- [partTypes.ts](../../packages/core/src/partTypes.ts) — the type system.

--- a/agent-docs/modules/dom-core.md
+++ b/agent-docs/modules/dom-core.md
@@ -1,0 +1,63 @@
+# Module: dom-core (`@atomic-testing/dom-core`)
+
+## Purpose
+
+The base DOM implementation of `Interactor`. Turns a `PartLocator` into real DOM operations using `@testing-library/dom` + `@testing-library/user-event`. The React and Vue interactors subclass `DOMInteractor`; the Playwright one does not.
+
+## Public surface
+
+Barrel: [dom-core/src/index.ts](../../packages/dom-core/src/index.ts).
+
+| Export | Kind | File |
+|--------|------|------|
+| `DOMInteractor` | class (`implements Interactor`) | [DOMInteractor.ts](../../packages/dom-core/src/DOMInteractor.ts#L32) |
+| `createDomTestEngine(element, parts, _option?)` | function | [createDomTestEngine.ts](../../packages/dom-core/src/createDomTestEngine.ts#L13) |
+| `FakeMouseEvent` | class | [fakeEvents/FakeMouseEvent.ts](../../packages/dom-core/src/fakeEvents/FakeMouseEvent.ts#L5) |
+| `IDomTestEngineOption` | type (`= IComponentDriverOption`) | [types.ts](../../packages/dom-core/src/types.ts#L3) |
+
+Depends on: `@atomic-testing/core`, `@testing-library/dom`, `@testing-library/user-event`.
+
+## Responsibilities
+
+- Resolve locators to elements (`getElement` via `rootEl.querySelector(All)`).
+- Implement every `Interactor` method against the DOM.
+- Provide a no-render `createDomTestEngine` for already-present DOM.
+
+## Non-goals
+
+- No framework reactivity flushing — that's `ReactInteractor`/`VueInteractor`'s job.
+- No rendering/mounting of components — pass it an existing element.
+
+## How it works
+
+`DOMInteractor` is constructed with a `rootEl` (default `document.documentElement`), held as `protected readonly` so subclasses can re-`clone()` ([DOMInteractor.ts#L33](../../packages/dom-core/src/DOMInteractor.ts#L33)). The private workhorse is `getElement(locator, isMultiple?)`: it calls `locatorUtil.toCssSelector(locator, this)` then `rootEl.querySelector`/`querySelectorAll` ([DOMInteractor.ts#L379-L391](../../packages/dom-core/src/DOMInteractor.ts#L379-L391)).
+
+Interaction details worth knowing:
+
+- **`click`** uses `userEvent.click(el)` for a simple click, but switches to `FakeMouseEvent('click', {clientX, clientY})` + `fireEvent` when a `position` is given — comment notes some MUI components ignore `fireEvent('click')` ([DOMInteractor.ts#L81-L101](../../packages/dom-core/src/DOMInteractor.ts#L81-L101)).
+- **`enterText`** clears first (unless `option.append`), validates date/time formats for date-typed inputs, then `userEvent.type` ([DOMInteractor.ts#L315-L339](../../packages/dom-core/src/DOMInteractor.ts#L315-L339)).
+- **Mouse position** is computed relative to the element's bounding box (`calculateMousePosition`), centering when no preferred point is given ([DOMInteractor.ts#L64-L71](../../packages/dom-core/src/DOMInteractor.ts#L64-L71)).
+- **`isVisible`** returns false on `opacity: 0`, `visibility: hidden`, or `display: none` (does not check viewport) ([DOMInteractor.ts#L456-L478](../../packages/dom-core/src/DOMInteractor.ts#L456-L478)).
+- **`mouseEnter`/`mouseLeave`** are emulated with `fireEvent.mouseOver`/`mouseOut` (testing-library nuance) ([DOMInteractor.ts#L240-L266](../../packages/dom-core/src/DOMInteractor.ts#L240-L266)).
+
+`createDomTestEngine(element, parts)` simply wraps `new DOMInteractor(element)` in a `TestEngine` with an empty root locator and a no-op cleanup ([createDomTestEngine.ts#L13-L27](../../packages/dom-core/src/createDomTestEngine.ts#L13-L27)).
+
+### FakeMouseEvent
+
+`@testing-library` events drop `pageX/pageY`; `FakeMouseEvent extends MouseEvent` and `Object.assign`s them back so position-based interactions work ([FakeMouseEvent.ts](../../packages/dom-core/src/fakeEvents/FakeMouseEvent.ts#L5-L13)).
+
+## Invariants & failure modes
+
+- Every mutative method throws `ElementNotFoundError(locator, action)` when `getElement` returns `null` (e.g. [DOMInteractor.ts#L82-L85](../../packages/dom-core/src/DOMInteractor.ts#L82-L85)).
+- `getInputValue` only reads `INPUT`/`TEXTAREA`; `getSelectValues`/`getSelectLabels` only read `SELECT` `option:checked` ([DOMInteractor.ts#L393-L423](../../packages/dom-core/src/DOMInteractor.ts#L393-L423)).
+- `waitUntilComponentState` delegates to `interactorUtil.interactorWaitUtil` (throws on timeout); `waitUntil` delegates to `timingUtil.waitUntil` (returns last value) ([DOMInteractor.ts#L362-L371](../../packages/dom-core/src/DOMInteractor.ts#L362-L371)).
+
+## Extension points
+
+- **A new environment that is DOM-based** → subclass `DOMInteractor`, `override` interactive methods to add flushing, and `override clone()` to return your subclass. See `ReactInteractor`/`VueInteractor` in [modules/framework-adapters.md](framework-adapters.md).
+
+## Related files
+
+- [DOMInteractor.ts](../../packages/dom-core/src/DOMInteractor.ts) — the implementation.
+- [../DOMAIN.md](../DOMAIN.md) — interactor contract & invariants.
+- [../ARCHITECTURE.md](../ARCHITECTURE.md#interactor-inheritance) — where DOMInteractor sits in the inheritance tree.

--- a/agent-docs/modules/framework-adapters.md
+++ b/agent-docs/modules/framework-adapters.md
@@ -1,0 +1,91 @@
+# Module group: framework adapters (React & Vue)
+
+Covers five packages that adapt the DOM interactor to a UI framework's render lifecycle and reactivity:
+
+| Package | Provides | Targets |
+|---------|----------|---------|
+| `@atomic-testing/react-core` | `ReactInteractor` | shared React logic |
+| `@atomic-testing/react-18` | `createTestEngine`, `createRenderedTestEngine` | React 18 |
+| `@atomic-testing/react-19` | same | React 19 |
+| `@atomic-testing/react-legacy` | same | React ≤17 |
+| `@atomic-testing/vue-3` | `VueInteractor`, `createTestEngine`, `createRenderedTestEngine` | Vue 3 |
+
+> Why so many React packages? They isolate React-major render-API differences from consumers. `react-18` and `react-19` are implementation-identical; they exist to pin different peer ranges. See [ADR-003](../adr/003-version-specific-packages.md).
+
+## Purpose
+
+Render a component into the DOM (or wrap a pre-rendered one) and inject an interactor that flushes the framework's pending updates after each action, so the same driver code behaves deterministically.
+
+## Public surface
+
+| Export | Package | File |
+|--------|---------|------|
+| `ReactInteractor` (extends `DOMInteractor`) | react-core | [ReactInteractor.ts](../../packages/react-core/src/ReactInteractor.ts#L22) |
+| `createTestEngine`, `createRenderedTestEngine` | react-18 | [createTestEngine.ts](../../packages/react-18/src/createTestEngine.ts) |
+| `createTestEngine`, `createRenderedTestEngine` | react-19 | [createTestEngine.ts](../../packages/react-19/src/createTestEngine.ts) |
+| `createTestEngine`, `createRenderedTestEngine` | react-legacy | [createTestEngine.ts](../../packages/react-legacy/src/createTestEngine.ts) |
+| `IReactTestEngineOption` (`{ rootElement? }`) | react-18/19/legacy | [react-18/types.ts](../../packages/react-18/src/types.ts#L3) |
+| `VueInteractor` (extends `DOMInteractor`) | vue-3 | [VueInteractor.ts](../../packages/vue-3/src/VueInteractor.ts#L22) |
+| `createTestEngine`, `createRenderedTestEngine` | vue-3 | [createTestEngine.ts](../../packages/vue-3/src/createTestEngine.ts) |
+| `IVueTestEngineOption`, `VueSFCLikeComponent` | vue-3 | [vue-3/types.ts](../../packages/vue-3/src/types.ts) |
+
+## How it works
+
+### ReactInteractor
+
+Extends `DOMInteractor` and `override`s every interactive method to wrap the `super` call in `act()` from `@testing-library/react`, so React state updates are flushed before the method resolves ([ReactInteractor.ts#L22-L127](../../packages/react-core/src/ReactInteractor.ts#L22-L127)):
+
+```ts
+override async click(locator, option?) {
+  await act(async () => { await super.click(locator, option); });
+}
+```
+
+`clone()` returns `new ReactInteractor(this.rootEl)`.
+
+### VueInteractor
+
+Extends `DOMInteractor` and `override`s each method to call `super.*` then `await this.flush()`, where `flush` awaits Vue's `nextTick()` ([VueInteractor.ts#L22-L114](../../packages/vue-3/src/VueInteractor.ts#L22-L114)). The flush happens **after** the action (vs React wrapping the action).
+
+### createTestEngine variants
+
+All five follow the same shape: append a container to `rootElement ?? document.body`, tag it with a `data-*` attribute, render, build `TestEngine(byAttribute(attr, id), interactor, { parts }, cleanup)`. They differ only in the render/unmount API:
+
+| | react-18 / react-19 | react-legacy | vue-3 |
+|--|---------------------|--------------|-------|
+| render | `createRoot(container).render(node)` in `act()` ([L33-L36](../../packages/react-18/src/createTestEngine.ts#L33-L36)) | `ReactDOM.render(node, container)` in `act()` ([L35-L37](../../packages/react-legacy/src/createTestEngine.ts#L35-L37)) | `render(component, { container })` from `@testing-library/vue`, fallback `createApp().mount()` ([L68-L80](../../packages/vue-3/src/createTestEngine.ts#L68-L80)) |
+| `act` import | `@testing-library/react` | `react-dom/test-utils` | — |
+| unmount | `root.unmount()` in `act()` | `ReactDOM.unmountComponentAtNode` | `unmount()` / `app.unmount()` |
+| attribute | `data-atomic-testing-react` | `data-atomic-testing-react-legacy` | `data-atomic-testing-vue` |
+| input | `ReactNode` | `ReactElement` | `Component \| VueSFCLikeComponent` |
+
+`createRenderedTestEngine(rootElement, parts)` skips rendering — it tags an existing element and wires cleanup to just remove the attribute. Useful in Storybook-style environments where the host renders the component ([react-18/createTestEngine.ts#L65-L88](../../packages/react-18/src/createTestEngine.ts#L65-L88)).
+
+`vue-3` additionally accepts a `VueSFCLikeComponent` (`{ template, setup?, data?, methods?, computed?, props?, name? }`) and compiles it via `defineComponent` before mounting ([createTestEngine.ts#L15-L48](../../packages/vue-3/src/createTestEngine.ts#L15-L48)).
+
+## Non-goals
+
+- These packages do not query/act on the DOM themselves beyond what `DOMInteractor` provides — they only add reactivity flushing and lifecycle.
+- They do not provide assertions or test orchestration — see [modules/test-runner.md](test-runner.md).
+
+## Invariants & failure modes
+
+- Each `createTestEngine` call creates a fresh engine + container; `cleanUp()` unmounts and removes the container. Do not share an engine across tests — `useTestEngine` enforces per-test creation.
+- React reactivity is only correctly flushed if interactions go through the driver/`ReactInteractor`; bypassing it (raw DOM events) skips `act()`.
+
+## Dependencies
+
+- react-core → `core`, `dom-core`, `@testing-library/react`.
+- react-18/19/legacy → `core`, `dom-core`, `react-core`, plus React peer deps ([react-18/package.json#L36-L54](../../packages/react-18/package.json#L36-L54)).
+- vue-3 → `core`, `dom-core`, `@testing-library/vue`, `@vue/compiler-sfc` ([vue-3/package.json#L36-L52](../../packages/vue-3/package.json#L36-L52)).
+
+## Extension points
+
+- **Support a new React major** → copy `react-18`, adjust the render/unmount API and peer ranges; reuse `ReactInteractor` unchanged if `act` semantics match.
+- **Support another DOM framework** → mirror `vue-3`: subclass `DOMInteractor` with the framework's flush primitive, add a `createTestEngine`.
+
+## Related files
+
+- [../ARCHITECTURE.md](../ARCHITECTURE.md#createtestengine-variants--what-actually-differs) — variant comparison.
+- [modules/dom-core.md](dom-core.md) — the base interactor these extend.
+- [adr/003-version-specific-packages.md](../adr/003-version-specific-packages.md) — rationale for the version split.

--- a/agent-docs/modules/playwright.md
+++ b/agent-docs/modules/playwright.md
@@ -1,0 +1,69 @@
+# Module: playwright (`@atomic-testing/playwright`)
+
+## Purpose
+
+Run the same component drivers in a real browser via Playwright. Provides a `PlaywrightInteractor` that implements `Interactor` directly over a Playwright `Page`, a `createTestEngine`, and the glue (`testRunnerAdapter`) that lets a shared `*.suite.ts` execute as an E2E test.
+
+## Public surface
+
+Barrel: [playwright/src/index.ts](../../packages/playwright/src/index.ts).
+
+| Export | Kind | File |
+|--------|------|------|
+| `PlaywrightInteractor` | class (`implements Interactor`) | [PlaywrightInteractor.ts](../../packages/playwright/src/PlaywrightInteractor.ts#L31) |
+| `createTestEngine(page, parts)` | function | [createTestEngine.ts](../../packages/playwright/src/createTestEngine.ts#L14) |
+| `goto(url, fixture?)` | function | [testRunnerAdapter.ts](../../packages/playwright/src/testRunnerAdapter.ts#L17) |
+| `playwrightGetTestEngine(scenePart, fixture)` | function | [testRunnerAdapter.ts#L30](../../packages/playwright/src/testRunnerAdapter.ts#L30) |
+| `playWrightTestFrameworkMapper` | `TestFrameworkMapper` | [testRunnerAdapter.ts#L41](../../packages/playwright/src/testRunnerAdapter.ts#L41) |
+| `getTestRunnerInterface<T>()` | function → `E2eTestInterface<T>` | [testRunnerAdapter.ts#L74](../../packages/playwright/src/testRunnerAdapter.ts#L74) |
+
+Depends on: `@atomic-testing/core`, `@atomic-testing/internal-test-runner`; `@playwright/test` is a peer ([package.json#L31-L37](../../packages/playwright/package.json#L31-L37)).
+
+## Responsibilities
+
+- Implement `Interactor` using Playwright's locator/mouse/keyboard APIs.
+- Adapt Playwright's `test.*` lifecycle + `expect` to the shared `TestFrameworkMapper`.
+- Navigate to the suite's `url` before each E2E test.
+
+## Non-goals
+
+- No component rendering — the app under test is served separately and reached via `goto(url)`. (See `CLAUDE.md` "Running E2E Tests": start the dev server first.)
+- Does not reuse `DOMInteractor` — it is an independent implementation. See [ADR-002](../adr/002-interactor-abstraction.md).
+
+## How it works
+
+`PlaywrightInteractor(page)` resolves each `PartLocator` via `locatorUtil.toCssSelector(locator, this)` and calls `page.locator(css).<action>()` ([PlaywrightInteractor.ts#L31-L324](../../packages/playwright/src/PlaywrightInteractor.ts#L31-L324)). Notable points vs the DOM implementation:
+
+- **No `act()`/`nextTick()`** — Playwright auto-waits for actionability.
+- **`mouseMove`** hovers then `page.mouse.move(0, 0)` to reset pointer ([L133-L138](../../packages/playwright/src/PlaywrightInteractor.ts#L133-L138)).
+- **`mouseOut`/`mouseLeave`** hover then `dispatchEvent('mouseout')` for cross-browser reliability ([L158-L176](../../packages/playwright/src/PlaywrightInteractor.ts#L158-L176)).
+- **`enterText`** clears (unless `append`) and validates date-typed input formats, mirroring `DOMInteractor` ([L104-L121](../../packages/playwright/src/PlaywrightInteractor.ts#L104-L121)).
+- **`isVisible`** checks `opacity`/`visibility`/`display` but wraps reads in try/catch so an element detaching mid-animation resolves to `false` instead of throwing ([L259-L297](../../packages/playwright/src/PlaywrightInteractor.ts#L259-L297)).
+- **`isReadonly`** is inferred from the `readonly` attribute; **`isDisabled`** uses Playwright's `isDisabled()` ([L248-L257](../../packages/playwright/src/PlaywrightInteractor.ts#L248-L257)).
+
+`createTestEngine(page, parts)` builds `new TestEngine([], new PlaywrightInteractor(page), { parts })` with no cleanup hook (Playwright owns the page lifecycle) ([createTestEngine.ts#L14-L20](../../packages/playwright/src/createTestEngine.ts#L14-L20)).
+
+### Test-runner glue
+
+- `playWrightTestFrameworkMapper` maps `expect`/`test.*` to `TestFrameworkMapper`. It carries intentional `@ts-expect-error`s because Playwright's fixture-destructuring callback signatures differ from the normalized interface (compatible at runtime) ([testRunnerAdapter.ts#L41-L69](../../packages/playwright/src/testRunnerAdapter.ts#L41-L69)).
+- `getTestRunnerInterface()` returns `{ getTestEngine: playwrightGetTestEngine, goto }` — passed as the third arg to `testRunner` ([testRunnerAdapter.ts#L74-L79](../../packages/playwright/src/testRunnerAdapter.ts#L74-L79)).
+
+E2E adapter file (from `CLAUDE.md`):
+```ts
+testRunner(testSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());
+```
+
+## Invariants & failure modes
+
+- `goto` requires the fixture's `page`; it is called in `beforeEach` by `testRunner` for E2E interfaces ([testRunner.ts#L34-L43](../../packages/internal-test-runner/src/testRunner.ts#L34-L43)).
+- Cross-browser caveats (from `CLAUDE.md`): mouse events differ across engines; click coordinates can have sub-pixel offsets — use `assertApproxEqual` with tolerance.
+
+## Extension points
+
+- **Add an interactor capability** → implement the new `Interactor` method here too (Playwright is not a `DOMInteractor` subclass, so it won't inherit it).
+
+## Related files
+
+- [../ARCHITECTURE.md](../ARCHITECTURE.md#the-shared-three-file-test-pattern) — how E2E fits the shared pattern.
+- [modules/test-runner.md](test-runner.md) — `TestFrameworkMapper`, `testRunner`, `useTestEngine`.
+- [adr/002-interactor-abstraction.md](../adr/002-interactor-abstraction.md) — why Playwright reimplements rather than extends.

--- a/agent-docs/modules/test-runner.md
+++ b/agent-docs/modules/test-runner.md
@@ -1,0 +1,106 @@
+# Module group: test runner
+
+Covers the suite-orchestration layer that makes one test suite run in Jest, Vitest, and Playwright, plus the demo app used by suites/docs:
+
+| Package | Provides |
+|---------|----------|
+| `@atomic-testing/internal-test-runner` | `testRunner`, `useTestEngine`, `TestFrameworkMapper`, `TestSuiteInfo`, interface types |
+| `@atomic-testing/internal-test-runner-jest-adapter` | `jestTestAdapter` |
+| `@atomic-testing/internal-test-runner-vitest-adapter` | `vitestAdapter` |
+| `@atomic-testing/internal-react-example` | `ExampleApp`, `ExampleList` — demo harness |
+
+> `internal-*` packages are workspace-private dev tooling (not published consumer API). The Playwright mapper (`playWrightTestFrameworkMapper`) lives in `@atomic-testing/playwright` — see [modules/playwright.md](playwright.md).
+
+## Purpose
+
+Define a framework-neutral way to describe a test suite (`TestSuiteInfo`), a normalized assertion/lifecycle surface (`TestFrameworkMapper`), and a driver (`testRunner`) that wires a suite to a concrete runner + interaction interface.
+
+## Public surface
+
+Barrel: [internal-test-runner/src/index.ts](../../packages/internal-test-runner/src/index.ts).
+
+| Export | Kind | File |
+|--------|------|------|
+| `testRunner(suite \| suites, mapper, interactionInterface)` | function | [testRunner.ts#L7](../../packages/internal-test-runner/src/testRunner.ts#L7) |
+| `useTestEngine(scenePart, getTestEngine, { beforeEach, afterEach })` | function | [useTestEngine.ts#L21](../../packages/internal-test-runner/src/useTestEngine.ts#L21) |
+| `TestSuiteInfo<T>` | type | [types.ts#L114](../../packages/internal-test-runner/src/types.ts#L114) |
+| `TestFrameworkMapper` | type | [types.ts#L72](../../packages/internal-test-runner/src/types.ts#L72) |
+| `GetTestEngine<T>`, `InteractionInterface<T>`, `E2eTestInterface<T>`, `E2eTestRunEnvironmentFixture`, `TestFixture` | types | [types.ts](../../packages/internal-test-runner/src/types.ts) |
+| `emptyGoto` | const | [testRunner.ts#L5](../../packages/internal-test-runner/src/testRunner.ts#L5) |
+| `jestTestAdapter` | `TestFrameworkMapper` | [jest-adapter/index.ts#L13](../../packages/internal-test-runner-jest-adapter/src/index.ts#L13) |
+| `vitestAdapter` | `TestFrameworkMapper` | [vitest-adapter/index.ts#L10](../../packages/internal-test-runner-vitest-adapter/src/index.ts#L10) |
+| `ExampleApp`, `ExampleList`, `ExampleToc`, `AppProps` | React components/types | [internal-react-example/src/index.ts](../../packages/internal-react-example/src/index.ts) |
+
+## Key types
+
+- **`TestSuiteInfo<T>`** = `{ title?, url, tests(getTestEngine, mapper) }`. `url` is the E2E navigation target; DOM runs ignore it ([types.ts#L114-L121](../../packages/internal-test-runner/src/types.ts#L114-L121)).
+- **`TestFrameworkMapper`** — assertions (`assertEqual`, `assertNotEqual`, `assertTrue`, `assertFalse`, `assertApproxEqual`) + lifecycle (`describe`, `test`, `it`, `beforeEach`, `afterEach`, `beforeAll`, `afterAll`). `describe`/`test`/`it` carry `.only`/`.skip` ([types.ts#L53-L88](../../packages/internal-test-runner/src/types.ts#L53-L88)).
+- **`GetTestEngine<T>`** = `(scenePart, context?) => TestEngine<T>` — supplied by each adapter (`context` carries `{ page }` for E2E).
+- **`InteractionInterface<T>`** = `DomTestInterface<T> | E2eTestInterface<T>`; the E2E variant adds `goto(url, fixture?)`.
+
+## How it works
+
+`testRunner(testSuiteInfo, testMethod, interactionInterface)` ([testRunner.ts#L7-L50](../../packages/internal-test-runner/src/testRunner.ts#L7-L50)):
+
+1. Normalizes to an array of suites.
+2. For each suite: `testMethod.describe(title, …)`.
+3. Installs a `beforeEach` that reads `arguments[0]` to tell Jest's done-callback from Playwright's fixture, then — if the interface has `goto` (E2E) — navigates to `url` before signalling done.
+4. Calls `suite.tests(getTestEngine, testMethod)`, where the suite author writes the actual `test(...)` cases.
+
+`useTestEngine(scenePart, getTestEngine, { beforeEach, afterEach })` ([useTestEngine.ts#L21-L46](../../packages/internal-test-runner/src/useTestEngine.ts#L21-L46)):
+- `beforeEach`: `testEngine = getTestEngine(scenePart, { page })` (page is `undefined` for DOM).
+- `afterEach`: `await testEngine.cleanUp()`.
+- Returns a getter `() => testEngine`; tests call `engine()` to read the current instance.
+
+### Adapters
+
+| Adapter | Backs assertions/lifecycle with | `@ts` notes |
+|---------|---------------------------------|-------------|
+| `jestTestAdapter` | `@jest/globals` `expect`/`describe`/`test`/hooks | `@ts-ignore` on `describe`/`test`/`it` (signature mismatch) ([jest-adapter/index.ts](../../packages/internal-test-runner-jest-adapter/src/index.ts)) |
+| `vitestAdapter` | `vitest` `expect`/`describe`/`test`/hooks | none needed — Vitest 4 aligns ([vitest-adapter/index.ts](../../packages/internal-test-runner-vitest-adapter/src/index.ts)) |
+| `playWrightTestFrameworkMapper` | `@playwright/test` | `@ts-expect-error` (fixture-callback mismatch); in the playwright package |
+
+All three implement `assertApproxEqual` as `expect(Math.abs(actual-expected)).toBeLessThanOrEqual(tolerance)`.
+
+### Demo harness (`internal-react-example`)
+
+`ExampleApp` is a `react-router-dom` layout (200px nav + content `<Outlet>`) that routes a list of `ExampleToc` (`{ label, path, ui }`) entries; `ExampleList` renders an array of `IExampleUIUnit` examples ([ExampleApp.tsx](../../packages/internal-react-example/src/ExampleApp.tsx#L34-L72)). It hosts the components that `package-tests` E2E suites navigate to via `url`.
+
+## Worked example (three-file pattern)
+
+Suite (`*.suite.ts`):
+```ts
+export const scenePart = { input: { locator: byDataTestId('input'), driver: HTMLTextInputDriver } } satisfies ScenePart;
+export const testSuite: TestSuiteInfo<typeof scenePart> = {
+  title: 'MyComponent', url: '/my-component',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe('MyComponent', () => {
+      const engine = useTestEngine(scenePart, getTestEngine, { beforeEach, afterEach });
+      test('sets value', async () => {
+        await engine().parts.input.setValue('test');
+        assertEqual(await engine().parts.input.getValue(), 'test');
+      });
+    });
+  },
+};
+```
+DOM adapter (`*.dom.test.ts`): `testRunner(testSuite, jestTestAdapter, { getTestEngine: (p) => createTestEngine(<MyComponent/>, p) })`.
+E2E adapter (`*.e2e.test.ts`): `testRunner(testSuite, playWrightTestFrameworkMapper, getTestRunnerInterface())`.
+
+(See `CLAUDE.md` for the canonical version of this pattern.)
+
+## Invariants & failure modes
+
+- A new engine is created per test; `cleanUp` runs in `afterEach`. Sharing engines across tests is unsupported.
+- `beforeEach` runtime dispatch relies on `arguments[0]` being a function (Jest) vs object (Playwright fixture) — do not refactor those callbacks to arrow functions without preserving `arguments`.
+
+## Extension points
+
+- **Support another runner** → implement a `TestFrameworkMapper` mapping its `expect`/lifecycle (copy `vitestAdapter`).
+- **Add an assertion** → extend `TestFrameworkMapper` in `types.ts` and implement it in every adapter (jest, vitest, playwright).
+
+## Related files
+
+- [../ARCHITECTURE.md](../ARCHITECTURE.md#the-shared-three-file-test-pattern) — diagram of the flow.
+- [adr/004-shared-three-file-test-pattern.md](../adr/004-shared-three-file-test-pattern.md) — rationale.
+- [modules/playwright.md](playwright.md) — the E2E mapper + interface.


### PR DESCRIPTION

Adds an LLM-optimized documentation set under a new repo-root `agent-docs/` folder so future agents (and contributors) can understand the 21-package library without crawling source. Every claim is cited to a `path#Symbol`/`#Lxx` source location; the set is kept separate from the user-facing Docusaurus site in `docs/`. Covers the full layer stack — core, interactors, framework adapters, the shared test runner, and the component-driver catalogs.

## Key Changes

- Add `DOMAIN.md`, `ARCHITECTURE.md`, `AGENTS.md`, and `INDEX.md` covering the type system, layer stack/interactor inheritance, and an agent routing playbook (with Mermaid diagrams).
- Add 8 layer-grouped module docs (core, dom-core, framework-adapters, playwright, test-runner, html/mui/mui-x drivers), collapsing near-identical version packages with version-diff notes.
- Add 4 ADRs documenting the consequential design decisions: component-driver pattern, `Interactor` abstraction, version-specific packages, and the shared three-file test pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
