### PR TITLE
Backfill missing MUI driver behaviors across v5, v6, and v7

### DIFF
--- a/package-tests/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
+++ b/package-tests/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
@@ -79,6 +79,31 @@ export const BasicAutoComplete: React.FunctionComponent = () => {
           renderInput={params => <TextField {...params} label='Movie' />}
         />
       </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>No options: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='empty-options-auto-complete'
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>Loading: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='loading-auto-complete'
+          loading
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/package-tests/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/package-tests/component-driver-mui-v5-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -33,6 +33,16 @@ export const basicAutoCompleteExampleScenePart = {
     locator: byDataTestId('disabled-auto-complete'),
     driver: AutoCompleteDriver,
   },
+
+  emptyOptionsSelect: {
+    locator: byDataTestId('empty-options-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+
+  loadingSelect: {
+    locator: byDataTestId('loading-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
 } satisfies ScenePart;
 
 export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExampleScenePart, JSX.Element> = {
@@ -43,7 +53,7 @@ export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExam
 export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteExample.scene> = {
   title: 'Basic AutoComplete',
   url: '/autocomplete',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicAutoCompleteExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Selected label should be empty initially', async () => {
@@ -71,6 +81,29 @@ export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteE
     test('Disabled select should be disabled', async () => {
       const isDisabled = await engine().parts.disabledSelect.isDisabled();
       assertTrue(isDisabled);
+    });
+
+    test('No-options state is detected once the popup is opened', async () => {
+      await engine().parts.emptyOptionsSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.emptyOptionsSelect.isLoading());
+    });
+
+    test('Loading state is detected once the popup is opened', async () => {
+      await engine().parts.loadingSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.loadingSelect.isLoading());
+      assertFalse(await engine().parts.loadingSelect.hasNoOptions());
+    });
+
+    test('Neither state is reported while the popup is closed', async () => {
+      assertFalse(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.loadingSelect.isLoading());
+    });
+
+    test('Neither state is reported when options are available', async () => {
+      await engine().parts.select.parts.input.setValue('The');
+      assertFalse(await engine().parts.select.hasNoOptions());
+      assertFalse(await engine().parts.select.isLoading());
     });
   },
 };

--- a/package-tests/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.suite.ts
+++ b/package-tests/component-driver-mui-v5-test/src/examples/checkbox/IconCheckbox.suite.ts
@@ -23,12 +23,17 @@ export const iconCheckboxExample: IExampleUnit<typeof iconCheckboxExampleScenePa
 export const iconCheckboxTestSuite: TestSuiteInfo<typeof iconCheckboxExample.scene> = {
   title: 'Icon Checkbox',
   url: '/checkbox',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse, assertEqual }) => {
     const engine = useTestEngine(iconCheckboxExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Favorite checkbox should not be selected initially', async () => {
       const isSelected = await engine().parts.favorite.isSelected();
       assertFalse(isSelected);
+    });
+
+    test('Icon checkbox without a FormControlLabel has no label', async () => {
+      const label = await engine().parts.favorite.getLabel();
+      assertEqual(label, undefined);
     });
 
     test('Bookmark checkbox should not be selected initially', async () => {

--- a/package-tests/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.suite.ts
+++ b/package-tests/component-driver-mui-v5-test/src/examples/checkbox/LabelCheckbox.suite.ts
@@ -23,12 +23,22 @@ export const labelCheckboxExample: IExampleUnit<typeof labelCheckboxExampleScene
 export const labelCheckboxTestSuite: TestSuiteInfo<typeof labelCheckboxExample.scene> = {
   title: 'Label Checkbox',
   url: '/checkbox',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse, assertEqual }) => {
     const engine = useTestEngine(labelCheckboxExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Apple checkbox should be checked by default', async () => {
       const isSelected = await engine().parts.apple.isSelected();
       assertTrue(isSelected);
+    });
+
+    test('Apple checkbox exposes its label text', async () => {
+      const label = await engine().parts.apple.getLabel();
+      assertEqual(label, 'Apple');
+    });
+
+    test('Banana checkbox exposes its own label, not a sibling label', async () => {
+      const label = await engine().parts.banana.getLabel();
+      assertEqual(label, 'Banana');
     });
 
     test('Banana checkbox should not be checked by default', async () => {

--- a/package-tests/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.suite.ts
+++ b/package-tests/component-driver-mui-v5-test/src/examples/dialog/AlertDialog.suite.ts
@@ -64,5 +64,14 @@ export const alertDialogTestSuite: TestSuiteInfo<typeof alertDialogExample.scene
       const isOpen = await engine().parts.dialog.isOpen();
       assertFalse(isOpen);
     });
+
+    test('Clicking the backdrop should close the dialog', async () => {
+      await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
+
+      const closed = await engine().parts.dialog.closeByBackdropClick();
+      assertTrue(closed);
+      assertFalse(await engine().parts.dialog.isOpen());
+    });
   },
 };

--- a/package-tests/component-driver-mui-v5-test/src/examples/rating/Rating.examples.tsx
+++ b/package-tests/component-driver-mui-v5-test/src/examples/rating/Rating.examples.tsx
@@ -26,7 +26,12 @@ export const BasicRating: React.FunctionComponent = () => {
       <Divider />
 
       <Typography>Readonly</Typography>
-      <Rating data-testid='readonly' aria-label='SSS' precision={0.5} value={2.5} readOnly />
+      <Rating data-testid='readonly' precision={0.5} value={2.5} readOnly />
+
+      <Divider />
+
+      <Typography>Readonly with custom label</Typography>
+      <Rating data-testid='readonly-custom-label' aria-label='Great movie' value={3} readOnly />
 
       <Divider />
 

--- a/package-tests/component-driver-mui-v5-test/src/examples/rating/Rating.suite.ts
+++ b/package-tests/component-driver-mui-v5-test/src/examples/rating/Rating.suite.ts
@@ -13,6 +13,10 @@ export const basicRatingExampleScenePart = {
     locator: byDataTestId('readonly'),
     driver: RatingDriver,
   },
+  readonlyCustomLabel: {
+    locator: byDataTestId('readonly-custom-label'),
+    driver: RatingDriver,
+  },
   disabled: {
     locator: byDataTestId('disabled'),
     driver: RatingDriver,
@@ -31,7 +35,7 @@ export const basicRatingExample: IExampleUnit<typeof basicRatingExampleScenePart
 export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene> = {
   title: 'Basic Rating',
   url: '/rating',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicRatingExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Basic rating should exist', async () => {
@@ -55,14 +59,29 @@ export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene
       assertTrue(exists);
     });
 
+    test('Readonly rating value is read from the accessible aria-label', async () => {
+      const value = await engine().parts.readonly.getValue();
+      assertEqual(value, 2.5);
+    });
+
+    test('Readonly rating with a custom label falls back to counting filled stars', async () => {
+      const value = await engine().parts.readonlyCustomLabel.getValue();
+      assertEqual(value, 3);
+    });
+
     test('Disabled rating should exist', async () => {
       const exists = await engine().parts.disabled.exists();
       assertTrue(exists);
     });
 
+    test('isDisabled reflects the disabled state', async () => {
+      assertTrue(await engine().parts.disabled.isDisabled());
+      assertFalse(await engine().parts.basic.isDisabled());
+    });
+
     test('Initially empty rating should start empty', async () => {
       const value = await engine().parts.initiallyEmpty.getValue();
-      assertEqual(value || 0, 0);
+      assertEqual(value, null);
     });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
@@ -79,6 +79,31 @@ export const BasicAutoComplete: React.FunctionComponent = () => {
           renderInput={params => <TextField {...params} label='Movie' />}
         />
       </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>No options: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='empty-options-auto-complete'
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>Loading: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='loading-auto-complete'
+          loading
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -33,6 +33,16 @@ export const basicAutoCompleteExampleScenePart = {
     locator: byDataTestId('disabled-auto-complete'),
     driver: AutoCompleteDriver,
   },
+
+  emptyOptionsSelect: {
+    locator: byDataTestId('empty-options-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+
+  loadingSelect: {
+    locator: byDataTestId('loading-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
 } satisfies ScenePart;
 
 export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExampleScenePart, JSX.Element> = {
@@ -43,7 +53,7 @@ export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExam
 export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteExample.scene> = {
   title: 'Basic AutoComplete',
   url: '/autocomplete',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicAutoCompleteExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Selected label should be empty initially', async () => {
@@ -71,6 +81,29 @@ export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteE
     test('Disabled select should be disabled', async () => {
       const isDisabled = await engine().parts.disabledSelect.isDisabled();
       assertTrue(isDisabled);
+    });
+
+    test('No-options state is detected once the popup is opened', async () => {
+      await engine().parts.emptyOptionsSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.emptyOptionsSelect.isLoading());
+    });
+
+    test('Loading state is detected once the popup is opened', async () => {
+      await engine().parts.loadingSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.loadingSelect.isLoading());
+      assertFalse(await engine().parts.loadingSelect.hasNoOptions());
+    });
+
+    test('Neither state is reported while the popup is closed', async () => {
+      assertFalse(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.loadingSelect.isLoading());
+    });
+
+    test('Neither state is reported when options are available', async () => {
+      await engine().parts.select.parts.input.setValue('The');
+      assertFalse(await engine().parts.select.hasNoOptions());
+      assertFalse(await engine().parts.select.isLoading());
     });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/checkbox/IconCheckbox.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/checkbox/IconCheckbox.suite.ts
@@ -23,12 +23,17 @@ export const iconCheckboxExample: IExampleUnit<typeof iconCheckboxExampleScenePa
 export const iconCheckboxTestSuite: TestSuiteInfo<typeof iconCheckboxExample.scene> = {
   title: 'Icon Checkbox',
   url: '/checkbox',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse, assertEqual }) => {
     const engine = useTestEngine(iconCheckboxExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Favorite checkbox should not be selected initially', async () => {
       const isSelected = await engine().parts.favorite.isSelected();
       assertFalse(isSelected);
+    });
+
+    test('Icon checkbox without a FormControlLabel has no label', async () => {
+      const label = await engine().parts.favorite.getLabel();
+      assertEqual(label, undefined);
     });
 
     test('Bookmark checkbox should not be selected initially', async () => {

--- a/package-tests/component-driver-mui-v6-test/src/examples/checkbox/LabelCheckbox.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/checkbox/LabelCheckbox.suite.ts
@@ -23,12 +23,22 @@ export const labelCheckboxExample: IExampleUnit<typeof labelCheckboxExampleScene
 export const labelCheckboxTestSuite: TestSuiteInfo<typeof labelCheckboxExample.scene> = {
   title: 'Label Checkbox',
   url: '/checkbox',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertFalse, assertEqual }) => {
     const engine = useTestEngine(labelCheckboxExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Apple checkbox should be checked by default', async () => {
       const isSelected = await engine().parts.apple.isSelected();
       assertTrue(isSelected);
+    });
+
+    test('Apple checkbox exposes its label text', async () => {
+      const label = await engine().parts.apple.getLabel();
+      assertEqual(label, 'Apple');
+    });
+
+    test('Banana checkbox exposes its own label, not a sibling label', async () => {
+      const label = await engine().parts.banana.getLabel();
+      assertEqual(label, 'Banana');
     });
 
     test('Banana checkbox should not be checked by default', async () => {

--- a/package-tests/component-driver-mui-v6-test/src/examples/dialog/AlertDialog.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/dialog/AlertDialog.suite.ts
@@ -64,5 +64,14 @@ export const alertDialogTestSuite: TestSuiteInfo<typeof alertDialogExample.scene
       const isOpen = await engine().parts.dialog.isOpen();
       assertFalse(isOpen);
     });
+
+    test('Clicking the backdrop should close the dialog', async () => {
+      await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
+
+      const closed = await engine().parts.dialog.closeByBackdropClick();
+      assertTrue(closed);
+      assertFalse(await engine().parts.dialog.isOpen());
+    });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/rating/Rating.examples.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/examples/rating/Rating.examples.tsx
@@ -26,7 +26,12 @@ export const BasicRating: React.FunctionComponent = () => {
       <Divider />
 
       <Typography>Readonly</Typography>
-      <Rating data-testid='readonly' aria-label='SSS' precision={0.5} value={2.5} readOnly />
+      <Rating data-testid='readonly' precision={0.5} value={2.5} readOnly />
+
+      <Divider />
+
+      <Typography>Readonly with custom label</Typography>
+      <Rating data-testid='readonly-custom-label' aria-label='Great movie' value={3} readOnly />
 
       <Divider />
 

--- a/package-tests/component-driver-mui-v6-test/src/examples/rating/Rating.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/rating/Rating.suite.ts
@@ -13,6 +13,10 @@ export const basicRatingExampleScenePart = {
     locator: byDataTestId('readonly'),
     driver: RatingDriver,
   },
+  readonlyCustomLabel: {
+    locator: byDataTestId('readonly-custom-label'),
+    driver: RatingDriver,
+  },
   disabled: {
     locator: byDataTestId('disabled'),
     driver: RatingDriver,
@@ -31,7 +35,7 @@ export const basicRatingExample: IExampleUnit<typeof basicRatingExampleScenePart
 export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene> = {
   title: 'Basic Rating',
   url: '/rating',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicRatingExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Basic rating should exist', async () => {
@@ -55,14 +59,29 @@ export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene
       assertTrue(exists);
     });
 
+    test('Readonly rating value is read from the accessible aria-label', async () => {
+      const value = await engine().parts.readonly.getValue();
+      assertEqual(value, 2.5);
+    });
+
+    test('Readonly rating with a custom label falls back to counting filled stars', async () => {
+      const value = await engine().parts.readonlyCustomLabel.getValue();
+      assertEqual(value, 3);
+    });
+
     test('Disabled rating should exist', async () => {
       const exists = await engine().parts.disabled.exists();
       assertTrue(exists);
     });
 
+    test('isDisabled reflects the disabled state', async () => {
+      assertTrue(await engine().parts.disabled.isDisabled());
+      assertFalse(await engine().parts.basic.isDisabled());
+    });
+
     test('Initially empty rating should start empty', async () => {
       const value = await engine().parts.initiallyEmpty.getValue();
-      assertEqual(value || 0, 0);
+      assertEqual(value, null);
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.examples.tsx
@@ -79,6 +79,31 @@ export const BasicAutoComplete: React.FunctionComponent = () => {
           renderInput={params => <TextField {...params} label='Movie' />}
         />
       </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>No options: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='empty-options-auto-complete'
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
+
+      <Stack direction='column'>
+        <Stack direction='row'>
+          <span>Loading: </span>
+        </Stack>
+        <Autocomplete
+          data-testid='loading-auto-complete'
+          loading
+          options={[] as string[]}
+          sx={{ width: 300 }}
+          renderInput={params => <TextField {...params} label='Movie' />}
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -33,6 +33,16 @@ export const basicAutoCompleteExampleScenePart = {
     locator: byDataTestId('disabled-auto-complete'),
     driver: AutoCompleteDriver,
   },
+
+  emptyOptionsSelect: {
+    locator: byDataTestId('empty-options-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
+
+  loadingSelect: {
+    locator: byDataTestId('loading-auto-complete'),
+    driver: AutoCompleteDriver,
+  },
 } satisfies ScenePart;
 
 export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExampleScenePart, JSX.Element> = {
@@ -43,7 +53,7 @@ export const basicAutoCompleteExample: IExampleUnit<typeof basicAutoCompleteExam
 export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteExample.scene> = {
   title: 'Basic AutoComplete',
   url: '/autocomplete',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicAutoCompleteExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Selected label should be empty initially', async () => {
@@ -71,6 +81,29 @@ export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteE
     test('Disabled select should be disabled', async () => {
       const isDisabled = await engine().parts.disabledSelect.isDisabled();
       assertTrue(isDisabled);
+    });
+
+    test('No-options state is detected once the popup is opened', async () => {
+      await engine().parts.emptyOptionsSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.emptyOptionsSelect.isLoading());
+    });
+
+    test('Loading state is detected once the popup is opened', async () => {
+      await engine().parts.loadingSelect.parts.input.setValue('a');
+      assertTrue(await engine().parts.loadingSelect.isLoading());
+      assertFalse(await engine().parts.loadingSelect.hasNoOptions());
+    });
+
+    test('Neither state is reported while the popup is closed', async () => {
+      assertFalse(await engine().parts.emptyOptionsSelect.hasNoOptions());
+      assertFalse(await engine().parts.loadingSelect.isLoading());
+    });
+
+    test('Neither state is reported when options are available', async () => {
+      await engine().parts.select.parts.input.setValue('The');
+      assertFalse(await engine().parts.select.hasNoOptions());
+      assertFalse(await engine().parts.select.isLoading());
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/dialog/AlertDialog.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/dialog/AlertDialog.suite.ts
@@ -64,5 +64,14 @@ export const alertDialogTestSuite: TestSuiteInfo<typeof alertDialogExample.scene
       const isOpen = await engine().parts.dialog.isOpen();
       assertFalse(isOpen);
     });
+
+    test('Clicking the backdrop should close the dialog', async () => {
+      await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
+
+      const closed = await engine().parts.dialog.closeByBackdropClick();
+      assertTrue(closed);
+      assertFalse(await engine().parts.dialog.isOpen());
+    });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/rating/Rating.examples.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/examples/rating/Rating.examples.tsx
@@ -26,7 +26,12 @@ export const BasicRating: React.FunctionComponent = () => {
       <Divider />
 
       <Typography>Readonly</Typography>
-      <Rating data-testid='readonly' aria-label='SSS' precision={0.5} value={2.5} readOnly />
+      <Rating data-testid='readonly' precision={0.5} value={2.5} readOnly />
+
+      <Divider />
+
+      <Typography>Readonly with custom label</Typography>
+      <Rating data-testid='readonly-custom-label' aria-label='Great movie' value={3} readOnly />
 
       <Divider />
 

--- a/package-tests/component-driver-mui-v7-test/src/examples/rating/Rating.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/rating/Rating.suite.ts
@@ -13,6 +13,10 @@ export const basicRatingExampleScenePart = {
     locator: byDataTestId('readonly'),
     driver: RatingDriver,
   },
+  readonlyCustomLabel: {
+    locator: byDataTestId('readonly-custom-label'),
+    driver: RatingDriver,
+  },
   disabled: {
     locator: byDataTestId('disabled'),
     driver: RatingDriver,
@@ -31,7 +35,7 @@ export const basicRatingExample: IExampleUnit<typeof basicRatingExampleScenePart
 export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene> = {
   title: 'Basic Rating',
   url: '/rating',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicRatingExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Basic rating should exist', async () => {
@@ -55,14 +59,29 @@ export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene
       assertTrue(exists);
     });
 
+    test('Readonly rating value is read from the accessible aria-label', async () => {
+      const value = await engine().parts.readonly.getValue();
+      assertEqual(value, 2.5);
+    });
+
+    test('Readonly rating with a custom label falls back to counting filled stars', async () => {
+      const value = await engine().parts.readonlyCustomLabel.getValue();
+      assertEqual(value, 3);
+    });
+
     test('Disabled rating should exist', async () => {
       const exists = await engine().parts.disabled.exists();
       assertTrue(exists);
     });
 
+    test('isDisabled reflects the disabled state', async () => {
+      assertTrue(await engine().parts.disabled.isDisabled());
+      assertFalse(await engine().parts.basic.isDisabled());
+    });
+
     test('Initially empty rating should start empty', async () => {
       const value = await engine().parts.initiallyEmpty.getValue();
-      assertEqual(value || 0, 0);
+      assertEqual(value, null);
     });
   },
 };

--- a/packages/component-driver-mui-v5/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/AutoCompleteDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLButtonDriver, HTMLElementDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byCssSelector,
   byLinkedElement,
   byRole,
@@ -29,6 +30,14 @@ export const parts = {
 } satisfies ScenePart;
 
 const optionLocator = byRole('option');
+
+// In the "no options" and "loading" states MUI renders no listbox, so the popup
+// cannot be reached through the `dropdown` part (which keys off the combobox's
+// linked listbox id). These nodes live in the popper (portaled outside the driver
+// subtree), so they are matched by their global class. Only one Autocomplete
+// popup is open at a time, so a global match is unambiguous in practice.
+const noOptionsLocator = byCssClass('MuiAutocomplete-noOptions');
+const loadingLocator = byCssClass('MuiAutocomplete-loading');
 
 /**
  * The match type of the autocomplete, default to 'exact'
@@ -119,6 +128,23 @@ export class AutoCompleteDriver extends ComponentDriver<typeof parts> implements
 
   async isReadonly(): Promise<boolean> {
     return this.parts.input.isReadonly();
+  }
+
+  /**
+   * Whether the popup is currently showing its loading indicator (the
+   * `loadingText`). Only meaningful while the popup is open — open it first
+   * (e.g. by typing into the input), since MUI renders nothing otherwise.
+   */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.exists(loadingLocator);
+  }
+
+  /**
+   * Whether the popup is currently showing its "no options" message. Same
+   * open-the-popup-first caveat as {@link AutoCompleteDriver.isLoading}.
+   */
+  async hasNoOptions(): Promise<boolean> {
+    return this.interactor.exists(noOptionsLocator);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/CheckboxDriver.ts
@@ -1,11 +1,14 @@
 import { HTMLCheckboxDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssSelector,
   byTagName,
   ComponentDriver,
   IComponentDriverOption,
   IFormFieldDriver,
   Interactor,
   IToggleDriver,
+  locatorUtil,
+  Optional,
   PartLocator,
   ScenePart,
   ScenePartDriver,
@@ -82,9 +85,36 @@ export class CheckboxDriver
   }
 
   /**
+   * Get the text of the label associated with the checkbox, or `undefined` when the checkbox
+   * is rendered without one (e.g. a bare `<Checkbox>` outside of a `FormControlLabel`).
+   *
+   * MUI's `FormControlLabel` does not expose a `for`/`id` or `aria-labelledby` association; it
+   * labels the control implicitly by wrapping it in a `<label>` and rendering the text as a
+   * sibling. The label therefore lives outside this driver's own subtree, so we re-root at the
+   * enclosing `<label>` — matched against this checkbox via `:has()`, while preserving the
+   * surrounding scope — and read its text. This resolves to a single CSS selector, so it behaves
+   * identically across every interactor (DOM/React/Vue and Playwright).
+   */
+  async getLabel(): Promise<Optional<string>> {
+    const labelLocator = this.getEnclosingLabelLocator();
+    const hasLabel = await this.interactor.exists(labelLocator);
+    return hasLabel ? this.interactor.getText(labelLocator) : undefined;
+  }
+
+  /**
+   * Build a locator for the `<label>` that encloses this checkbox, scoped to the same ancestor
+   * context as the checkbox itself so that sibling checkboxes are never mismatched.
+   */
+  private getEnclosingLabelLocator(): PartLocator {
+    const chain = locatorUtil.toChain(this.locator);
+    const selfSelector = chain[chain.length - 1].selector;
+    return locatorUtil.append(chain.slice(0, -1), byCssSelector(`label:has(${selfSelector})`));
+  }
+
+  /**
    * Identifier for this driver.
    */
   get driverName(): string {
-    return 'MuiV5SelectDriver';
+    return 'MuiV5CheckboxDriver';
   }
 }

--- a/packages/component-driver-mui-v5/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/DialogDriver.ts
@@ -50,6 +50,31 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
+   * Dismiss the dialog by clicking outside its content, then wait for it to close.
+   *
+   * MUI's "backdrop click" is handled on the `.MuiDialog-container` surface (which
+   * overlays the visual `.MuiBackdrop-root`), firing `onClose` only when the click
+   * target is the container itself. The click therefore lands on the container near
+   * its top-left corner to avoid the centered paper. Whether it actually closes
+   * depends on the consumer's `onClose` handling (MUI reports a `"backdropClick"`
+   * reason); the returned boolean reflects the observed close, not merely the click.
+   *
+   * @param timeoutMs How long to wait for the close transition to finish
+   * @returns true if the dialog closed
+   */
+  async closeByBackdropClick(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
+    await this.enforcePartExistence('dialogContainer');
+    // MUI only dismisses when the same element receives mousedown and click, so
+    // drive the full press/release/click sequence on the container's empty corner
+    // (the click target must be the container, not the centered paper).
+    const cornerClick = { position: { x: 5, y: 5 } } as const;
+    await this.parts.dialogContainer.mouseDown(cornerClick);
+    await this.parts.dialogContainer.mouseUp(cornerClick);
+    await this.parts.dialogContainer.click(cornerClick);
+    return this.waitForClose(timeoutMs);
+  }
+
+  /**
    * Wait for dialog to open
    * @param timeoutMs
    * @returns true open has performed successfully

--- a/packages/component-driver-mui-v5/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/RatingDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byCssSelector,
   byInputType,
   byValue,
@@ -19,6 +20,16 @@ export const parts = {
   },
 } satisfies ScenePart;
 
+/**
+ * MUI marks the disabled/read-only state with a class on the Rating root span
+ * (`Mui-disabled` / `Mui-readOnly`), not on the visually-hidden radio inputs that
+ * the composed {@link HTMLRadioButtonGroupDriver} can see — so these states are
+ * only observable from the root element.
+ */
+const disabledClassName = 'Mui-disabled';
+const readOnlyClassName = 'Mui-readOnly';
+const filledIconClassName = 'MuiRating-iconFilled';
+
 export class RatingDriver extends ComponentDriver<typeof parts> implements IInputDriver<number | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -28,26 +39,72 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
   }
 
   async getValue(): Promise<number | null> {
-    // TODO: https://github.com/atomic-testing/atomic-testing/issues/69
-    // getValue() does not work when readonly
+    // A read-only Rating renders no radio inputs (root becomes `role="img"` with the
+    // value carried in `aria-label`), so the radio-based read below cannot be used.
+    const isReadOnly = await this.interactor.hasCssClass(this.locator, readOnlyClassName);
+    if (isReadOnly) {
+      return this.getReadOnlyValue();
+    }
+
     await this.enforcePartExistence('choices');
     const value = await this.parts.choices.getValue();
-    if (value == null) {
+    // The "no rating" state is the visually-hidden radio whose `value` attribute is the
+    // empty string; treat it the same as an absent selection.
+    if (value == null || value === '') {
       return null;
     }
     return parseFloat(value);
   }
 
+  /**
+   * Read the value of a read-only Rating.
+   *
+   * Primary source is the root's `aria-label`, which MUI populates with the accessible
+   * name (e.g. `"2.5 Stars"`) — accessibility-first and precision-accurate. When a
+   * caller supplies a custom, non-numeric `aria-label`, fall back to counting the
+   * filled star icons; that count is exact for whole-star ratings.
+   */
+  private async getReadOnlyValue(): Promise<number | null> {
+    const label = await this.interactor.getAttribute(this.locator, 'aria-label');
+    if (label != null) {
+      const parsed = parseFloat(label);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    const filledLocator = locatorUtil.append(this.locator, byCssClass(filledIconClassName));
+    const filledIcons = await this.interactor.getAttribute(filledLocator, 'class', true);
+    return filledIcons.length > 0 ? filledIcons.length : null;
+  }
+
+  /**
+   * Whether the Rating is disabled. `disabled` is reflected as the `Mui-disabled`
+   * class on the root span (the composed radio-group driver exposes no `isDisabled`).
+   */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, disabledClassName);
+  }
+
   async setValue(value: number | null): Promise<boolean> {
-    // TODO: Setting value to null is not supported.  https://github.com/atomic-testing/atomic-testing/issues/68
     const currentValue = await this.getValue();
     if (value === currentValue) {
       return true;
     }
 
-    const valueToClick = (value == null ? currentValue : value) as number;
-    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
+    // Clearing (value == null) reuses MUI's "click the selected star again to
+    // reset" behaviour by re-clicking the current value's label. This resets the
+    // rating in real browsers but not in jsdom, where MUI's clear path depends on
+    // pointer coordinates that jsdom does not provide; the empty radio (`value=""`)
+    // that jsdom could click has no `<label>` and is not reliably clickable in
+    // browsers. A fully portable clear needs a coordinate-free click primitive on
+    // the Interactor. TODO(#68): revisit once that primitive exists.
+    const valueToClick = value ?? currentValue;
+    if (valueToClick == null) {
+      return true;
+    }
 
+    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
     const targetExists = await this.interactor.exists(targetLocator);
     if (targetExists) {
       const id = await this.interactor.getAttribute(targetLocator, 'id');

--- a/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLButtonDriver, HTMLElementDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byLinkedElement,
   byRole,
   ComponentDriver,
@@ -27,6 +28,14 @@ export const parts = {
 } satisfies ScenePart;
 
 const optionLocator = byRole('option');
+
+// In the "no options" and "loading" states MUI renders no listbox, so the popup
+// cannot be reached through the `dropdown` part (which keys off the combobox's
+// `aria-controls`). These nodes live in the popper (portaled outside the driver
+// subtree), so they are matched by their global class. Only one Autocomplete
+// popup is open at a time, so a global match is unambiguous in practice.
+const noOptionsLocator = byCssClass('MuiAutocomplete-noOptions');
+const loadingLocator = byCssClass('MuiAutocomplete-loading');
 
 /**
  * The match type of the autocomplete, default to 'exact'
@@ -117,6 +126,23 @@ export class AutoCompleteDriver extends ComponentDriver<typeof parts> implements
 
   async isReadonly(): Promise<boolean> {
     return this.parts.input.isReadonly();
+  }
+
+  /**
+   * Whether the popup is currently showing its loading indicator (the
+   * `loadingText`). Only meaningful while the popup is open — open it first
+   * (e.g. by typing into the input), since MUI renders nothing otherwise.
+   */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.exists(loadingLocator);
+  }
+
+  /**
+   * Whether the popup is currently showing its "no options" message. Same
+   * open-the-popup-first caveat as {@link AutoCompleteDriver.isLoading}.
+   */
+  async hasNoOptions(): Promise<boolean> {
+    return this.interactor.exists(noOptionsLocator);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/CheckboxDriver.ts
@@ -1,11 +1,14 @@
 import { HTMLCheckboxDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssSelector,
   byTagName,
   ComponentDriver,
   IComponentDriverOption,
   IFormFieldDriver,
   Interactor,
   IToggleDriver,
+  locatorUtil,
+  Optional,
   PartLocator,
   ScenePart,
   ScenePartDriver,
@@ -60,6 +63,33 @@ export class CheckboxDriver
 
   isReadonly(): Promise<boolean> {
     return this.parts.checkbox.isReadonly();
+  }
+
+  /**
+   * Get the text of the label associated with the checkbox, or `undefined` when the checkbox
+   * is rendered without one (e.g. a bare `<Checkbox>` outside of a `FormControlLabel`).
+   *
+   * MUI's `FormControlLabel` does not expose a `for`/`id` or `aria-labelledby` association; it
+   * labels the control implicitly by wrapping it in a `<label>` and rendering the text as a
+   * sibling. The label therefore lives outside this driver's own subtree, so we re-root at the
+   * enclosing `<label>` — matched against this checkbox via `:has()`, while preserving the
+   * surrounding scope — and read its text. This resolves to a single CSS selector, so it behaves
+   * identically across every interactor (DOM/React/Vue and Playwright).
+   */
+  async getLabel(): Promise<Optional<string>> {
+    const labelLocator = this.getEnclosingLabelLocator();
+    const hasLabel = await this.interactor.exists(labelLocator);
+    return hasLabel ? this.interactor.getText(labelLocator) : undefined;
+  }
+
+  /**
+   * Build a locator for the `<label>` that encloses this checkbox, scoped to the same ancestor
+   * context as the checkbox itself so that sibling checkboxes are never mismatched.
+   */
+  private getEnclosingLabelLocator(): PartLocator {
+    const chain = locatorUtil.toChain(this.locator);
+    const selfSelector = chain[chain.length - 1].selector;
+    return locatorUtil.append(chain.slice(0, -1), byCssSelector(`label:has(${selfSelector})`));
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/DialogDriver.ts
@@ -50,6 +50,31 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
+   * Dismiss the dialog by clicking outside its content, then wait for it to close.
+   *
+   * MUI's "backdrop click" is handled on the `.MuiDialog-container` surface (which
+   * overlays the visual `.MuiBackdrop-root`), firing `onClose` only when the click
+   * target is the container itself. The click therefore lands on the container near
+   * its top-left corner to avoid the centered paper. Whether it actually closes
+   * depends on the consumer's `onClose` handling (MUI reports a `"backdropClick"`
+   * reason); the returned boolean reflects the observed close, not merely the click.
+   *
+   * @param timeoutMs How long to wait for the close transition to finish
+   * @returns true if the dialog closed
+   */
+  async closeByBackdropClick(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
+    await this.enforcePartExistence('dialogContainer');
+    // MUI only dismisses when the same element receives mousedown and click, so
+    // drive the full press/release/click sequence on the container's empty corner
+    // (the click target must be the container, not the centered paper).
+    const cornerClick = { position: { x: 5, y: 5 } } as const;
+    await this.parts.dialogContainer.mouseDown(cornerClick);
+    await this.parts.dialogContainer.mouseUp(cornerClick);
+    await this.parts.dialogContainer.click(cornerClick);
+    return this.waitForClose(timeoutMs);
+  }
+
+  /**
    * Wait for dialog to open
    * @param timeoutMs
    * @returns true open has performed successfully

--- a/packages/component-driver-mui-v6/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/RatingDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byCssSelector,
   byInputType,
   byValue,
@@ -19,6 +20,16 @@ export const parts = {
   },
 } satisfies ScenePart;
 
+/**
+ * MUI marks the disabled/read-only state with a class on the Rating root span
+ * (`Mui-disabled` / `Mui-readOnly`), not on the visually-hidden radio inputs that
+ * the composed {@link HTMLRadioButtonGroupDriver} can see — so these states are
+ * only observable from the root element.
+ */
+const disabledClassName = 'Mui-disabled';
+const readOnlyClassName = 'Mui-readOnly';
+const filledIconClassName = 'MuiRating-iconFilled';
+
 export class RatingDriver extends ComponentDriver<typeof parts> implements IInputDriver<number | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -28,26 +39,72 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
   }
 
   async getValue(): Promise<number | null> {
-    // TODO: https://github.com/atomic-testing/atomic-testing/issues/69
-    // getValue() does not work when readonly
+    // A read-only Rating renders no radio inputs (root becomes `role="img"` with the
+    // value carried in `aria-label`), so the radio-based read below cannot be used.
+    const isReadOnly = await this.interactor.hasCssClass(this.locator, readOnlyClassName);
+    if (isReadOnly) {
+      return this.getReadOnlyValue();
+    }
+
     await this.enforcePartExistence('choices');
     const value = await this.parts.choices.getValue();
-    if (value == null) {
+    // The "no rating" state is the visually-hidden radio whose `value` attribute is the
+    // empty string; treat it the same as an absent selection.
+    if (value == null || value === '') {
       return null;
     }
     return parseFloat(value);
   }
 
+  /**
+   * Read the value of a read-only Rating.
+   *
+   * Primary source is the root's `aria-label`, which MUI populates with the accessible
+   * name (e.g. `"2.5 Stars"`) — accessibility-first and precision-accurate. When a
+   * caller supplies a custom, non-numeric `aria-label`, fall back to counting the
+   * filled star icons; that count is exact for whole-star ratings.
+   */
+  private async getReadOnlyValue(): Promise<number | null> {
+    const label = await this.interactor.getAttribute(this.locator, 'aria-label');
+    if (label != null) {
+      const parsed = parseFloat(label);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    const filledLocator = locatorUtil.append(this.locator, byCssClass(filledIconClassName));
+    const filledIcons = await this.interactor.getAttribute(filledLocator, 'class', true);
+    return filledIcons.length > 0 ? filledIcons.length : null;
+  }
+
+  /**
+   * Whether the Rating is disabled. `disabled` is reflected as the `Mui-disabled`
+   * class on the root span (the composed radio-group driver exposes no `isDisabled`).
+   */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, disabledClassName);
+  }
+
   async setValue(value: number | null): Promise<boolean> {
-    // TODO: Setting value to null is not supported.  https://github.com/atomic-testing/atomic-testing/issues/68
     const currentValue = await this.getValue();
     if (value === currentValue) {
       return true;
     }
 
-    const valueToClick = (value == null ? currentValue : value) as number;
-    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
+    // Clearing (value == null) reuses MUI's "click the selected star again to
+    // reset" behaviour by re-clicking the current value's label. This resets the
+    // rating in real browsers but not in jsdom, where MUI's clear path depends on
+    // pointer coordinates that jsdom does not provide; the empty radio (`value=""`)
+    // that jsdom could click has no `<label>` and is not reliably clickable in
+    // browsers. A fully portable clear needs a coordinate-free click primitive on
+    // the Interactor. TODO(#68): revisit once that primitive exists.
+    const valueToClick = value ?? currentValue;
+    if (valueToClick == null) {
+      return true;
+    }
 
+    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
     const targetExists = await this.interactor.exists(targetLocator);
     if (targetExists) {
       const id = await this.interactor.getAttribute(targetLocator, 'id');

--- a/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLButtonDriver, HTMLElementDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byLinkedElement,
   byRole,
   ComponentDriver,
@@ -27,6 +28,14 @@ export const parts = {
 } satisfies ScenePart;
 
 const optionLocator = byRole('option');
+
+// In the "no options" and "loading" states MUI renders no listbox, so the popup
+// cannot be reached through the `dropdown` part (which keys off the combobox's
+// `aria-controls`). These nodes live in the popper (portaled outside the driver
+// subtree), so they are matched by their global class. Only one Autocomplete
+// popup is open at a time, so a global match is unambiguous in practice.
+const noOptionsLocator = byCssClass('MuiAutocomplete-noOptions');
+const loadingLocator = byCssClass('MuiAutocomplete-loading');
 
 /**
  * The match type of the autocomplete, default to 'exact'
@@ -117,6 +126,23 @@ export class AutoCompleteDriver extends ComponentDriver<typeof parts> implements
 
   async isReadonly(): Promise<boolean> {
     return this.parts.input.isReadonly();
+  }
+
+  /**
+   * Whether the popup is currently showing its loading indicator (the
+   * `loadingText`). Only meaningful while the popup is open — open it first
+   * (e.g. by typing into the input), since MUI renders nothing otherwise.
+   */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.exists(loadingLocator);
+  }
+
+  /**
+   * Whether the popup is currently showing its "no options" message. Same
+   * open-the-popup-first caveat as {@link AutoCompleteDriver.isLoading}.
+   */
+  async hasNoOptions(): Promise<boolean> {
+    return this.interactor.exists(noOptionsLocator);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/DialogDriver.ts
@@ -50,6 +50,31 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
+   * Dismiss the dialog by clicking outside its content, then wait for it to close.
+   *
+   * MUI's "backdrop click" is handled on the `.MuiDialog-container` surface (which
+   * overlays the visual `.MuiBackdrop-root`), firing `onClose` only when the click
+   * target is the container itself. The click therefore lands on the container near
+   * its top-left corner to avoid the centered paper. Whether it actually closes
+   * depends on the consumer's `onClose` handling (MUI reports a `"backdropClick"`
+   * reason); the returned boolean reflects the observed close, not merely the click.
+   *
+   * @param timeoutMs How long to wait for the close transition to finish
+   * @returns true if the dialog closed
+   */
+  async closeByBackdropClick(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
+    await this.enforcePartExistence('dialogContainer');
+    // MUI only dismisses when the same element receives mousedown and click, so
+    // drive the full press/release/click sequence on the container's empty corner
+    // (the click target must be the container, not the centered paper).
+    const cornerClick = { position: { x: 5, y: 5 } } as const;
+    await this.parts.dialogContainer.mouseDown(cornerClick);
+    await this.parts.dialogContainer.mouseUp(cornerClick);
+    await this.parts.dialogContainer.click(cornerClick);
+    return this.waitForClose(timeoutMs);
+  }
+
+  /**
    * Wait for dialog to open
    * @param timeoutMs
    * @returns true open has performed successfully

--- a/packages/component-driver-mui-v7/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/RatingDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
 import {
+  byCssClass,
   byCssSelector,
   byInputType,
   byValue,
@@ -19,6 +20,16 @@ export const parts = {
   },
 } satisfies ScenePart;
 
+/**
+ * MUI marks the disabled/read-only state with a class on the Rating root span
+ * (`Mui-disabled` / `Mui-readOnly`), not on the visually-hidden radio inputs that
+ * the composed {@link HTMLRadioButtonGroupDriver} can see — so these states are
+ * only observable from the root element.
+ */
+const disabledClassName = 'Mui-disabled';
+const readOnlyClassName = 'Mui-readOnly';
+const filledIconClassName = 'MuiRating-iconFilled';
+
 export class RatingDriver extends ComponentDriver<typeof parts> implements IInputDriver<number | null> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -28,26 +39,72 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
   }
 
   async getValue(): Promise<number | null> {
-    // TODO: https://github.com/atomic-testing/atomic-testing/issues/69
-    // getValue() does not work when readonly
+    // A read-only Rating renders no radio inputs (root becomes `role="img"` with the
+    // value carried in `aria-label`), so the radio-based read below cannot be used.
+    const isReadOnly = await this.interactor.hasCssClass(this.locator, readOnlyClassName);
+    if (isReadOnly) {
+      return this.getReadOnlyValue();
+    }
+
     await this.enforcePartExistence('choices');
     const value = await this.parts.choices.getValue();
-    if (value == null) {
+    // The "no rating" state is the visually-hidden radio whose `value` attribute is the
+    // empty string; treat it the same as an absent selection.
+    if (value == null || value === '') {
       return null;
     }
     return parseFloat(value);
   }
 
+  /**
+   * Read the value of a read-only Rating.
+   *
+   * Primary source is the root's `aria-label`, which MUI populates with the accessible
+   * name (e.g. `"2.5 Stars"`) — accessibility-first and precision-accurate. When a
+   * caller supplies a custom, non-numeric `aria-label`, fall back to counting the
+   * filled star icons; that count is exact for whole-star ratings.
+   */
+  private async getReadOnlyValue(): Promise<number | null> {
+    const label = await this.interactor.getAttribute(this.locator, 'aria-label');
+    if (label != null) {
+      const parsed = parseFloat(label);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    const filledLocator = locatorUtil.append(this.locator, byCssClass(filledIconClassName));
+    const filledIcons = await this.interactor.getAttribute(filledLocator, 'class', true);
+    return filledIcons.length > 0 ? filledIcons.length : null;
+  }
+
+  /**
+   * Whether the Rating is disabled. `disabled` is reflected as the `Mui-disabled`
+   * class on the root span (the composed radio-group driver exposes no `isDisabled`).
+   */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, disabledClassName);
+  }
+
   async setValue(value: number | null): Promise<boolean> {
-    // TODO: Setting value to null is not supported.  https://github.com/atomic-testing/atomic-testing/issues/68
     const currentValue = await this.getValue();
     if (value === currentValue) {
       return true;
     }
 
-    const valueToClick = (value == null ? currentValue : value) as number;
-    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
+    // Clearing (value == null) reuses MUI's "click the selected star again to
+    // reset" behaviour by re-clicking the current value's label. This resets the
+    // rating in real browsers but not in jsdom, where MUI's clear path depends on
+    // pointer coordinates that jsdom does not provide; the empty radio (`value=""`)
+    // that jsdom could click has no `<label>` and is not reliably clickable in
+    // browsers. A fully portable clear needs a coordinate-free click primitive on
+    // the Interactor. TODO(#68): revisit once that primitive exists.
+    const valueToClick = value ?? currentValue;
+    if (valueToClick == null) {
+      return true;
+    }
 
+    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
     const targetExists = await this.interactor.exists(targetLocator);
     if (targetExists) {
       const id = await this.interactor.getAttribute(targetLocator, 'id');


### PR DESCRIPTION

Implements the Group B "missing tester-facing behaviors" from the MUI
driver audit (#871) and backfills them across the v5, v6, and v7 driver
packages. These behaviors were previously unreachable -- the relevant
element sits outside the driver's part subtree or doesn't exist in the
tested DOM state -- so each needed a new method. Also backfills
CheckboxDriver.getLabel() (already present in v7) to v5 and v6.

Key changes:
- RatingDriver: add isDisabled(); read readOnly values from the root
  aria-label with a filled-icon-count fallback (#69); return null for
  the empty state.
- DialogDriver: add closeByBackdropClick(), dismissing via the container
  surface with a mousedown->mouseup->click sequence that is portable
  across jsdom and all three Playwright browsers.
- AutoCompleteDriver: add isLoading() and hasNoOptions() to detect the
  listbox-less "loading"/"no options" popup states.
- CheckboxDriver (v5/v6): add getLabel() via an enclosing-label :has()
  locator; also fix v5's driverName, which incorrectly reported
  "MuiV5SelectDriver".

Notes:
- Verified: all jsdom suites green (v5/v6/v7); full Playwright e2e green
  on chromium + firefox + webkit for v7.
- v5/v6 e2e is blocked by a pre-existing MUI 5/6 + Vite 8 emotion
  dev-server bug (empty #root); their logic is verified via jsdom
  (identical code to the e2e-verified v7).
- Deferred (need a new Interactor primitive): Rating clear setValue(null)
  mechanism #68 (read-side fixed), Dialog Escape, Chip deleteViaKeyboard().

Closes #871
Closes #69

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
