### PR TITLE
chore(ci): add trusted-publishing maintainer scripts

### DIFF
--- a/bootstrap-new-package.sh
+++ b/bootstrap-new-package.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One-time bootstrap for a NEW @atomic-testing/* package so it can use Trusted
+# Publishing.
+#
+# Why this exists: npm requires a package to already exist on the registry before
+# a trusted publisher can be attached, so a brand-new package's FIRST publish
+# can't use OIDC. This script does that first publish with your `npm login`
+# session (publishing a throwaway 0.0.0 placeholder), then attaches the trusted
+# publisher. After this, CI (publish.sh) publishes the real version via OIDC like
+# every other package — and setup-trusted-publishers.sh auto-discovers it, so
+# there's no list to edit.
+#
+# Usage:  ./bootstrap-new-package.sh <package-folder-name>      e.g. react-20
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+REPO="atomic-testing/atomic-testing"
+WORKFLOW="publish.yml"
+PLACEHOLDER_VERSION="0.0.0"   # low on purpose: CI publishes the real (higher) version next release
+
+[[ $# -eq 1 ]] || { echo "Usage: $0 <package-folder-name>"; exit 1; }
+DIR="packages/$1"
+[[ -f "$DIR/package.json" ]] || { echo "ERROR: no package.json at $DIR"; exit 1; }
+
+# Preflight
+npm trust --help >/dev/null 2>&1 || { echo "ERROR: need npm >= 11.10.0 (yours: $(npm -v)). Upgrade: npm install -g npm@latest"; exit 1; }
+npm whoami >/dev/null 2>&1        || { echo "ERROR: not logged in to npm. Run: npm login"; exit 1; }
+
+PKG="$(node -p "require('./$DIR/package.json').name")"
+echo "Bootstrapping $PKG  ($DIR)"
+
+# 1. Build the package and its workspace dependencies (correct order)
+echo "→ Building (with deps)…"
+pnpm --filter "${PKG}..." build
+
+# 2. First publish (placeholder) — only if the package doesn't exist on npm yet
+if npm view "$PKG" version >/dev/null 2>&1; then
+  echo "→ $PKG already exists on npm — skipping placeholder publish."
+else
+  echo "→ Publishing placeholder $PLACEHOLDER_VERSION to create the package…"
+  ORIG="$(node -p "require('./$DIR/package.json').version")"
+  (
+    cd "$DIR"
+    npm version "$PLACEHOLDER_VERSION" --no-git-tag-version --allow-same-version >/dev/null
+    # restore the original version whatever happens next
+    trap 'npm version "$ORIG" --no-git-tag-version --allow-same-version >/dev/null 2>&1 || true' EXIT
+    pnpm publish --access public --no-git-checks
+  )
+  echo "  ✓ placeholder published"
+fi
+
+# 3. Attach the trusted publisher (package now exists)
+echo "→ Configuring trusted publisher…"
+npm trust github "$PKG" --file "$WORKFLOW" --repo "$REPO" --allow-publish -y
+echo "  ✓ trusted publisher configured"
+
+echo
+echo "Done. $PKG is OIDC-ready — CI will publish the real version on the next release."
+echo "(setup-trusted-publishers.sh auto-discovers it; no list to update.)"

--- a/publish.sh
+++ b/publish.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 # Bulk publish all packages (or just build if --build-only)
 # Use in conjunction with pnpm bumpVersion #.#.# to update all package versions
+#
+# Auth is npm Trusted Publishing (OIDC) — see .github/workflows/publish.yml.
+# Adding a NEW package? npm can't attach a trusted publisher to a package that
+# doesn't exist yet, so its first publish can't use OIDC. Bootstrap it once:
+#     ./bootstrap-new-package.sh <package-folder-name>
+# After that it publishes here automatically. To (re)apply every trusted-publisher
+# config at once: ./setup-trusted-publishers.sh
 
 BUILD_ONLY=false
 

--- a/setup-trusted-publishers.sh
+++ b/setup-trusted-publishers.sh
@@ -1,34 +1,24 @@
 #!/usr/bin/env bash
-# Configure npm Trusted Publishers (GitHub Actions OIDC) for all published
-# @atomic-testing/* packages. Run once. Requires npm CLI >= 11.10.0 and an
-# authenticated npm session (`npm login`) with write access + account 2FA.
+# Reconcile npm Trusted Publishers (GitHub Actions OIDC) for every published
+# @atomic-testing/* package. Idempotent — safe to re-run anytime (e.g. after
+# adding a package; re-applying an existing config is a no-op/update).
+#
+# The package set is derived from packages/* to mirror publish.sh, so new
+# packages are picked up automatically — no list to maintain. The EXCLUDE list
+# below MUST stay in sync with the one in publish.sh.
+#
+# Requires: npm CLI >= 11.10.0, and `npm login` (account-level 2FA enabled).
 set -uo pipefail   # intentionally NOT -e: one failure shouldn't abort the batch
 
-REPO="atomic-testing/atomic-testing"
-WORKFLOW="publish.yml"          # filename only — must match the trigger workflow
-SCOPE="@atomic-testing"
+cd "$(dirname "$0")"
 
-PACKAGES=(
-  core
-  dom-core
-  react-core
-  react-18
-  react-19
-  react-legacy
-  vue-3
-  playwright
-  component-driver-html
-  component-driver-mui-v6
-  component-driver-mui-v7
-  component-driver-mui-x-v6
-  component-driver-mui-x-v7
-  component-driver-mui-x-v8
-  internal-test-runner
-  internal-test-runner-jest-adapter
-  internal-test-runner-vitest-adapter
-  internal-mui-x-test-fixture
-  internal-react-example
-)
+REPO="atomic-testing/atomic-testing"
+WORKFLOW="publish.yml"            # filename only — must match the trigger workflow
+
+# Folders publish.sh does NOT publish — keep in sync with publish.sh
+EXCLUDE=(temp component-driver-mui-v5 component-driver-mui-x-v5)
+
+is_excluded() { local d="$1" e; for e in "${EXCLUDE[@]}"; do [[ "$d" == "$e" ]] && return 0; done; return 1; }
 
 # Pre-flight: `npm trust` exists only on npm >= 11.10.0
 if ! npm trust --help >/dev/null 2>&1; then
@@ -37,15 +27,22 @@ if ! npm trust --help >/dev/null 2>&1; then
   exit 1
 fi
 
-failed=()
-for pkg in "${PACKAGES[@]}"; do
-  full="$SCOPE/$pkg"
-  echo "→ $full"
-  if npm trust github "$full" --file "$WORKFLOW" --repo "$REPO" --allow-publish -y; then
+failed=(); count=0
+for dir in packages/*/; do
+  folder="$(basename "$dir")"
+  is_excluded "$folder" && continue
+  [[ -f "$dir/package.json" ]] || continue
+  # skip private (unpublished) packages
+  [[ "$(node -p "require('./$dir/package.json').private === true")" == "true" ]] && continue
+
+  pkg="$(node -p "require('./$dir/package.json').name")"
+  count=$((count + 1))
+  echo "→ $pkg"
+  if npm trust github "$pkg" --file "$WORKFLOW" --repo "$REPO" --allow-publish -y; then
     echo "  ✓ configured"
   else
     echo "  ✗ FAILED"
-    failed+=("$full")
+    failed+=("$pkg")
   fi
   sleep 2   # avoid registry rate limiting
 done
@@ -54,7 +51,7 @@ echo
 if (( ${#failed[@]} )); then
   echo "Completed with ${#failed[@]} failure(s):"
   printf '   - %s\n' "${failed[@]}"
-  echo "Re-run the script to retry — re-applying an existing config is a no-op/update."
+  echo "Re-run the script to retry (idempotent)."
   exit 1
 fi
-echo "All ${#PACKAGES[@]} packages configured. ✓"
+echo "All $count package(s) configured. ✓"


### PR DESCRIPTION
## What

Maintainer tooling for the npm Trusted Publishing (OIDC) setup that landed in #891. No CI/runtime behavior change — these are local helper scripts plus a doc note.

- **`setup-trusted-publishers.sh`** — reconciles a GitHub Actions trusted publisher for every published `@atomic-testing/*` package via `npm trust`. Package set is **discovered from `packages/*`** (mirroring `publish.sh`, same EXCLUDE list, skips `private` packages), so it has no hardcoded list to maintain. Idempotent — safe to re-run.
- **`bootstrap-new-package.sh <folder>`** — one-time setup for a brand-new package. npm can't attach a trusted publisher to a package that doesn't exist yet, so this does the first publish (a throwaway `0.0.0` placeholder, original version auto-restored) under your `npm login`, then attaches the trusted publisher. After this, CI publishes the real version via OIDC.
- **`publish.sh`** — short comment pointing maintainers at both scripts.

## Notes

- Requires npm CLI **≥ 11.10.0** (for `npm trust`) and `npm login`; both scripts pre-flight-check this.
- Verified: dynamic discovery resolves to exactly the 19 published packages (the two frozen MUI 5 packages excluded); all scripts pass `bash -n`.
- Safe to merge anytime — independent of the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)