### PR TITLE
fix(ci): drop broken redundant pnpm -r version publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,7 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "Determined version: $VERSION"
 
-      - name: Update package versions
-        run: |
-          # This command updates all packages to the new version
-          pnpm -r version $VERSION --no-git-tag-version
-
-      - name: Build packages
+      - name: Set package versions
         run: pnpm bumpVersion $VERSION
 
       - name: Publish packages


### PR DESCRIPTION
## Problem

With the OIDC checkout fix in place, the `v0.84.1` release run got past checkout and failed at the **Update package versions** step:

```
ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT  None of the selected packages has a "version" script
```

Newer pnpm 10.x treats `pnpm -r version $VERSION` as "run the `version` **script** in every workspace package" rather than the version-bump command, so it errors. This was latent — earlier releases (0.82–0.84) died at checkout first, masking it. npm has been stuck at `@atomic-testing/core@0.81.0` since January as a result.

## Fix

Delete the broken step. It's **redundant**: the next step runs `pnpm bumpVersion` → [`scripts/bumpVersion.js`](scripts/bumpVersion.js), which already rewrites `"version"` in every `packages/*/package.json`.

Also rename the remaining `Build packages` step to **Set package versions** — it only runs `bumpVersion` (sets versions); the actual build happens inside `publish.sh`. (Calling out the rename explicitly since it's a behavior-neutral clarity change.)

## After merge

Re-fire the release (recreate `v0.84.1` from updated `main`) to publish all 19 packages via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)