### PR TITLE
fix(docs): exclude frozen MUI 5 packages from TypeDoc

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,10 +29,15 @@ const atomicCodeTheme: PrismTheme = {
   ],
 };
 
+// MUI 5 / MUI-X 5 are frozen & EOL (ADR-005) and no longer built, so their type
+// declarations are absent and TypeDoc can't resolve cross-package imports from
+// them — exclude from API docs. Keep in sync with publish.sh's exclude list.
+const EXCLUDED_FROM_DOCS = new Set(['component-driver-mui-v5', 'component-driver-mui-x-v5']);
+
 function getPackageNames() {
   const baseDir = path.join(__dirname, '../packages');
   const packageNames = fs.readdirSync(baseDir).filter(name => {
-    if (name.startsWith('internal-')) {
+    if (name.startsWith('internal-') || EXCLUDED_FROM_DOCS.has(name)) {
       return false;
     }
     const fullPath = path.join(baseDir, name);


### PR DESCRIPTION
## Problem

The documentation build (`Verify documentation build`) fails:

```
Converting project at packages/component-driver-mui-x-v5
  error TS2307: Cannot find module '@atomic-testing/component-driver-mui-v5'
[error] Failed to convert one or more packages, result will not be merged together
[WARNING] No docs found in "api": can't auto-generate a sidebar.
[ERROR] Sidebar category "API Documentation" has neither any subitem nor a link.
```

**Root cause:** the MUI 5 freeze (ADR-005, landed today) removed `component-driver-mui-v5` / `component-driver-mui-x-v5` from `publish.sh`, so they're no longer built → no `.d.ts`. But `docusaurus-plugin-typedoc`'s `getPackageNames()` still includes them, so TypeDoc tries to convert `mui-x-v5` (which imports `mui-v5`), can't resolve the types, and **aborts the entire merged API output** → empty `api/` → Docusaurus errors on the empty autogenerated category.

This is latent on `main`; `doc-ci.yml` only runs on `docs/**` changes, so it first surfaced on PR #898 (the next docs-touching PR). It is **not** caused by #898.

## Fix

Exclude the two frozen packages from the docs TypeDoc entry points (mirrors `publish.sh`). The companion freeze PR already dropped `check:type` for them (72ea85c); this closes the same gap for TypeDoc.

This PR touches `docs/**`, so its own `Verify documentation build` check validates the fix.

## Note

Once merged, update PR #898 from `main` so its docs build picks up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)