### PR TITLE
fix(ci): make version commit-back resilient to main moving

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: bump version to $VERSION [skip ci]"
+          # Re-apply the bump onto the latest main so the push fast-forwards even
+          # if main advanced (e.g. a merge) while this release was building.
+          git fetch origin main
+          git reset --hard
+          git checkout -B main origin/main
+          pnpm bumpVersion "$VERSION"
+          git add -A
+          git diff --cached --quiet || git commit -m "chore: bump version to $VERSION [skip ci]"
           git push origin HEAD:main


### PR DESCRIPTION
## Problem

`v0.84.1` **published all 19 packages successfully** (OIDC + provenance ✅). The run still went red on the final **Commit version updates** step:

```
! [rejected]  HEAD -> main (fetch first)
Updates were rejected because the remote contains work that you do not have locally.
```

The step commits on the detached **tag** checkout and does `git push HEAD:main`. When `main` advances during the release run (here: PR #893 merged mid-build), the push isn't a fast-forward and fails. Not branch protection.

## Fix

Re-apply the bump onto the latest `main` before pushing, and skip the commit when nothing changed:

```bash
git fetch origin main
git reset --hard
git checkout -B main origin/main
pnpm bumpVersion "$VERSION"
git add -A
git diff --cached --quiet || git commit -m "chore: bump version to $VERSION [skip ci]"
git push origin HEAD:main
```

## After merge

Re-fire `v0.84.1`. The idempotent `publish.sh` skips all packages (already at 0.84.1) and only the commit-back runs — giving us one fully green run and syncing main's package.json versions (currently stale at 0.81.0) to 0.84.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)