### PR TITLE
fix(ci): upgrade npm to >= 11.5.1 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Set package versions
         run: pnpm bumpVersion $VERSION
 
+      - name: Upgrade npm for OIDC trusted publishing
+        # `pnpm publish` shells out to npm, and OIDC trusted publishing requires
+        # npm >= 11.5.1. The Node 22 runner ships npm 10.x, which doesn't attempt
+        # the OIDC token exchange and fails with ENEEDAUTH. Keep pnpm on 10.x —
+        # pnpm 11 has a known OIDC regression.
+        run: npm install -g npm@latest
+
       - name: Publish packages
         # Auth via npm Trusted Publishing (OIDC) — no NPM_TOKEN needed.
         # Requires `id-token: write` (above) plus a Trusted Publisher configured


### PR DESCRIPTION
## Problem

With checkout and the version step fixed, the `v0.84.1` run reached the actual publish and built + packed every tarball successfully, then failed at auth:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

`pnpm publish` (pnpm 10.34.4) **shells out to the system `npm`** for the registry operation. OIDC trusted publishing requires **npm ≥ 11.5.1**, but the Node 22 runner ships **npm 10.x**, which doesn't understand OIDC and never attempts the token exchange → `ENEEDAUTH`.

## Fix

Add a step before publishing:

```yaml
- name: Upgrade npm for OIDC trusted publishing
  run: npm install -g npm@latest
```

pnpm stays pinned to 10.x (pnpm 11 has a known OIDC 404 regression). The trusted-publisher configs (19 packages) and `id-token: write` are already in place, so once npm is current the OIDC exchange should succeed.

## After merge

Re-fire `v0.84.1` from updated `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)