### PR TITLE
chore: end support for MUI 5 and MUI-X 5 (deprecate in place)

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -106,14 +106,12 @@ jobs:
         include:
           - name: 'HTML components'
             directory: 'component-driver-html-test'
-          - name: 'MUI v5 components'
-            directory: 'component-driver-mui-v5-test'
+          # MUI v5 / MUI X v5 reached end of support (2026-06-27) and are no longer
+          # tested in CI. See agent-docs/adr/005-drop-mui-5-support.md
           - name: 'MUI v6 components'
             directory: 'component-driver-mui-v6-test'
           - name: 'MUI v7 components'
             directory: 'component-driver-mui-v7-test'
-          - name: 'MUI X v5 components'
-            directory: 'component-driver-mui-x-v5-test'
           - name: 'MUI X v6 components'
             directory: 'component-driver-mui-x-v6-test'
           - name: 'MUI X v7 components'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ including but not limited to:
 
   runner.
 
+## Version support policy
+
+Material UI moves fast and each major has a distinct rendered DOM, so this
+project ships one driver package per MUI major (see
+[ADR-003](agent-docs/adr/003-version-specific-packages.md)). To keep the
+maintained surface focused, older majors reach **end of support** once newer
+ones are stable.
+
+| Driver family | Supported majors | End of support            |
+| ------------- | ---------------- | ------------------------- |
+| MUI (core)    | v6, v7           | **v5 - ended 2026-06-27** |
+| MUI-X         | v6, v7, v8       | **v5 - ended 2026-06-27** |
+
+**MUI 5 / MUI-X 5 are no longer supported** as of **2026-06-27**. The
+`@atomic-testing/component-driver-mui-v5` and
+`@atomic-testing/component-driver-mui-x-v5` packages are frozen at `0.81.0`:
+they remain installable at that version but receive no fixes, new drivers, or
+CI/e2e coverage, and their test suites no longer run. New work targets v6/v7
+(MUI-X also v8). Rationale and migration notes:
+[ADR-005](agent-docs/adr/005-drop-mui-5-support.md).
+
+> Note: the MUI-X date/time **picker** drivers only ever shipped in the v5
+> package; they have no v6–v8 successor at this time.
+
 ## Getting Started
 
 1. Install Node.js (v22.12 or newer) and [pnpm](https://pnpm.io/) (v10 or newer).

--- a/agent-docs/adr/003-version-specific-packages.md
+++ b/agent-docs/adr/003-version-specific-packages.md
@@ -4,6 +4,11 @@
 
 Accepted (describes the existing design).
 
+> **Update (2026-06-27):** MUI 5 and MUI-X 5 reached end of support — the
+> `mui-v5` / `mui-x-v5` packages are frozen and deprecated in place. See
+> [ADR-005](005-drop-mui-5-support.md). Mentions of v5 below describe the
+> original design, not the currently supported set (v6/v7; v8 for MUI-X).
+
 ## Context
 
 Two dependencies make breaking changes across major versions in ways that affect this library:

--- a/agent-docs/adr/005-drop-mui-5-support.md
+++ b/agent-docs/adr/005-drop-mui-5-support.md
@@ -1,0 +1,79 @@
+# ADR-005: End of support for MUI 5 and MUI-X 5
+
+## Status
+
+Accepted (2026-06-27).
+
+## Context
+
+[ADR-003](003-version-specific-packages.md) established one driver package per
+MUI major because each major ships a distinct rendered DOM. The trade-off it
+named is real: `mui-v5`/`-v6`/`-v7` are ~95% identical, so every cross-cutting
+fix or new driver must be replicated across every maintained major. As v6/v7
+(and MUI-X v6/v7/v8) became the versions under active development, continuing to
+carry v5 cost maintenance effort and CI time for a major that new work no longer
+targets.
+
+Additional v5-specific drag at the time of this decision:
+
+- The v5 (and v6) Playwright e2e harness was blocked by a Vite 8 / Rolldown
+  dep-optimizer defect specific to the MUI 5/6 prebundle shape (tracked in
+  #877; the purely-v5 instance was #886), so v5 had no working cross-browser
+  e2e path.
+- The v5 driver checklist (#23) still had open navigation components, all of
+  which are also tracked for v6/v7 in newer issues.
+
+The MUI-X picker caveat: `component-driver-mui-x-v5` is the **only** MUI-X
+package that ships date/time **picker** drivers (v6–v8 are DataGrid-only). That
+coverage was never carried forward and is not reintroduced by this decision.
+
+## Decision
+
+**MUI 5 and MUI-X 5 are no longer supported, effective 2026-06-27.** Support is
+ended by deprecation in place rather than deletion:
+
+- `packages/component-driver-mui-v5` and `packages/component-driver-mui-x-v5`
+  remain in the repo, frozen at `0.81.0`. Each carries a `deprecated` field in
+  `package.json` and a warning banner in its README.
+- They are excluded from `publish.sh` (so the release pipeline no longer
+  republishes them) — they are **not** marked deprecated on the npm registry, so
+  the already-published `0.81.0` keeps installing silently.
+- Their test packages (`package-tests/component-driver-mui-v5-test`,
+  `…-mui-x-v5-test`) remain but are removed from the CI test matrix
+  (`.github/workflows/buildui.yml`); their suites no longer run.
+- New work (drivers, fixes, state accessors) targets v6/v7, and v8 for MUI-X.
+- The `examples/example-mui-signup-form` example and the documentation site were
+  intentionally left referencing v5 for now; migrating them is deferred.
+
+## Consequences
+
+- ✅ Smaller maintained surface: cross-cutting MUI work replicates across v6/v7
+  instead of v5/v6/v7.
+- ✅ Faster CI (two fewer test-matrix legs) and no more wasted publishes.
+- ✅ No breakage for existing consumers — `0.81.0` stays installable from npm.
+- ⚠️ The MUI-X date/time picker drivers (v5-only) now have no supported home.
+- ⚠️ Docs, the signup-form example, and several package READMEs still import
+  `mui-v5` and will need a follow-up migration pass.
+- ⚠️ "Frozen in repo, not deprecated on npm" means the only deprecation signal a
+  consumer sees is the `package.json` `deprecated` field and the README — not an
+  `npm install` warning.
+
+## Issue disposition
+
+- **Closed as purely v5** (wontfix): #886 (v5 e2e harness), #23 (v5 driver
+  checklist).
+- **Narrowed to the supported majors** (v5 dropped from scope): #880–#885
+  (driver enhancements), #73 (Slider), #877 (e2e blocker → v6 only).
+- **Re-scoped to v6/v7**: #86 (Rating fractional `setValue`), #68 (Rating reset
+  to no star) — the Rating driver is shared across majors, and #878 already
+  tracks the underlying coordinate-free primitive.
+- **Unchanged**: #878 (core Interactor primitives) — version-agnostic; its v5
+  references are now moot but the work stands.
+
+## Alternatives considered
+
+| Alternative | Why not chosen |
+|-------------|----------------|
+| Delete the v5 packages and tests outright | Would break the example app and docs immediately and discard installable history; reversible deprecation chosen instead |
+| `npm deprecate` the published packages | Out of scope for this pass — kept to repo/docs signals only to avoid surfacing install-time warnings now |
+| Keep v5 on full support | The maintenance/CI cost no longer matched its usage; new work targets v6/v7 |

--- a/package-tests/component-driver-mui-v5-test/README.md
+++ b/package-tests/component-driver-mui-v5-test/README.md
@@ -1,3 +1,6 @@
 # @atomic-testing/component-driver-mui-v5-test
 
+> [!WARNING]
+> **Deprecated — MUI 5 reached end of support on 2026-06-27.** These suites are frozen and no longer run in CI. See [ADR-005](../../agent-docs/adr/005-drop-mui-5-support.md).
+
 DOM and end-to-end tests for component drivers for [MUI](https://mui.com) V5 components

--- a/package-tests/component-driver-mui-x-v5-test/README.md
+++ b/package-tests/component-driver-mui-x-v5-test/README.md
@@ -1,3 +1,6 @@
-# @atomic-testing/component-driver-mui-v5-test
+# @atomic-testing/component-driver-mui-x-v5-test
 
-DOM and end-to-end tests for component drivers for [MUI](https://mui.com) V5 components
+> [!WARNING]
+> **Deprecated — MUI-X 5 reached end of support on 2026-06-27.** These suites are frozen and no longer run in CI. See [ADR-005](../../agent-docs/adr/005-drop-mui-5-support.md).
+
+DOM and end-to-end tests for component drivers for [MUI X](https://mui.com/x/) V5 components

--- a/packages/component-driver-mui-v5/README.md
+++ b/packages/component-driver-mui-v5/README.md
@@ -1,5 +1,8 @@
 # @atomic-testing/component-driver-mui-v5
 
+> [!WARNING]
+> **Deprecated — MUI 5 reached end of support on 2026-06-27.** This package is frozen at `0.81.0`; it receives no fixes, new drivers, or CI/e2e coverage. Migrate to [`@atomic-testing/component-driver-mui-v6`](../component-driver-mui-v6) or [`-v7`](../component-driver-mui-v7). Rationale: [ADR-005](../../agent-docs/adr/005-drop-mui-5-support.md).
+
 Component drivers for [Material UI](https://mui.com) v5 components. Component drivers expose simple APIs for unit tests or end‑to‑end tests to interact with MUI components—such as reading states and setting values—so test engineers can focus on test flows without needing to track how the inner MUI components work.
 
 ## The problem

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@atomic-testing/component-driver-mui-v5",
   "version": "0.81.0",
-  "description": "Atomic Testing Component driver to help drive Material UI v5 components",
+  "deprecated": "MUI 5 reached end of support in atomic-testing on 2026-06-27. This package is frozen at 0.81.0 and will not receive fixes or new drivers. Migrate to @atomic-testing/component-driver-mui-v6 or -v7. See https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md",
+  "description": "[DEPRECATED: MUI 5 end of support] Atomic Testing Component driver to help drive Material UI v5 components",
   "keywords": [
     "integration",
     "integration-driver",

--- a/packages/component-driver-mui-x-v5/README.md
+++ b/packages/component-driver-mui-x-v5/README.md
@@ -1,5 +1,8 @@
 # @atomic-testing/component-driver-mui-x-v5
 
+> [!WARNING]
+> **Deprecated — MUI-X 5 reached end of support on 2026-06-27.** This package is frozen at `0.81.0`; it receives no fixes, new drivers, or CI/e2e coverage. For DataGrid, migrate to [`-x-v6`](../component-driver-mui-x-v6) / [`-x-v7`](../component-driver-mui-x-v7) / [`-x-v8`](../component-driver-mui-x-v8). Note the date/time picker drivers ship **only** in this v5 package and were never carried forward. Rationale: [ADR-005](../../agent-docs/adr/005-drop-mui-5-support.md).
+
 Component drivers for [Material UI X](https://mui.com/x/) v5 components.
 They provide Atomic Testing support for advanced MUI widgets.
 

--- a/packages/component-driver-mui-x-v5/package.json
+++ b/packages/component-driver-mui-x-v5/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v5",
   "version": "0.81.0",
-  "description": "Atomic Testing Component driver to help drive Material UI X v5 components",
+  "deprecated": "MUI-X 5 reached end of support in atomic-testing on 2026-06-27. This package is frozen at 0.81.0 and will not receive fixes or new drivers. For DataGrid, migrate to @atomic-testing/component-driver-mui-x-v6/-v7/-v8; note the date/time picker drivers were never carried past v5. See https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md",
+  "description": "[DEPRECATED: MUI-X 5 end of support] Atomic Testing Component driver to help drive Material UI X v5 components",
   "keywords": [
     "integration",
     "integration-driver",

--- a/publish.sh
+++ b/publish.sh
@@ -24,6 +24,10 @@ done
 declare -a exclude=(
   # add any others here...
   "temp"
+  # MUI 5 / MUI-X 5 reached end of support (2026-06-27); frozen, not republished.
+  # See agent-docs/adr/005-drop-mui-5-support.md
+  "component-driver-mui-v5"
+  "component-driver-mui-x-v5"
 )
 
 


### PR DESCRIPTION

End of support for the MUI 5 and MUI-X 5 drivers and their test suites, effective
2026-06-27. The packages are deprecated in place (frozen at 0.81.0, kept installable)
rather than deleted, so existing consumers keep working while all new MUI driver work
targets v6/v7 (and v8 for MUI-X). The npm registry is intentionally left untouched.

## Key Changes

- Freeze the v5 packages: publish.sh exclude, dropped from the CI test matrix, package.json
  `deprecated` fields, and README warning banners on all four v5 packages.
- Document the decision: new "Version support policy" section in the root README and
  ADR-005 (with a pointer note added to ADR-003).
- Triage GitHub issues separately: closed pure-v5 #886/#23, narrowed #880-885/#73/#877
  and re-scoped Rating #86/#68 to the supported majors.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
