### PR TITLE
chore(ci): publish via npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -38,13 +39,11 @@ jobs:
         run: pnpm bumpVersion $VERSION
 
       - name: Publish packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          # Publish each package in the monorepo (customize as needed)
-          ./publish.sh
-          rm ~/.npmrc
+        # Auth via npm Trusted Publishing (OIDC) — no NPM_TOKEN needed.
+        # Requires `id-token: write` (above) plus a Trusted Publisher configured
+        # for every @atomic-testing/* package on npmjs.com (org: atomic-testing,
+        # repo: atomic-testing, workflow file: publish.yml).
+        run: ./publish.sh
 
       - name: Commit version updates
         run: |


### PR DESCRIPTION
## What

Switch the release publish job to **npm Trusted Publishing (OIDC)** instead of a long-lived `NPM_TOKEN`.

- Add `id-token: write` permission (required for GitHub Actions to mint an OIDC token).
- Drop the `NODE_AUTH_TOKEN` env + `~/.npmrc` write/remove from the **Publish packages** step; `pnpm publish` (pnpm 10) now authenticates via OIDC.

## ⚠️ Do not merge until prerequisites are done

1. A **Trusted Publisher** is configured for **every** published `@atomic-testing/*` package on npmjs.com (19 packages), all with:
   - Organization or user: `atomic-testing`
   - Repository: `atomic-testing`
   - Workflow filename: `publish.yml`
   - Allowed action: `npm publish`
2. `CODEMOD_TOKEN` has been rotated (separate issue — it expired and broke the last release at checkout, before publish ran).

## Notes

- Keep the `NPM_TOKEN` secret in place until the **first** OIDC release succeeds, then delete it (rollback safety).
- Stay on **pnpm 10** — pnpm 11 has a known OIDC-publish 404 regression.
- Node 22 (CI) already satisfies the Node ≥ 22.14.0 requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)