### PR TITLE
docs: redesign Docusaurus site with new visual identity

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,10 +6,28 @@ import path from 'path';
 // require('prism-react-renderer/themes/github');
 import type * as Preset from '@docusaurus/preset-classic';
 import type { Config } from '@docusaurus/types';
-import { themes } from 'prism-react-renderer';
+import type { PrismTheme } from 'prism-react-renderer';
 
-const darkCodeTheme = themes.dracula; // require('prism-react-renderer/themes/dracula');
-const lightCodeTheme = themes.github;
+// Custom Prism theme: code blocks are always dark navy with the design's token colors,
+// in both light and dark site themes. Colors mirror the design tokenizer palette.
+const atomicCodeTheme: PrismTheme = {
+  plain: { color: '#cbd7e6', backgroundColor: '#0e1726' },
+  styles: [
+    { types: ['comment', 'prolog', 'doctype', 'cdata'], style: { color: '#5e7488', fontStyle: 'italic' } },
+    { types: ['punctuation'], style: { color: '#7e91ab' } },
+    { types: ['operator', 'entity', 'url'], style: { color: '#9fb3cc' } },
+    { types: ['keyword', 'storage', 'keyword-control', 'atrule'], style: { color: '#c9a6f0' } },
+    { types: ['boolean', 'number', 'constant', 'symbol', 'inserted'], style: { color: '#5fe3c8' } },
+    { types: ['string', 'char', 'attr-value'], style: { color: '#7fd1f0' } },
+    { types: ['function', 'function-variable'], style: { color: '#7fd1f0' } },
+    { types: ['class-name', 'maybe-class-name', 'builtin'], style: { color: '#8fd4ff' } },
+    { types: ['tag', 'deleted'], style: { color: '#7fb0f5' } },
+    { types: ['attr-name', 'property', 'selector'], style: { color: '#9bd0ff' } },
+    { types: ['variable', 'parameter'], style: { color: '#cbd7e6' } },
+    { types: ['regex', 'important'], style: { color: '#5fe3c8' } },
+    { types: ['namespace'], style: { opacity: '0.7' } },
+  ],
+};
 
 function getPackageNames() {
   const baseDir = path.join(__dirname, '../packages');
@@ -103,7 +121,7 @@ const config: Config = {
       title: 'Atomic Testing',
       logo: {
         alt: 'Atomic Testing Logo',
-        src: 'img/logo.svg',
+        src: 'img/logo-atom.svg',
       },
       items: [
         {
@@ -185,8 +203,8 @@ const config: Config = {
       copyright: `Copyright © 2022-${new Date().getFullYear()} Tangent Lin`,
     },
     prism: {
-      theme: lightCodeTheme,
-      darkTheme: darkCodeTheme,
+      theme: atomicCodeTheme,
+      darkTheme: atomicCodeTheme,
     },
     colorMode: {
       defaultMode: 'light',

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -1,86 +1,74 @@
 import clsx from 'clsx';
-import React, { JSX } from 'react';
+import React, { type JSX, type ReactNode } from 'react';
 
 import styles from './styles.module.css';
 
 type FeatureItem = {
+  icon: string;
+  iconVariant: 'blue' | 'teal';
   title: string;
-  Svg?: React.ComponentType<React.ComponentProps<'svg'>>;
-  description: JSX.Element;
+  description: ReactNode;
 };
 
-const FeatureList: FeatureItem[] = [
+const featureList: FeatureItem[] = [
   {
-    title: 'Write Once, Test Everywhere',
-    // Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
+    icon: '♻️',
+    iconVariant: 'blue',
+    title: 'Write once, test everywhere',
+    description:
+      'The same test code works across React, Vue, Playwright and DOM testing. Learn once, test any UI framework.',
+  },
+  {
+    icon: '🎯',
+    iconVariant: 'teal',
+    title: 'High-level semantic APIs',
     description: (
       <>
-        Same test code works across React, Vue, Playwright, and DOM testing.
-        <br />
-        <strong>Learn once, test any UI framework.</strong>
+        <code className={styles.inlineCode}>select.selectByLabel(&apos;Option 2&apos;)</code> instead of brittle DOM
+        queries. Focus on behavior, not implementation.
       </>
     ),
   },
   {
-    title: 'High-Level Semantic APIs',
-    // Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
-    description: (
-      <>
-        <code>muiSelect.selectByLabel('Option 2')</code> instead of complex DOM queries.
-        <br />
-        <strong>Focus on user behavior, not implementation details.</strong>
-      </>
-    ),
+    icon: '🧩',
+    iconVariant: 'blue',
+    title: 'Framework-agnostic drivers',
+    description:
+      'Reuse component drivers across Material-UI, Bootstrap and custom components. Component library changes don’t break your tests.',
   },
   {
-    title: 'Framework Agnostic Drivers',
-    // Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
-    description: (
-      <>
-        Reuse component drivers across Material-UI, Bootstrap, and custom components.
-        <br />
-        <strong>Component library changes don't break your tests.</strong>
-      </>
-    ),
-  },
-  {
-    title: 'Future-Proof Architecture',
-    // Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
-    description: (
-      <>
-        Framework migrations, library upgrades, and test environment changes become trivial.
-        <br />
-        <strong>Your testing investment scales with your application.</strong>
-      </>
-    ),
+    icon: '🛡️',
+    iconVariant: 'teal',
+    title: 'Future-proof architecture',
+    description:
+      'Framework migrations, library upgrades and environment changes become trivial. Your testing investment scales with your app.',
   },
 ];
 
-function Feature({ title, Svg, description, index }: FeatureItem & { index: number }) {
-  const isOdd = index % 2 === 1;
-  const padder = <div className={clsx('col col--6')}></div>;
+function Feature({ icon, iconVariant, title, description }: FeatureItem): JSX.Element {
   return (
-    <div className='row'>
-      {isOdd ? padder : null}
-      <div className={clsx('col col--6')}>
-        <div>{Svg ? <Svg className={styles.featureSvg} role='img' /> : null}</div>
-        <div className='padding-horiz--md'>
-          <h3>{title}</h3>
-          <p>{description}</p>
-        </div>
+    <article className={styles.card}>
+      <div className={clsx(styles.iconTile, styles[iconVariant])} aria-hidden='true'>
+        {icon}
       </div>
-      {!isOdd ? padder : null}
-    </div>
+      <h3 className={styles.cardTitle}>{title}</h3>
+      <p className={styles.cardBody}>{description}</p>
+    </article>
   );
 }
 
 export default function HomepageFeatures(): JSX.Element {
   return (
     <section className={styles.features}>
-      <div className='container'>
-        {FeatureList.map((props, idx) => (
-          <Feature key={idx} index={idx} {...props} />
-        ))}
+      <div className={styles.inner}>
+        <header className={styles.heading}>
+          <h2 className={styles.headingTitle}>Why teams adopt it</h2>
+        </header>
+        <div className={styles.grid}>
+          {featureList.map((feature) => (
+            <Feature key={feature.title} {...feature} />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/docs/src/components/HomepageFeatures/styles.module.css
+++ b/docs/src/components/HomepageFeatures/styles.module.css
@@ -1,11 +1,111 @@
 .features {
-  display: flex;
-  align-items: center;
-  padding: 2rem 0;
   width: 100%;
+  background: var(--at-bg);
 }
 
-.featureSvg {
-  height: 200px;
-  width: 200px;
+.inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 88px 24px;
+}
+
+.heading {
+  max-width: 620px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.headingTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 38px;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--at-text);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+
+.card {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 16px;
+  padding: 28px;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 16px 40px rgba(18, 32, 46, 0.09);
+  transform: translateY(-3px);
+  border-color: var(--at-text-faint);
+}
+
+.iconTile {
+  width: 44px;
+  height: 44px;
+  border-radius: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 21px;
+}
+
+.iconTile.blue {
+  background: linear-gradient(135deg, #e7f0ff, #dbeafe);
+}
+
+.iconTile.teal {
+  background: linear-gradient(135deg, #dbf6f0, #ccf1ea);
+}
+
+.cardTitle {
+  font-family: var(--at-font-display);
+  font-weight: 600;
+  font-size: 20px;
+  margin: 18px 0 0;
+  color: var(--at-text);
+}
+
+.cardBody {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--at-text-muted);
+  margin: 9px 0 0;
+}
+
+.inlineCode {
+  font-family: var(--at-font-mono);
+  font-size: 13px;
+  background: var(--at-code-chip-bg);
+  padding: 1px 6px;
+  border-radius: 5px;
+  color: var(--at-code-chip-ink);
+  border: 0;
+}
+
+@media (max-width: 996px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .inner {
+    padding: 64px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
 }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,30 +1,801 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
 /**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+ * Atomic Testing — global theme for Docusaurus 3.10 + Infima.
+ *
+ * Translates the Claude "Design Composer" export (/tmp/design.html) into an
+ * idiomatic Docusaurus theme. The `--at-*` custom properties form a shared
+ * token contract that cascades globally and is consumed by CSS modules
+ * (e.g. the marketing homepage). Names must match the spec EXACTLY.
+ *
+ * Structure:
+ *   1. :root  — brand + font tokens, LIGHT perceptual tokens, Infima mapping
+ *   2. [data-theme='dark'] — DARK perceptual tokens + Infima primary remap
+ *   3. Globals (body, scrollbars, selection, headings)
+ *   4. Navbar
+ *   5. Sidebar
+ *   6. Doc content (markdown / article)
+ *   7. Table of contents (right rail)
+ *   8. Admonitions
+ *   9. Code (blocks + inline)
+ *  10. Tables
+ *  11. Pagination
+ *  12. Buttons
+ *  13. Footer
+ *  14. Reduced-motion safeguard
  */
 
-/* You can override the default Infima variables here. */
+/* ============================================================
+ * 1. :root — brand + fonts (theme-independent) + LIGHT tokens
+ * ============================================================ */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  /* --- Brand colors (theme-independent) --- */
+  --at-blue: #2d6be3;
+  --at-blue-deep: #1f58c9;
+  --at-teal: #14b8b0;
+  --at-sky: #38bdf8;
+  --at-indigo: #6366f1;
+  --at-mint: #5fe3c8;
+
+  /* --- Dark "navy" palette used by code blocks + footer in both themes --- */
+  --at-ink: #0e1726;
+  --at-ink-border: #1d2a3d;
+  --at-ink-bar: #0b1320;
+  --at-ink-text: #cbd7e6;
+  --at-ink-faint: #5e7488;
+
+  /* --- Brand gradients --- */
+  --at-gradient: linear-gradient(135deg, #2d6be3, #14b8b0);
+  --at-gradient-btn: linear-gradient(135deg, #2d6be3, #1f58c9);
+  --at-gradient-text: linear-gradient(120deg, #2d6be3 0%, #14b8b0 60%, #38bdf8 100%);
+
+  /* --- Font stacks --- */
+  --at-font-display: 'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --at-font-body: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+  --at-font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  /* --- Perceptual tokens — LIGHT --- */
+  --at-bg: #f6f8fb;
+  --at-bg-alt: #f0f4f9;
+  --at-surface: #ffffff;
+  --at-border: #e6ebf2;
+  --at-border-soft: #eef2f7;
+  --at-hover: #eef2f7;
+  --at-text: #0e1726;
+  --at-text-strong: #16202e;
+  --at-text-muted: #4a5b70;
+  --at-text-faint: #8090a8;
+  --at-text-faint2: #6b7c93;
+  --at-nav-bg: rgba(246, 248, 251, 0.82);
+  --at-grid-line: #e9eef5;
+  --at-teal-ink: #0f8a6c;
+
+  --at-tip-bg: #ecfdf6;
+  --at-tip-border: #c4f0df;
+  --at-tip-ink: #0f8a6c;
+  --at-tip-body: #2c4f44;
+
+  --at-note-bg: #eff5ff;
+  --at-note-border: #cfe0fb;
+  --at-note-ink: #1f58c9;
+  --at-note-body: #2c3e5e;
+  --at-note-chip-bg: #dde9fb;
+
+  --at-code-chip-bg: #eef2f7;
+  --at-code-chip-ink: #1f58c9;
+  --at-th-bg: #f0f4f9;
+  --at-kbd-bg: #eef2f7;
+  --at-scroll: #c2cedd;
+  --at-scroll-hover: #a7b6c9;
+  --at-hero-tint1: rgba(56, 189, 248, 0.1);
+  --at-hero-tint2: rgba(20, 184, 176, 0.08);
+
+  /* ----------------------------------------------------------
+   * Infima mapping (LIGHT) — drive Docusaurus from our tokens.
+   * ---------------------------------------------------------- */
+  --ifm-color-primary: #2d6be3;
+  --ifm-color-primary-dark: #245fce;
+  --ifm-color-primary-darker: #2259c2;
+  --ifm-color-primary-darkest: #1c4aa0;
+  --ifm-color-primary-light: #4a82e8;
+  --ifm-color-primary-lighter: #6193eb;
+  --ifm-color-primary-lightest: #84acf0;
+
+  --ifm-background-color: var(--at-bg);
+  --ifm-background-surface-color: var(--at-surface);
+
+  --ifm-font-family-base: var(--at-font-body);
+  --ifm-font-family-monospace: var(--at-font-mono);
+  --ifm-heading-font-family: var(--at-font-display);
+  --ifm-heading-font-weight: 700;
+
+  --ifm-navbar-background-color: var(--at-nav-bg);
+  --ifm-navbar-height: 62px;
+  --ifm-navbar-shadow: none;
+
+  --ifm-menu-color: var(--at-text-muted);
+  --ifm-toc-border-color: var(--at-border);
+
+  --ifm-color-content: var(--at-text);
+  --ifm-heading-color: var(--at-text);
+  --ifm-link-color: var(--at-blue);
+  --ifm-table-stripe-background: transparent;
+  --ifm-code-font-size: 92%;
+  --ifm-blockquote-color: var(--at-text-muted);
+
+  --docusaurus-highlighted-code-line-bg: rgba(45, 107, 230, 0.12);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
+/* ============================================================
+ * 2. [data-theme='dark'] — DARK perceptual tokens + Infima remap
+ * ============================================================ */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  /* --- Perceptual tokens — DARK --- */
+  --at-bg: #090e16;
+  --at-bg-alt: #0c121d;
+  --at-surface: #111b29;
+  --at-border: #22324a;
+  --at-border-soft: #182232;
+  --at-hover: #17202f;
+  --at-text: #eef4fb;
+  --at-text-strong: #ffffff;
+  --at-text-muted: #a1b1c7;
+  --at-text-faint: #76869c;
+  --at-text-faint2: #8294ab;
+  --at-nav-bg: rgba(9, 14, 22, 0.84);
+  --at-grid-line: rgba(255, 255, 255, 0.05);
+  --at-teal-ink: #5fe3c8;
+
+  --at-tip-bg: #0d241d;
+  --at-tip-border: #1c4a3c;
+  --at-tip-ink: #5fe3c8;
+  --at-tip-body: #bfe9dd;
+
+  --at-note-bg: #0e1d33;
+  --at-note-border: #1f3a63;
+  --at-note-ink: #7fb0f5;
+  --at-note-body: #c2d4ef;
+  --at-note-chip-bg: #15294a;
+
+  --at-code-chip-bg: #17263d;
+  --at-code-chip-ink: #84b4f7;
+  --at-th-bg: #0f1a28;
+  --at-kbd-bg: #17263d;
+  --at-scroll: #26374e;
+  --at-scroll-hover: #334864; /* spec note: design had typo #33486400 */
+  --at-hero-tint1: rgba(56, 189, 248, 0.09);
+  --at-hero-tint2: rgba(20, 184, 176, 0.08);
+
+  /* ----------------------------------------------------------
+   * Infima mapping (DARK) — lighter primary ramp for contrast.
+   * ---------------------------------------------------------- */
+  --ifm-color-primary: #6c9cf0;
+  --ifm-color-primary-dark: #4f86ec;
+  --ifm-color-primary-darker: #407bea;
+  --ifm-color-primary-darkest: #2160c9;
+  --ifm-color-primary-light: #89b2f4;
+  --ifm-color-primary-lighter: #98bdf6;
+  --ifm-color-primary-lightest: #c5dafb;
+
+  --ifm-heading-color: var(--at-text-strong);
+  --docusaurus-highlighted-code-line-bg: rgba(56, 189, 248, 0.16);
+}
+
+/* Infima declares --ifm-background(-surface)-color inside its own
+ * `html[data-theme='dark']` rule (specificity 0,1,1), which outranks the
+ * `:root` mapping above (0,1,0) and forces a grey (#1b1b1d). Re-assert our
+ * tokens with a matching selector (later in the cascade → wins) so the page
+ * background stays the design's deep navy even when scrolled past content. */
+html[data-theme='dark'] {
+  --ifm-background-color: var(--at-bg);
+  --ifm-background-surface-color: var(--at-surface);
+  background-color: var(--at-bg);
+}
+
+/* ============================================================
+ * 3. Globals
+ * ============================================================ */
+html,
+body {
+  background: var(--at-bg);
+}
+
+body {
+  color: var(--at-text);
+  font-family: var(--at-font-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Custom scrollbars driven by --at-scroll tokens */
+::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--at-scroll);
+  border-radius: 6px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--at-scroll-hover);
+  background-clip: padding-box;
+}
+
+/* Firefox scrollbar */
+* {
+  scrollbar-color: var(--at-scroll) transparent;
+}
+
+::selection {
+  background: rgba(45, 107, 230, 0.22);
+  color: var(--at-text-strong);
+}
+
+/* Display font for all headings with tight tracking */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-family: var(--at-font-display);
+  letter-spacing: -0.02em;
+  color: var(--at-text);
+}
+
+h1 {
+  font-weight: 700;
+}
+
+/* ============================================================
+ * 4. Navbar — translucent, blurred, bordered (no shadow)
+ * ============================================================ */
+.navbar {
+  background: var(--at-nav-bg);
+  backdrop-filter: saturate(180%) blur(14px);
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid var(--at-border);
+  box-shadow: none;
+}
+
+.navbar__title {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--at-text-strong);
+}
+
+.navbar__link {
+  color: var(--at-text-muted);
+  font-weight: 500;
+  padding: 7px 12px;
+  border-radius: 8px;
+}
+
+.navbar__link:hover {
+  background: var(--at-hover);
+  color: var(--at-text-strong);
+}
+
+/* Active-route link: indicate the current section with color only — no
+   persistent background pill (so docs pages match the clean homepage navbar).
+   Hover still shows the background. */
+.navbar__link--active {
+  background: transparent;
+  color: var(--at-text-strong);
+}
+
+.navbar__link--active:hover {
+  background: var(--at-hover);
+}
+
+/* Search button + color-mode toggle styled as bordered surface pills */
+.navbar .DocSearch-Button {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 9px;
+  color: var(--at-text-faint);
+  font-family: var(--at-font-body);
+  box-shadow: none;
+  height: 36px;
+}
+
+.navbar .DocSearch-Button:hover {
+  border-color: var(--at-text-faint);
+  box-shadow: none;
+}
+
+.navbar .DocSearch-Button-Keys {
+  font-family: var(--at-font-mono);
+}
+
+.navbar .DocSearch-Button-Key {
+  background: var(--at-kbd-bg);
+  border: 1px solid var(--at-border);
+  box-shadow: none;
+  color: var(--at-text-faint);
+}
+
+/* Color-mode toggle pill */
+.navbar .clean-btn.toggleButton_,
+.navbar [class*='toggleButton'],
+.navbar .colorModeToggle_ button,
+.navbar [class*='colorModeToggle'] {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 9px;
+  width: 36px;
+  height: 36px;
+}
+
+.navbar [class*='toggleButton']:hover,
+.navbar [class*='colorModeToggle'] button:hover {
+  border-color: var(--at-text-faint);
+  background: var(--at-surface);
+}
+
+/* GitHub navbar item rendered as a bordered pill */
+.navbar__item.navbar__link[href*='github'],
+.navbar__items--right .navbar__link[href*='github'] {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 9px;
+  color: var(--at-text-strong);
+  font-weight: 600;
+}
+
+.navbar__item.navbar__link[href*='github']:hover {
+  border-color: var(--at-text-faint);
+  background: var(--at-surface);
+}
+
+/* ============================================================
+ * 5. Sidebar (.menu)
+ * ============================================================ */
+.menu {
+  font-size: 14px;
+}
+
+.menu__link {
+  font-size: 14px;
+  border-radius: 7px;
+  color: var(--at-text-muted);
+}
+
+.menu__link:hover {
+  background: var(--at-hover);
+  color: var(--at-text-strong);
+}
+
+/* Active item: gradient pill, forced white, no hover recolor */
+.menu__link--active,
+.menu__link--active:hover {
+  background: var(--at-gradient-btn);
+  color: #fff !important;
+  font-weight: 600;
+}
+
+/* Category labels keep their emoji; slightly bolder w/ tracking */
+.menu__list-item-collapsible .menu__link {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.menu__list-item-collapsible:hover {
+  background: var(--at-hover);
+  border-radius: 7px;
+}
+
+/* Don't let an active *category* link inherit the gradient pill */
+.menu__list-item-collapsible .menu__link--active {
+  background: transparent;
+  color: var(--at-text-strong) !important;
+}
+
+.menu__list-item-collapsible:hover .menu__link--active {
+  background: transparent;
+}
+
+/* ============================================================
+ * 6. Doc content (.markdown / article)
+ * ============================================================ */
+.markdown h1,
+article h1 {
+  font-family: var(--at-font-display);
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--at-text);
+}
+
+.markdown h2 {
+  font-family: var(--at-font-display);
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin-top: 40px;
+  padding-top: 12px;
+  border-top: 1px solid var(--at-border-soft);
+  color: var(--at-text);
+}
+
+.markdown h3 {
+  font-family: var(--at-font-display);
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--at-text-strong);
+}
+
+.markdown p {
+  color: var(--at-text);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.markdown strong {
+  color: var(--at-text-strong);
+  font-weight: 600;
+}
+
+.markdown a {
+  color: var(--at-blue);
+}
+
+/* Breadcrumbs — small + muted */
+.breadcrumbs__link {
+  font-size: 13px;
+  color: var(--at-text-faint);
+}
+
+.breadcrumbs__item--active .breadcrumbs__link {
+  color: var(--at-text-strong);
+  background: transparent;
+}
+
+.breadcrumbs__link:hover {
+  color: var(--at-blue);
+  background: var(--at-hover);
+}
+
+/* ============================================================
+ * 7. Table of contents (right rail)
+ * ============================================================ */
+.table-of-contents {
+  border-left: 1px solid var(--at-border);
+  font-size: 13.5px;
+}
+
+.table-of-contents__link {
+  color: var(--at-text-faint2);
+}
+
+.table-of-contents__link:hover {
+  color: var(--at-text-strong);
+}
+
+.table-of-contents__link--active,
+.table-of-contents__link--active code {
+  color: var(--at-blue);
+  font-weight: 500;
+}
+
+/* ============================================================
+ * 8. Admonitions — design tip/note pills
+ * ============================================================ */
+.theme-admonition,
+.alert {
+  border-radius: 10px;
+}
+
+/* TIP / SUCCESS — teal accent */
+.theme-admonition-tip,
+.alert--success {
+  background: var(--at-tip-bg);
+  border: 1px solid var(--at-tip-border);
+  border-left: 3px solid var(--at-teal);
+  color: var(--at-tip-body);
+}
+
+.theme-admonition-tip .admonitionHeading_,
+.theme-admonition-tip [class*='admonitionHeading'],
+.alert--success [class*='admonitionHeading'] {
+  color: var(--at-tip-ink);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.theme-admonition-tip [class*='admonitionIcon'] svg,
+.alert--success [class*='admonitionIcon'] svg {
+  fill: var(--at-tip-ink);
+}
+
+/* NOTE / INFO / SECONDARY — blue accent */
+.theme-admonition-note,
+.theme-admonition-info,
+.alert--secondary,
+.alert--info {
+  background: var(--at-note-bg);
+  border: 1px solid var(--at-note-border);
+  border-left: 3px solid var(--at-blue);
+  color: var(--at-note-body);
+}
+
+.theme-admonition-note [class*='admonitionHeading'],
+.theme-admonition-info [class*='admonitionHeading'],
+.alert--secondary [class*='admonitionHeading'],
+.alert--info [class*='admonitionHeading'] {
+  color: var(--at-note-ink);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.theme-admonition-note [class*='admonitionIcon'] svg,
+.theme-admonition-info [class*='admonitionIcon'] svg,
+.alert--secondary [class*='admonitionIcon'] svg,
+.alert--info [class*='admonitionIcon'] svg {
+  fill: var(--at-note-ink);
+}
+
+/* Inline code chips inside note/info admonitions adopt the note palette */
+.theme-admonition-note :not(pre) > code,
+.theme-admonition-info :not(pre) > code {
+  background: var(--at-note-chip-bg);
+  color: var(--at-note-ink);
+}
+
+/* Keep warning/danger readable (left as Infima defaults but rounded) */
+.theme-admonition-warning,
+.theme-admonition-danger,
+.alert--warning,
+.alert--danger {
+  border-radius: 10px;
+}
+
+/* ============================================================
+ * 9. Code — blocks always dark navy; inline = light pill
+ * ============================================================ */
+.theme-code-block,
+[class*='codeBlockContainer'],
+pre.prism-code,
+.markdown pre {
+  background: #0e1726 !important;
+  border: 1px solid #1d2a3d;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(14, 23, 38, 0.12);
+}
+
+[class*='codeBlockContent'] pre.prism-code,
+[class*='codeBlock'] {
+  background: #0e1726 !important;
+}
+
+/* Force token text onto the dark code background */
+pre.prism-code,
+pre.prism-code code,
+[class*='codeBlockLines'] {
+  color: #cbd7e6;
+  font-family: var(--at-font-mono);
+}
+
+/* Code block title bar */
+[class*='codeBlockTitle'] {
+  background: #0b1320;
+  color: #5e7488;
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  border-bottom: 1px solid #1d2a3d;
+}
+
+/* Copy button (dark) */
+[class*='codeBlockContainer'] [class*='copyButton'],
+[class*='buttonGroup'] button {
+  background: #1a2942;
+  border: 1px solid #29405f;
+  color: #9fb3cc;
+}
+
+[class*='codeBlockContainer'] [class*='copyButton']:hover,
+[class*='buttonGroup'] button:hover {
+  background: #1a2942;
+  border-color: #29405f;
+  color: #cbd7e6;
+}
+
+[class*='copyButtonIcon'],
+[class*='copyButtonSuccessIcon'] {
+  color: #9fb3cc;
+}
+
+/* INLINE code — light pill, never dark */
+:not(pre) > code {
+  background: var(--at-code-chip-bg);
+  color: var(--at-code-chip-ink);
+  border: none;
+  border-radius: 5px;
+  padding: 1px 6px;
+  font-size: 0.86em;
+  font-family: var(--at-font-mono);
+  vertical-align: baseline;
+}
+
+/* Keyboard chips */
+kbd {
+  background: var(--at-kbd-bg);
+  border: 1px solid var(--at-border);
+  border-radius: 5px;
+  box-shadow: none;
+  color: var(--at-text-faint);
+  font-family: var(--at-font-mono);
+}
+
+/* ============================================================
+ * 10. Tables — rounded container, uppercase header
+ * ============================================================ */
+.markdown table {
+  display: table;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--at-border);
+  border-radius: 12px;
+  overflow: hidden;
+  font-size: 14px;
+}
+
+.markdown table thead tr {
+  background: var(--at-th-bg);
+}
+
+.markdown table th {
+  background: var(--at-th-bg);
+  text-transform: uppercase;
+  font-size: 12.5px;
+  letter-spacing: 0.03em;
+  color: var(--at-text-muted);
+  font-weight: 600;
+  padding: 12px 16px;
+  border: none;
+  border-bottom: 1px solid var(--at-border);
+}
+
+.markdown table td {
+  padding: 12px 16px;
+  border: none;
+  border-bottom: 1px solid var(--at-border-soft);
+  color: var(--at-text);
+}
+
+.markdown table tr {
+  background: transparent;
+  border: none;
+}
+
+.markdown table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Mono cells (e.g. type/param columns) read as code without the chip */
+.markdown table td code {
+  background: var(--at-code-chip-bg);
+  color: var(--at-code-chip-ink);
+}
+
+/* ============================================================
+ * 11. Pagination — card style links
+ * ============================================================ */
+.pagination-nav__link {
+  border: 1px solid var(--at-border);
+  border-radius: 11px;
+  padding: 14px 18px;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--at-text-faint);
+}
+
+.pagination-nav__sublabel {
+  font-size: 12px;
+  color: var(--at-text-faint);
+}
+
+.pagination-nav__label {
+  color: var(--at-blue);
+  font-weight: 600;
+}
+
+/* ============================================================
+ * 12. Buttons
+ * ============================================================ */
+.button {
+  border-radius: 10px;
+  font-family: var(--at-font-body);
+}
+
+.button--primary {
+  background: var(--at-gradient-btn);
+  border: none;
+  color: #fff;
+}
+
+.button--primary:hover {
+  background: var(--at-gradient-btn);
+  filter: brightness(1.05);
+  color: #fff;
+}
+
+.button--secondary {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  color: var(--at-text-strong);
+}
+
+.button--secondary:hover {
+  border-color: var(--at-text-faint);
+  background: var(--at-surface);
+  color: var(--at-text-strong);
+}
+
+/* ============================================================
+ * 13. Footer — always dark navy band
+ * ============================================================ */
+.footer,
+.footer--dark {
+  background: #0e1726;
+  color: #9fb0c6;
+  border-top: 1px solid #1d2a3d;
+  --ifm-footer-background-color: #0e1726;
+  --ifm-footer-color: #9fb0c6;
+  --ifm-footer-link-color: #9fb0c6;
+  --ifm-footer-title-color: #cbd7e6;
+}
+
+.footer__title {
+  color: #cbd7e6;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.footer__link-item {
+  color: #9fb0c6;
+}
+
+.footer__link-item:hover {
+  color: #fff;
+}
+
+.footer__copyright {
+  color: #5e7488;
+  font-size: 13px;
+}
+
+/* ============================================================
+ * 14. Reduced motion — disable decorative animation
+ * ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,23 +1,955 @@
 /**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
+ * Homepage marketing styles. Consumes the global --at-* token contract
+ * defined by the theme in src/css/custom.css.
  */
 
-.heroBanner {
-  padding: 4rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
+/* ============================ keyframes ============================ */
+@keyframes at-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
-
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
+@keyframes at-spin-rev {
+  to {
+    transform: rotate(-360deg);
+  }
+}
+@keyframes at-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 0.82;
+  }
+}
+@keyframes at-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-9px);
+  }
+}
+@keyframes at-floatx {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(0, -7px);
+  }
+}
+@keyframes at-glow {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(45, 111, 230, 0.32),
+      0 0 38px 6px rgba(20, 184, 176, 0.2);
+  }
+  50% {
+    box-shadow:
+      0 0 0 7px rgba(45, 111, 230, 0.06),
+      0 0 54px 12px rgba(20, 184, 176, 0.3);
+  }
+}
+@keyframes at-chippop {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-3px) scale(1.04);
   }
 }
 
-.buttons {
+/* ============================ section rhythm ============================ */
+.sectionHead {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.eyebrow {
+  font-family: var(--at-font-mono);
+  font-size: 12.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.eyebrowBlue {
+  color: var(--at-blue);
+}
+.eyebrowTeal {
+  color: var(--at-mint);
+}
+
+.sectionTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 38px;
+  letter-spacing: -0.02em;
+  margin: 12px 0 0;
+  color: var(--at-text);
+}
+
+.sectionSubtitle {
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--at-text-muted);
+  margin: 14px 0 0;
+}
+
+/* ============================ HERO ============================ */
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--at-border);
+  background: var(--at-bg);
+}
+
+.heroTint {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(900px 520px at 78% 8%, var(--at-hero-tint1), transparent 60%),
+    radial-gradient(720px 480px at 12% 92%, var(--at-hero-tint2), transparent 60%);
+  pointer-events: none;
+}
+
+.heroGrid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--at-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--at-grid-line) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask-image: radial-gradient(900px 600px at 70% 20%, #000, transparent 78%);
+  pointer-events: none;
+}
+
+.heroInner {
+  position: relative;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 78px 24px 84px;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 48px;
+  align-items: center;
+}
+
+.heroCopy {
+  min-width: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 999px;
+  padding: 5px 13px 5px 7px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--at-text-muted);
+  box-shadow: 0 1px 2px rgba(18, 32, 46, 0.04);
+}
+
+.badgeChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--at-gradient);
+  color: #fff;
+  font-weight: 600;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11.5px;
+}
+
+.heroTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: clamp(40px, 6vw, 58px);
+  line-height: 1.04;
+  letter-spacing: -0.025em;
+  margin: 22px 0 0;
+  color: var(--at-text);
+}
+
+.gradientWord {
+  background: var(--at-gradient-text);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.heroSubtitle {
+  font-size: 18.5px;
+  line-height: 1.62;
+  color: var(--at-text-muted);
+  max-width: 540px;
+  margin: 22px 0 0;
+}
+.heroSubtitle strong {
+  color: var(--at-text-strong);
+  font-weight: 600;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 13px;
+  margin-top: 30px;
+}
+
+.btnPrimary {
+  font-family: var(--at-font-body);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--at-gradient-btn);
+  border: none;
+  padding: 13px 24px;
+  border-radius: 11px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 6px 18px rgba(45, 107, 230, 0.3);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+.btnPrimary:hover {
+  color: #fff;
+  text-decoration: none;
+  box-shadow: 0 8px 24px rgba(45, 107, 230, 0.42);
+  transform: translateY(-1px);
+}
+
+.btnSecondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--at-font-body);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--at-text-strong);
+  text-decoration: none;
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  padding: 13px 20px;
+  border-radius: 11px;
+  transition: border-color 0.2s ease;
+}
+.btnSecondary:hover {
+  color: var(--at-text-strong);
+  text-decoration: none;
+  border-color: var(--at-text-faint);
+}
+
+.installBox {
+  margin-top: 26px;
+  max-width: 540px;
+  background: var(--at-ink);
+  border: 1px solid var(--at-ink-border);
+  border-radius: 12px;
+  padding: 13px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 10px 30px rgba(14, 23, 38, 0.14);
+}
+.installPrompt {
+  color: var(--at-mint);
+  font-family: var(--at-font-mono);
+  font-size: 13px;
+}
+.installCmd {
+  flex: 1;
+  font-family: var(--at-font-mono);
+  font-size: 13px;
+  color: var(--at-ink-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: none;
+  border: 0;
+  padding: 0;
+}
+.installCopy {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  color: #9fb3cc;
+  background: #1a2942;
+  border: 1px solid #29405f;
+  padding: 5px 9px;
+  border-radius: 7px;
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+.installCopy:hover {
+  color: var(--at-ink-text);
+  border-color: #3a567c;
+}
+.copied {
+  color: var(--at-mint);
+}
+
+/* ---------------- hero visual ---------------- */
+.heroVisual {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 440px;
+}
+
+.animToggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  gap: 3px;
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 10px;
+  padding: 3px;
+  z-index: 4;
+  box-shadow: 0 4px 14px rgba(18, 32, 46, 0.06);
+}
+.animTab {
+  font-family: var(--at-font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 5px 11px;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  color: var(--at-text-faint);
+  transition: background 0.2s ease;
+}
+.animTabActive {
+  background: var(--at-gradient-btn);
+  color: #fff;
+}
+
+/* orbit */
+.orbit {
+  position: relative;
+  width: 380px;
+  height: 380px;
+}
+.nucleus {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 58px;
+  height: 58px;
+  margin: -29px 0 0 -29px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #5b8cf0, #1f58c9 70%);
+  animation: at-glow 3.4s ease-in-out infinite;
+}
+.nucleusGlow {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  background: var(--at-teal);
+  opacity: 0.55;
+  filter: blur(2px);
+  animation: at-pulse 3.4s ease-in-out infinite;
+}
+.ringWrap {
+  position: absolute;
+  inset: 0;
+}
+.ringSpin {
+  position: absolute;
+  inset: 0;
+}
+.ringSpin1 {
+  animation: at-spin 7s linear infinite;
+}
+.ringSpin2 {
+  animation: at-spin-rev 9s linear infinite;
+}
+.ringSpin3 {
+  animation: at-spin 8s linear infinite;
+}
+.ring {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 168px;
+  margin-top: -84px;
+  border: 1.5px solid;
+  border-radius: 50%;
+}
+.electron {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  margin: -7px 0 0 -7px;
+  border-radius: 50%;
+}
+.chip {
+  position: absolute;
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 9px;
+  padding: 6px 11px;
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  box-shadow: 0 8px 22px rgba(18, 32, 46, 0.1);
+}
+.chipBlue {
+  color: var(--at-blue);
+}
+.chipTeal {
+  color: var(--at-teal-ink);
+}
+.chipInk {
+  color: var(--at-text-strong);
+}
+.chipTopLeft {
+  left: -34px;
+  top: 26px;
+  animation: at-float 5s ease-in-out infinite;
+}
+.chipTopRight {
+  right: -42px;
+  top: 92px;
+  animation: at-float 6s ease-in-out infinite 0.8s;
+}
+.chipBottomLeft {
+  left: -16px;
+  bottom: 22px;
+  animation: at-float 5.5s ease-in-out infinite 0.4s;
+}
+
+/* compose */
+.compose {
+  position: relative;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: at-floatx 7s ease-in-out infinite;
+}
+.composeCard {
+  width: 320px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 15px 18px;
+  border-radius: 16px;
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+}
+.composeBadge {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 38px;
+  height: 24px;
+  border-radius: 7px;
+  box-shadow: 0 3px 9px rgba(45, 107, 230, 0.3);
+}
+.composeTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--at-text);
+}
+.composeSub {
+  font-family: var(--at-font-mono);
+  font-size: 10.5px;
+  color: var(--at-text-faint2);
+  margin-top: 1px;
+}
+.composeConnector {
+  position: relative;
+  width: 0;
+  height: 40px;
+  margin: 4px 0;
+  border-left: 2px dashed var(--at-border);
+}
+.composeResult {
+  margin-top: 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-radius: 999px;
+  background: var(--at-tip-bg);
+  border: 1px solid var(--at-tip-border);
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--at-tip-ink);
+  animation: at-chippop 2.6s ease-in-out infinite;
+}
+
+/* ============================ THE MAGIC ============================ */
+.magic {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 86px 24px;
+}
+
+.terminal {
+  max-width: 880px;
+  margin: 0 auto;
+  background: var(--at-ink);
+  border: 1px solid var(--at-ink-border);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(14, 23, 38, 0.22);
+}
+.terminalBar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--at-ink-border);
+  background: var(--at-ink-bar);
+}
+.trafficLights {
+  display: flex;
+  gap: 6px;
+  margin: 0 12px 0 6px;
+}
+.trafficLights span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  opacity: 0.7;
+}
+.dotRed {
+  background: #ff5f56;
+}
+.dotYellow {
+  background: #ffbd2e;
+}
+.dotGreen {
+  background: #27c93f;
+}
+.fwTab {
+  font-family: var(--at-font-body);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 6px 13px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #7e91ab;
+  transition: color 0.2s ease;
+}
+.fwTab:hover {
+  color: #e3edf8;
+}
+.fwTabActive {
+  background: rgba(255, 255, 255, 0.07);
+  color: #fff;
+}
+.fileName {
+  margin-left: auto;
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  color: var(--at-ink-faint);
+}
+.terminalCopy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--at-font-mono);
+  font-size: 11.5px;
+  color: #9fb3cc;
+  background: #1a2942;
+  border: 1px solid #29405f;
+  padding: 5px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+.terminalCopy:hover {
+  color: var(--at-ink-text);
+  border-color: #3a567c;
+}
+
+/* Strip the default CodeBlock chrome so the terminal frame owns the visuals. */
+.terminalBody :global(.theme-code-block),
+.terminalBody div[class*='codeBlockContainer'] {
+  margin: 0;
+  box-shadow: none;
+  border-radius: 0;
+  background: transparent;
+}
+.terminalBody pre[class*='codeBlock'],
+.terminalBody div[class*='codeBlockContent'] {
+  border-radius: 0;
+  background: var(--at-ink);
+}
+
+.magicCaption {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 22px;
+  font-size: 14.5px;
+  color: var(--at-text-muted);
+  flex-wrap: wrap;
+}
+.tealPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--at-tip-bg);
+  border: 1px solid var(--at-tip-border);
+  color: var(--at-tip-ink);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+/* ============================ COMPOSABLE dark band ============================ */
+.band {
+  background: var(--at-ink);
+  border-top: 1px solid var(--at-ink-border);
+  border-bottom: 1px solid var(--at-ink-border);
+  position: relative;
+  overflow: hidden;
+}
+.bandGrid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 44px 44px;
+}
+.bandInner {
+  position: relative;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 88px 24px;
+}
+.bandHead {
+  max-width: 640px;
+  margin: 0 auto 52px;
+  text-align: center;
+}
+.bandTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 38px;
+  letter-spacing: -0.02em;
+  margin: 12px 0 0;
+  color: #fff;
+}
+.bandSubtitle {
+  font-size: 17px;
+  line-height: 1.6;
+  color: #9fb0c6;
+  margin: 14px 0 0;
+}
+.bandRow {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.bandCard {
+  flex: 1;
+  min-width: 150px;
+  background: #131e30;
+  border: 1px solid #25364e;
+  border-radius: 14px;
+  padding: 18px;
+}
+.bandCardResult {
+  background: linear-gradient(135deg, #16314f, #123a39);
+  border-color: #2a6e6a;
+}
+.bandEyebrow {
+  font-family: var(--at-font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.bandCode {
+  font-family: var(--at-font-mono);
+  font-size: 13px;
+  color: var(--at-ink-text);
+  margin-top: 9px;
+}
+.bandText {
+  font-size: 12.5px;
+  color: #7e91ab;
+  margin-top: 8px;
+}
+.bandHint {
+  color: #9fb0c6;
+}
+.bandResultValue {
+  font-size: 14px;
+  color: #d6f5ee;
+  margin-top: 9px;
+  font-weight: 600;
+}
+.bandResultCaption {
+  font-size: 12.5px;
+  color: #8fc7bf;
+  margin-top: 8px;
+}
+.bandConnector {
+  display: flex;
+  align-items: center;
+  color: #3a567c;
+  font-size: 22px;
+}
+
+/* ============================ HOW IT WORKS ============================ */
+.howBand {
+  background: var(--at-bg-alt);
+  border-top: 1px solid var(--at-border);
+  border-bottom: 1px solid var(--at-border);
+}
+.howInner {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 80px 24px;
+}
+.howHead {
+  max-width: 620px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+.howTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 34px;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--at-text);
+}
+.howSubtitle {
+  font-size: 16px;
+  color: var(--at-text-muted);
+  margin: 12px 0 0;
+}
+.howGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.howCard {
+  background: var(--at-surface);
+  border: 1px solid var(--at-border);
+  border-radius: 14px;
+  padding: 22px;
+}
+.howNumber {
+  font-family: var(--at-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+}
+.howCardTitle {
+  font-family: var(--at-font-display);
+  font-weight: 600;
+  font-size: 16.5px;
+  margin: 8px 0 0;
+  color: var(--at-text);
+}
+.howCardBody {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--at-text-muted);
+  margin: 7px 0 0;
+}
+.howCode {
+  font-family: var(--at-font-mono);
+  font-size: 12px;
+  color: var(--at-code-chip-ink);
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+/* ============================ FINAL CTA ============================ */
+.ctaSection {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 90px 24px;
+}
+.ctaCard {
+  position: relative;
+  overflow: hidden;
+  border-radius: 22px;
+  background: linear-gradient(135deg, #0e1726 0%, #10243f 55%, #0c2e2c 100%);
+  padding: 64px 48px;
+  text-align: center;
+}
+.ctaGrid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: radial-gradient(600px 300px at 50% 0%, #000, transparent 80%);
+}
+.ctaContent {
+  position: relative;
+}
+.ctaTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 40px;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: #fff;
+}
+.ctaSubtitle {
+  font-size: 17px;
+  color: #9fb0c6;
+  margin: 14px auto 0;
+  max-width: 520px;
+}
+.ctaActions {
+  display: flex;
+  gap: 13px;
+  justify-content: center;
+  margin-top: 30px;
+  flex-wrap: wrap;
+}
+.ctaPrimary {
+  font-family: var(--at-font-body);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--at-ink);
+  background: #fff;
+  border: none;
+  padding: 13px 26px;
+  border-radius: 11px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+.ctaPrimary:hover {
+  color: var(--at-ink);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+.ctaSecondary {
+  font-family: var(--at-font-body);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 13px 22px;
+  border-radius: 11px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+.ctaSecondary:hover {
+  color: #fff;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+/* ============================ responsive ============================ */
+@media (max-width: 996px) {
+  .heroInner {
+    grid-template-columns: 1fr;
+    gap: 36px;
+    padding: 56px 20px 64px;
+  }
+  .heroVisual {
+    min-height: 420px;
+    margin-top: 16px;
+  }
+  .howGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .sectionTitle,
+  .bandTitle {
+    font-size: 32px;
+  }
+}
+
+@media (max-width: 600px) {
+  .magic,
+  .ctaSection {
+    padding: 56px 16px;
+  }
+  .howGrid {
+    grid-template-columns: 1fr;
+  }
+  .ctaCard {
+    padding: 48px 24px;
+  }
+  .ctaTitle {
+    font-size: 32px;
+  }
+  .bandRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .bandConnector {
+    justify-content: center;
+  }
+}
+
+/* ============================ reduced motion ============================ */
+@media (prefers-reduced-motion: reduce) {
+  .nucleus,
+  .nucleusGlow,
+  .ringSpin1,
+  .ringSpin2,
+  .ringSpin3,
+  .chipTopLeft,
+  .chipTopRight,
+  .chipBottomLeft,
+  .compose,
+  .composeResult,
+  .btnPrimary,
+  .btnSecondary,
+  .animTab,
+  .ctaPrimary,
+  .ctaSecondary {
+    animation: none !important;
+    transition: none !important;
+  }
+  .btnPrimary:hover,
+  .ctaPrimary:hover {
+    transform: none;
+  }
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,36 +1,518 @@
+import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
-import React from 'react';
+import React, { type JSX, type ReactNode, useCallback, useRef, useState } from 'react';
 
 import styles from './index.module.css';
 
-function HomepageHeader() {
-  const { siteConfig } = useDocusaurusContext();
+const GITHUB_URL = 'https://github.com/atomic-testing/atomic-testing';
+const HERO_INSTALL = 'pnpm add @atomic-testing/core @atomic-testing/react-19';
+const COPY_FEEDBACK_MS = 1600;
+
+const reactCode = `import { createTestEngine } from '@atomic-testing/react-19';
+import { HTMLButtonDriver, HTMLComponentDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId } from '@atomic-testing/core';
+
+// One scene definition — reused on every runtime
+const scene = {
+  greeting: { locator: byDataTestId('greeting'),   driver: HTMLComponentDriver },
+  button:   { locator: byDataTestId('welcome-btn'), driver: HTMLButtonDriver },
+};
+
+it('welcomes the user on click', async () => {
+  const engine = createTestEngine(<Welcome name="Alice" />, scene);
+
+  expect(await engine.parts.greeting.getText()).toBe('Hello Alice!');
+  await engine.parts.button.click();
+  expect(await engine.parts.button.getText()).toBe('Welcome!');
+
+  await engine.cleanUp();
+});`;
+
+const vueCode = `import { createTestEngine } from '@atomic-testing/vue-3';
+import { HTMLButtonDriver, HTMLComponentDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId } from '@atomic-testing/core';
+import Welcome from './Welcome.vue';
+
+// Same scene definition — nothing changes
+const scene = {
+  greeting: { locator: byDataTestId('greeting'),   driver: HTMLComponentDriver },
+  button:   { locator: byDataTestId('welcome-btn'), driver: HTMLButtonDriver },
+};
+
+it('welcomes the user on click', async () => {
+  const engine = createTestEngine(Welcome, scene);
+
+  expect(await engine.parts.greeting.getText()).toBe('Hello Alice!');
+  await engine.parts.button.click();
+  expect(await engine.parts.button.getText()).toBe('Welcome!');
+
+  await engine.cleanUp();
+});`;
+
+const playCode = `import { createTestEngine } from '@atomic-testing/playwright';
+import { HTMLButtonDriver, HTMLComponentDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId } from '@atomic-testing/core';
+import { test, expect } from '@playwright/test';
+
+// Same scene definition — nothing changes
+const scene = {
+  greeting: { locator: byDataTestId('greeting'),   driver: HTMLComponentDriver },
+  button:   { locator: byDataTestId('welcome-btn'), driver: HTMLButtonDriver },
+};
+
+test('welcomes the user on click', async ({ page }) => {
+  await page.goto('/welcome');
+  const engine = createTestEngine(page, scene);
+
+  expect(await engine.parts.greeting.getText()).toBe('Hello Alice!');
+  await engine.parts.button.click();
+  expect(await engine.parts.button.getText()).toBe('Welcome!');
+
+  await engine.cleanUp();
+});`;
+
+type FrameworkId = 'react' | 'vue' | 'playwright';
+
+type Framework = {
+  id: FrameworkId;
+  label: string;
+  accent: string;
+  code: string;
+};
+
+const frameworks: Framework[] = [
+  { id: 'react', label: '⚛ React', accent: '#38bdf8', code: reactCode },
+  { id: 'vue', label: '💚 Vue 3', accent: '#14b8b0', code: vueCode },
+  { id: 'playwright', label: '🎭 Playwright', accent: '#6366f1', code: playCode },
+];
+
+type AnimationId = 'orbit' | 'compose';
+
+function GitHubIcon({ size = 18 }: { size?: number }): JSX.Element {
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className='container'>
-        <h1 className='hero__title'>{siteConfig.title}</h1>
-        <p className='hero__subtitle'>{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link className='button button--secondary button--lg' to='/docs/quick-start'>
-            Get started
-          </Link>
+    <svg width={size} height={size} viewBox='0 0 16 16' fill='currentColor' aria-hidden='true'>
+      <path d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z' />
+    </svg>
+  );
+}
+
+function useCopy(): { copied: boolean; copy: (text: string) => void } {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copy = useCallback((text: string) => {
+    void navigator.clipboard?.writeText(text);
+    setCopied(true);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  }, []);
+
+  return { copied, copy };
+}
+
+function InstallBox(): JSX.Element {
+  const { copied, copy } = useCopy();
+  return (
+    <div className={styles.installBox}>
+      <span className={styles.installPrompt}>$</span>
+      <code className={styles.installCmd}>{HERO_INSTALL}</code>
+      <button
+        type='button'
+        className={styles.installCopy}
+        onClick={() => copy(HERO_INSTALL)}
+        aria-label='Copy install command'
+      >
+        {copied ? <span className={styles.copied}>✓ copied</span> : <span>copy</span>}
+      </button>
+    </div>
+  );
+}
+
+function OrbitVisual(): JSX.Element {
+  return (
+    <div className={styles.orbit}>
+      <div className={styles.nucleus} />
+      <div className={styles.nucleusGlow} />
+
+      <div className={styles.ringWrap} style={{ transform: 'rotate(0deg)' }}>
+        <div className={clsx(styles.ringSpin, styles.ringSpin1)}>
+          <div className={styles.ring} style={{ borderColor: 'rgba(45,107,230,.40)' }} />
+          <div
+            className={styles.electron}
+            style={{ background: '#2d6be3', boxShadow: '0 0 14px rgba(45,107,230,.7)' }}
+          />
         </div>
       </div>
-    </header>
+
+      <div className={styles.ringWrap} style={{ transform: 'rotate(60deg)' }}>
+        <div className={clsx(styles.ringSpin, styles.ringSpin2)}>
+          <div className={styles.ring} style={{ borderColor: 'rgba(20,184,176,.40)' }} />
+          <div
+            className={styles.electron}
+            style={{ background: '#14b8b0', boxShadow: '0 0 14px rgba(20,184,176,.7)' }}
+          />
+        </div>
+      </div>
+
+      <div className={styles.ringWrap} style={{ transform: 'rotate(120deg)' }}>
+        <div className={clsx(styles.ringSpin, styles.ringSpin3)}>
+          <div className={styles.ring} style={{ borderColor: 'rgba(56,189,248,.42)' }} />
+          <div
+            className={styles.electron}
+            style={{ background: '#38bdf8', boxShadow: '0 0 14px rgba(56,189,248,.7)' }}
+          />
+        </div>
+      </div>
+
+      <span className={clsx(styles.chip, styles.chipBlue, styles.chipTopLeft)}>byDataTestId()</span>
+      <span className={clsx(styles.chip, styles.chipTeal, styles.chipTopRight)}>MUIButtonDriver</span>
+      <span className={clsx(styles.chip, styles.chipInk, styles.chipBottomLeft)}>engine.parts</span>
+    </div>
+  );
+}
+
+function ComposeVisual(): JSX.Element {
+  const tiers: { title: string; subtitle: string; accent: string }[] = [
+    { title: 'Atoms', subtitle: 'Button · Input · Select', accent: '#2d6be3' },
+    { title: 'Molecules', subtitle: 'SearchField · FormRow', accent: '#14b8b0' },
+    { title: 'Organism', subtitle: 'LoginForm → Page', accent: '#38bdf8' },
+  ];
+  return (
+    <div className={styles.compose}>
+      {tiers.map((tier, index) => (
+        <React.Fragment key={tier.title}>
+          <div className={styles.composeCard} style={{ borderColor: tier.accent }}>
+            <span className={styles.composeBadge} style={{ background: tier.accent }} aria-hidden='true' />
+            <div>
+              <div className={styles.composeTitle}>{tier.title}</div>
+              <div className={styles.composeSub}>{tier.subtitle}</div>
+            </div>
+          </div>
+          {index < tiers.length - 1 ? <div className={styles.composeConnector} aria-hidden='true' /> : null}
+        </React.Fragment>
+      ))}
+      <div className={styles.composeResult}>✓ composed test · runs anywhere</div>
+    </div>
+  );
+}
+
+function AnimationToggle({
+  active,
+  onSelect,
+}: {
+  active: AnimationId;
+  onSelect: (id: AnimationId) => void;
+}): JSX.Element {
+  return (
+    <div className={styles.animToggle} role='tablist' aria-label='Hero visual'>
+      <button
+        type='button'
+        role='tab'
+        aria-selected={active === 'orbit'}
+        className={clsx(styles.animTab, active === 'orbit' && styles.animTabActive)}
+        onClick={() => onSelect('orbit')}
+      >
+        ⚛ Orbit
+      </button>
+      <button
+        type='button'
+        role='tab'
+        aria-selected={active === 'compose'}
+        className={clsx(styles.animTab, active === 'compose' && styles.animTabActive)}
+        onClick={() => onSelect('compose')}
+      >
+        🧩 Assemble
+      </button>
+    </div>
+  );
+}
+
+function HeroSection(): JSX.Element {
+  const [animation, setAnimation] = useState<AnimationId>('orbit');
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroTint} aria-hidden='true' />
+      <div className={styles.heroGrid} aria-hidden='true' />
+      <div className={styles.heroInner}>
+        <div className={styles.heroCopy}>
+          <div className={styles.badge}>
+            <span className={styles.badgeChip}>v3 · stable</span>
+            Portable UI testing for React · Vue · Playwright
+          </div>
+
+          <h1 className={styles.heroTitle}>
+            Write your UI tests
+            <br />
+            <span className={styles.gradientWord}>once.</span> Run them anywhere.
+          </h1>
+
+          <p className={styles.heroSubtitle}>
+            Atomic Testing composes tiny, reusable <strong>component drivers</strong> into portable test scenes — so the
+            same semantic test runs across frameworks, libraries, and environments. Learn once, test any UI.
+          </p>
+
+          <div className={styles.heroActions}>
+            <Link className={styles.btnPrimary} to='/docs/quick-start'>
+              Get started →
+            </Link>
+            <a className={styles.btnSecondary} href={GITHUB_URL} target='_blank' rel='noopener noreferrer'>
+              <GitHubIcon />
+              Star on GitHub
+            </a>
+          </div>
+
+          <InstallBox />
+        </div>
+
+        <div className={styles.heroVisual}>
+          <AnimationToggle active={animation} onSelect={setAnimation} />
+          {animation === 'orbit' ? <OrbitVisual /> : <ComposeVisual />}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MagicSection(): JSX.Element {
+  const [active, setActive] = useState<FrameworkId>('react');
+  const { copied, copy } = useCopy();
+  const activeFramework = frameworks.find((framework) => framework.id === active) ?? frameworks[0];
+
+  return (
+    <section className={styles.magic}>
+      <header className={styles.sectionHead}>
+        <div className={clsx(styles.eyebrow, styles.eyebrowBlue)}>The magic</div>
+        <h2 className={styles.sectionTitle}>One test. Every framework.</h2>
+        <p className={styles.sectionSubtitle}>
+          Switch the runtime tab — notice the scene definition and the test body never change. Only the import and mount
+          line differ.
+        </p>
+      </header>
+
+      <div className={styles.terminal}>
+        <div className={styles.terminalBar}>
+          <span className={styles.trafficLights} aria-hidden='true'>
+            <span className={styles.dotRed} />
+            <span className={styles.dotYellow} />
+            <span className={styles.dotGreen} />
+          </span>
+          {frameworks.map((framework) => (
+            <button
+              type='button'
+              key={framework.id}
+              className={clsx(styles.fwTab, active === framework.id && styles.fwTabActive)}
+              style={active === framework.id ? { boxShadow: `inset 0 -2px 0 ${framework.accent}` } : undefined}
+              onClick={() => setActive(framework.id)}
+              aria-pressed={active === framework.id}
+            >
+              {framework.label}
+            </button>
+          ))}
+          <span className={styles.fileName}>welcome.test.ts</span>
+          <button
+            type='button'
+            className={styles.terminalCopy}
+            onClick={() => copy(activeFramework.code)}
+            aria-label='Copy test code'
+          >
+            {copied ? <span className={styles.copied}>✓ copied</span> : <span>copy</span>}
+          </button>
+        </div>
+        <div className={styles.terminalBody}>
+          <CodeBlock language='tsx'>{activeFramework.code}</CodeBlock>
+        </div>
+      </div>
+
+      <div className={styles.magicCaption}>
+        <span className={styles.tealPill}>✓ identical scene &amp; assertions</span>
+        <span>— your testing knowledge transfers completely.</span>
+      </div>
+    </section>
+  );
+}
+
+type ComposeStep = {
+  eyebrow: string;
+  eyebrowColor: string;
+  code?: string;
+  text: ReactNode;
+  caption: ReactNode;
+  variant?: 'result';
+};
+
+const composeSteps: ComposeStep[] = [
+  {
+    eyebrow: 'Locator',
+    eyebrowColor: '#5fe3c8',
+    code: "byDataTestId('btn')",
+    text: 'Finds the element — by test id, role, text or CSS.',
+    caption: '',
+  },
+  {
+    eyebrow: 'Driver',
+    eyebrowColor: '#38bdf8',
+    code: 'MUIButtonDriver',
+    text: (
+      <>
+        Semantic API — <span className={styles.bandHint}>.click()</span>,{' '}
+        <span className={styles.bandHint}>.getText()</span>.
+      </>
+    ),
+    caption: '',
+  },
+  {
+    eyebrow: 'Scene → Engine',
+    eyebrowColor: '#2d6be3',
+    code: 'engine.parts.btn',
+    text: 'Orchestrates the whole test, any runtime.',
+    caption: '',
+  },
+  {
+    eyebrow: 'Result',
+    eyebrowColor: '#5fe3c8',
+    text: '✓ Passing everywhere',
+    caption: 'React · Vue · Playwright · DOM.',
+    variant: 'result',
+  },
+];
+
+function ComposableSection(): JSX.Element {
+  const connectors = ['+', '→', '='];
+  return (
+    <section className={styles.band}>
+      <div className={styles.bandGrid} aria-hidden='true' />
+      <div className={styles.bandInner}>
+        <header className={styles.bandHead}>
+          <div className={clsx(styles.eyebrow, styles.eyebrowTeal)}>Composable by design</div>
+          <h2 className={styles.bandTitle}>Small atoms. Infinite tests.</h2>
+          <p className={styles.bandSubtitle}>
+            Each primitive is tiny and replaceable. Compose them like atoms into molecules — locators and drivers snap
+            into scenes, scenes into engines, engines into suites that outlive any framework.
+          </p>
+        </header>
+        <div className={styles.bandRow}>
+          {composeSteps.map((step, index) => (
+            <React.Fragment key={step.eyebrow}>
+              <div className={clsx(styles.bandCard, step.variant === 'result' && styles.bandCardResult)}>
+                <div className={styles.bandEyebrow} style={{ color: step.eyebrowColor }}>
+                  {step.eyebrow}
+                </div>
+                {step.variant === 'result' ? (
+                  <div className={styles.bandResultValue}>{step.text}</div>
+                ) : (
+                  <div className={styles.bandCode}>{step.code}</div>
+                )}
+                <div className={step.variant === 'result' ? styles.bandResultCaption : styles.bandText}>
+                  {step.variant === 'result' ? step.caption : step.text}
+                </div>
+              </div>
+              {index < connectors.length ? (
+                <div className={styles.bandConnector} aria-hidden='true'>
+                  {connectors[index]}
+                </div>
+              ) : null}
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type HowStep = {
+  number: string;
+  color: string;
+  title: string;
+  description: ReactNode;
+};
+
+const howSteps: HowStep[] = [
+  { number: '01', color: '#2d6be3', title: 'ScenePart', description: 'Declare which components matter to the test.' },
+  {
+    number: '02',
+    color: '#14b8b0',
+    title: 'Locators',
+    description: (
+      <>
+        Find components with <code className={styles.howCode}>byDataTestId()</code> &amp; friends.
+      </>
+    ),
+  },
+  { number: '03', color: '#38bdf8', title: 'Drivers', description: 'Use semantic APIs instead of DOM manipulation.' },
+  {
+    number: '04',
+    color: '#2d6be3',
+    title: 'TestEngine',
+    description: 'Orchestrates everything together, in any runtime.',
+  },
+];
+
+function HowItWorksSection(): JSX.Element {
+  return (
+    <section className={styles.howBand}>
+      <div className={styles.howInner}>
+        <header className={styles.howHead}>
+          <h2 className={styles.howTitle}>What just happened?</h2>
+          <p className={styles.howSubtitle}>Four building blocks orchestrate every test.</p>
+        </header>
+        <div className={styles.howGrid}>
+          {howSteps.map((step) => (
+            <div key={step.number} className={styles.howCard}>
+              <div className={styles.howNumber} style={{ color: step.color }}>
+                {step.number}
+              </div>
+              <div className={styles.howCardTitle}>{step.title}</div>
+              <p className={styles.howCardBody}>{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FinalCtaSection(): JSX.Element {
+  return (
+    <section className={styles.ctaSection}>
+      <div className={styles.ctaCard}>
+        <div className={styles.ctaGrid} aria-hidden='true' />
+        <div className={styles.ctaContent}>
+          <h2 className={styles.ctaTitle}>Test once. Ship with confidence.</h2>
+          <p className={styles.ctaSubtitle}>Get your first portable test running in five minutes.</p>
+          <div className={styles.ctaActions}>
+            <Link className={styles.ctaPrimary} to='/docs/quick-start'>
+              Read the Quick Start →
+            </Link>
+            <Link className={styles.ctaSecondary} to='/docs/api-overview'>
+              Browse the API
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
 export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout title={`Hello from ${siteConfig.title}`} description='Description will go into a meta tag in <head />'>
-      <HomepageHeader />
+    <Layout
+      title={`${siteConfig.title} — Write your UI tests once`}
+      description='Portable UI testing library. Compose reusable component drivers into test scenes that run across React, Vue, Playwright and the DOM.'
+    >
       <main>
+        <HeroSection />
+        <MagicSection />
+        <ComposableSection />
         <HomepageFeatures />
+        <HowItWorksSection />
+        <FinalCtaSection />
       </main>
     </Layout>
   );

--- a/docs/static/img/logo-atom.svg
+++ b/docs/static/img/logo-atom.svg
@@ -1,0 +1,14 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Atomic Testing">
+  <defs>
+    <linearGradient id="atNucleus" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2d6be3" />
+      <stop offset="1" stop-color="#14b8b0" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(16 16)" fill="none" stroke-width="1.5">
+    <ellipse rx="13" ry="5" stroke="#2d6be3" stroke-opacity="0.6" transform="rotate(0)" />
+    <ellipse rx="13" ry="5" stroke="#14b8b0" stroke-opacity="0.6" transform="rotate(60)" />
+    <ellipse rx="13" ry="5" stroke="#38bdf8" stroke-opacity="0.6" transform="rotate(120)" />
+  </g>
+  <circle cx="16" cy="16" r="4" fill="url(#atNucleus)" />
+</svg>


### PR DESCRIPTION

Reskins the Docusaurus documentation site to match the new Claude Design system. Rebuilds the
marketing homepage and re-themes the entire reading view — navbar, sidebar, admonitions, code
blocks, tables and footer — with a shared light/dark token system, custom fonts and an atom logo.

## Key Changes

- Add full `--at-*` token theme in custom.css: fonts, navbar, sidebar, admonitions, code, footer
- Rebuild homepage (hero, framework-swap code tabs, composable band, features, CTA) + atom logo
- Add dark-navy Prism code theme; fix dark-mode page background + active navbar-link styling

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
