### PR TITLE
fix(publish): repository field for provenance + idempotent publish.sh

### DIFF
--- a/packages/component-driver-mui-v7/package.json
+++ b/packages/component-driver-mui-v7/package.json
@@ -2,6 +2,11 @@
   "name": "@atomic-testing/component-driver-mui-v7",
   "version": "0.81.0",
   "description": "Component driver for Material-UI v7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git",
+    "directory": "packages/component-driver-mui-v7"
+  },
   "files": [
     "dist",
     "src"

--- a/packages/internal-mui-x-test-fixture/package.json
+++ b/packages/internal-mui-x-test-fixture/package.json
@@ -3,6 +3,11 @@
   "version": "0.81.0",
   "license": "MIT",
   "author": "Tianzhen Lin <tangent@usa.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git",
+    "directory": "packages/internal-mui-x-test-fixture"
+  },
   "files": [
     "dist",
     "src"

--- a/publish.sh
+++ b/publish.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 # Bulk publish all packages (or just build if --build-only)
 # Use in conjunction with pnpm bumpVersion #.#.# to update all package versions
+#
+# Auth is npm Trusted Publishing (OIDC) — see .github/workflows/publish.yml.
+# Adding a NEW package? npm can't attach a trusted publisher to a package that
+# doesn't exist yet, so its first publish can't use OIDC. Bootstrap it once:
+#     ./bootstrap-new-package.sh <package-folder-name>
+# After that it publishes here automatically. To (re)apply every trusted-publisher
+# config at once: ./setup-trusted-publishers.sh
 
 BUILD_ONLY=false
 
@@ -53,8 +60,16 @@ for dir in */; do
     pnpm build
 
     if [[ "$BUILD_ONLY" == false ]]; then
-      echo "→ Publishing $pkg"
-      pnpm publish --access=public --no-git-checks
+      pkgName="$(node -p "require('./package.json').name")"
+      pkgVer="$(node -p "require('./package.json').version")"
+      # Idempotent: skip versions already on the registry so a re-run after a
+      # partial publish resumes instead of failing on "cannot publish over".
+      if npm view "${pkgName}@${pkgVer}" version > /dev/null 2>&1; then
+        echo "↷ Skipping $pkgName@$pkgVer (already published)"
+      else
+        echo "→ Publishing $pkgName@$pkgVer"
+        pnpm publish --access=public --no-git-checks
+      fi
     else
       echo "→ Skipping publish for $pkg"
     fi


### PR DESCRIPTION
## Problem

With OIDC working, the `v0.84.1` run published `component-driver-html` and `component-driver-mui-v6` (with provenance ✅), then failed on `component-driver-mui-v7`:

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/atomic-testing/atomic-testing"
```

Provenance (auto-enabled under trusted publishing) requires each `package.json` to declare a `repository.url` matching the source repo. A survey found **two published packages missing `repository` entirely**: `component-driver-mui-v7` and `internal-mui-x-test-fixture`.

## Fix

1. Add the standard `repository` block to both package.json files (mirrors the other packages).
2. **Make `publish.sh` idempotent** — skip any `name@version` already on the registry. This was exposed by the partial publish: `publish.sh` previously couldn't re-run the same version once some packages were live (`set -e` aborts on "cannot publish over existing version"). Now a re-fire resumes from where it left off and recovers cleanly from any partial publish — no version churn.

## After merge

Re-fire `v0.84.1` from updated `main`. `component-driver-html` and `mui-v6` (already at 0.84.1) will be skipped; the rest publish.

## Aside (not fixed here)

`component-driver-mui-x-v5` and `component-driver-mui-x-v6` have a copy-paste wrong `repository.directory` (point at `component-driver-mui-v5/v6`). Doesn't affect provenance (only `url` is validated), so left alone — flagging for a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)