### PR TITLE
feat: add MUI X v9 driver support (component-driver-mui-x-v9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,24 @@ ones are stable.
 | Driver family | Supported majors | End of support            |
 | ------------- | ---------------- | ------------------------- |
 | MUI (core)    | v6, v7, v9       | **v5 - ended 2026-06-27** |
-| MUI-X         | v6, v7, v8       | **v5 - ended 2026-06-27** |
+| MUI-X         | v6, v7, v8, v9   | **v5 - ended 2026-06-27** |
 
 **MUI 5 / MUI-X 5 are no longer supported** as of **2026-06-27**. The
 `@atomic-testing/component-driver-mui-v5` and
 `@atomic-testing/component-driver-mui-x-v5` packages are frozen at `0.81.0`:
 they remain installable at that version but receive no fixes, new drivers, or
 CI/e2e coverage, and their test suites no longer run. New work targets v6/v7/v9
-(MUI-X also v8). Rationale and migration notes:
+(MUI-X also v8 and v9). Rationale and migration notes:
 [ADR-005](agent-docs/adr/005-drop-mui-5-support.md).
 
 > Note: MUI Core has **no v8** — it jumped `7.3.11 → 9.0.0` to unify versioning
 > with MUI X, so `@atomic-testing/component-driver-mui-v9` is the successor to v7
 > (there is no `-mui-v8` package).
 >
-> Note: the MUI-X date/time **picker** drivers only ever shipped in the v5
-> package; they have no v6–v8 successor at this time.
+> Note: the MUI-X date/time **picker** drivers originally shipped only in the v5
+> package. The v9 package revives a read-capable `DesktopDatePicker` driver
+> (rewritten for the v9 `PickersSectionList` field DOM); writing a value and the
+> other picker variants are tracked as follow-ups.
 
 ## Getting Started
 

--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -420,3 +420,46 @@ pnpm add @atomic-testing/component-driver-mui-x-v8
 | DataGridDataRowDriver   | Driver for data rows in DataGrid          |
 
 </details>
+
+### [MUI X V9](https://mui.com/x/) components
+
+<details>
+  <summary>Component list</summary>
+
+Package: [@atomic-testing/component-driver-mui-x-v9](https://github.com/atomic-testing/atomic-testing/tree/main/packages/component-driver-mui-x-v9/src)
+
+<Tabs>
+<TabItem value="npm" label="npm">
+
+```bash
+npm install @atomic-testing/component-driver-mui-x-v9
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn add @atomic-testing/component-driver-mui-x-v9
+```
+
+</TabItem>
+<TabItem value="pnpm" label="pnpm">
+
+```bash
+pnpm add @atomic-testing/component-driver-mui-x-v9
+```
+
+</TabItem>
+</Tabs>
+
+| Driver                        | Description                                                        |
+| ----------------------------- | ----------------------------------------------------------------- |
+| DataGridPremiumDriver         | Driver for DataGrid / DataGridPro / DataGridPremium component      |
+| DataGridHeaderRowDriver       | Driver for header rows in DataGrid                                 |
+| DataGridDataRowDriver         | Driver for data rows in DataGrid                                   |
+| DataGridFooterDriver          | Driver for the DataGrid footer (pagination)                       |
+| DataGridPaginationActionDriver | Driver for the footer next/previous pagination controls          |
+| DesktopDatePickerDriver       | Read-capable driver for DesktopDatePicker (v9 section field)       |
+| SimpleTreeViewDriver          | Driver for SimpleTreeView / RichTreeView (expand/collapse, read)  |
+
+</details>

--- a/package-tests/component-driver-mui-x-v9-test/.npmrc
+++ b/package-tests/component-driver-mui-x-v9-test/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-tests/component-driver-mui-x-v9-test/README.md
+++ b/package-tests/component-driver-mui-x-v9-test/README.md
@@ -1,0 +1,3 @@
+# @atomic-testing/component-driver-mui-x-v9-test
+
+DOM and end-to-end tests for component drivers for [Material UI X](https://mui.com/x/) v9 components.

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DataGrid.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DataGrid.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { basicDataGridPremiumExample, basicDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(basicDataGridPremiumTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof basicDataGridPremiumExample.scene) => {
+    return createTestEngine(basicDataGridPremiumExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DataGrid.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DataGrid.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { basicDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(basicDataGridPremiumTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DatePicker.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DatePicker.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { desktopDatePickerExample, desktopDatePickerTestSuite } from '../src/examples';
+
+testRunner(desktopDatePickerTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof desktopDatePickerExample.scene) => {
+    return createTestEngine(desktopDatePickerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DatePicker.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DatePicker.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { desktopDatePickerTestSuite } from '../src/examples';
+
+testRunner(desktopDatePickerTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/TreeView.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/TreeView.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { simpleTreeViewExample, simpleTreeViewTestSuite } from '../src/examples';
+
+testRunner(simpleTreeViewTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof simpleTreeViewExample.scene) => {
+    return createTestEngine(simpleTreeViewExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/TreeView.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/TreeView.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { simpleTreeViewTestSuite } from '../src/examples';
+
+testRunner(simpleTreeViewTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/index.html
+++ b/package-tests/component-driver-mui-x-v9-test/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MUI X V9 Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package-tests/component-driver-mui-x-v9-test/jest.config.js
+++ b/package-tests/component-driver-mui-x-v9-test/jest.config.js
@@ -1,0 +1,9 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  testRegex: '(/__tests__/.*.dom.(test|spec)).(jsx?|tsx?)$',
+  displayName: 'component-driver-mui-x-v9-test',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/package-tests/component-driver-mui-x-v9-test/jest.setup.js
+++ b/package-tests/component-driver-mui-x-v9-test/jest.setup.js
@@ -1,0 +1,20 @@
+// __tests__/jest.setup.js
+
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
+
+// Capture the real console.error BEFORE spying so the mock can delegate to it.
+// Calling the spied `console.error` from inside the mock would recurse infinitely.
+const originalConsoleError = console.error;
+const errorSpy = jest.spyOn(console, 'error').mockImplementation((...args) => {
+  const [message] = args;
+  // Swallow the expected unlicensed-MUI-X warning; forward everything else verbatim.
+  if (typeof message === 'string' && message.includes('MUI X: Missing license key')) {
+    return;
+  }
+  originalConsoleError.apply(console, args);
+});
+
+afterAll(() => {
+  errorSpy.mockRestore();
+});

--- a/package-tests/component-driver-mui-x-v9-test/package.json
+++ b/package-tests/component-driver-mui-x-v9-test/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@atomic-testing/component-driver-mui-x-v9-test",
+  "version": "0.0.0",
+  "description": "Examples and tests for @atomic-testing/component-driver-mui-x-v9",
+  "keywords": [
+    "integration",
+    "integration-driver",
+    "material-ui",
+    "mui",
+    "react",
+    "testing",
+    "unit",
+    "v9"
+  ],
+  "license": "MIT",
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "start": "vite --force",
+    "build:ui": "vite build",
+    "test:dom": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:chrome": "playwright test --project=chromium"
+  },
+  "dependencies": {
+    "@atomic-testing/core": "workspace:*",
+    "@atomic-testing/internal-mui-x-test-fixture": "workspace:*",
+    "@atomic-testing/internal-react-example": "workspace:*",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
+    "@mui/system": "^9.0.0",
+    "@mui/x-charts": "^9.7.0",
+    "@mui/x-data-grid-generator": "^9.7.0",
+    "@mui/x-data-grid-premium": "^9.7.0",
+    "@mui/x-date-pickers": "^9.7.0",
+    "@mui/x-date-pickers-pro": "^9.7.0",
+    "@mui/x-tree-view": "^9.7.0",
+    "date-fns": "^4.1.0",
+    "exceljs": "^4.3.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router-dom": "^7.7.1"
+  },
+  "devDependencies": {
+    "@atomic-testing/component-driver-html": "workspace:*",
+    "@atomic-testing/component-driver-mui-v9": "workspace:*",
+    "@atomic-testing/component-driver-mui-x-v9": "workspace:*",
+    "@atomic-testing/internal-test-runner": "workspace:*",
+    "@atomic-testing/internal-test-runner-jest-adapter": "workspace:*",
+    "@atomic-testing/playwright": "workspace:*",
+    "@atomic-testing/react-19": "workspace:*",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/package-tests/component-driver-mui-x-v9-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-x-v9-test/playwright.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseUrl = 'http://localhost:5129';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './__tests__',
+  testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
+  /* Maximum time one test can run for. 30s tolerates Vite's cold first-compile and
+     cross-browser CI variance; a tighter budget caused flaky cold-start failures. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: baseUrl,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm start',
+    timeout: 120 * 1000,
+    url: baseUrl,
+    reuseExistingServer: true,
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/src/Home.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/Home.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function Home() {
+  return <p>Welcome</p>;
+}

--- a/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
@@ -1,0 +1,23 @@
+import { ExampleList, ExampleToc } from '@atomic-testing/internal-react-example';
+
+import { basicDataGridPremiumUIExample } from './examples/datagridpremium/BasicDataGridPremium.examples';
+import { basicDesktopDatePickerUIExample } from './examples/datepicker/DesktopDatePicker.examples';
+import { basicSimpleTreeViewUIExample } from './examples/treeview/SimpleTreeView.examples';
+
+export const tocs: ExampleToc[] = [
+  {
+    label: 'DataGrid Premium',
+    path: '/datagridpremium',
+    ui: <ExampleList examples={[basicDataGridPremiumUIExample]} />,
+  },
+  {
+    label: 'Desktop Date Picker',
+    path: '/datepicker',
+    ui: <ExampleList examples={[basicDesktopDatePickerUIExample]} />,
+  },
+  {
+    label: 'Simple Tree View',
+    path: '/treeview',
+    ui: <ExampleList examples={[basicSimpleTreeViewUIExample]} />,
+  },
+];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/BasicDataGridPremium.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/BasicDataGridPremium.examples.tsx
@@ -1,0 +1,36 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { basicGridColumnConfig, gridData, initialState } from '@atomic-testing/internal-mui-x-test-fixture';
+import Box from '@mui/material/Box';
+import { DataGridPremium, DataGridPremiumProps, GridColDef } from '@mui/x-data-grid-premium';
+import React, { JSX } from 'react';
+
+const gridCommonProps: DataGridPremiumProps = {
+  // The shared fixture widens column `type` to `string`; the first five columns are untyped,
+  // so this slice is safe to present as GridColDef[].
+  columns: basicGridColumnConfig.slice(0, 5) as GridColDef[],
+  rows: gridData.slice(0, 100),
+  initialState,
+  checkboxSelection: true,
+  pagination: true,
+  pageSizeOptions: [10, 25, 50],
+};
+
+export const BasicDataGridPremium: React.FunctionComponent = () => {
+  // Giving minWidth so in DOM test the grid will not be too small
+
+  return (
+    <Box sx={{ height: 480, minWidth: 800, width: '100%' }} data-testid='basic-grid-premium'>
+      <DataGridPremium {...gridCommonProps} />
+    </Box>
+  );
+};
+
+/**
+ * Basic DataGridPremium example from MUI's website
+ * @see https://mui.com/x/react-data-grid/
+ */
+export const basicDataGridPremiumUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic DataGridPremium',
+  ui: <BasicDataGridPremium />,
+};
+//#endregion

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/BasicDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/BasicDataGridPremium.suite.ts
@@ -1,0 +1,67 @@
+import { DataGridPremiumDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicDataGridPremiumUIExample } from './BasicDataGridPremium.examples';
+
+export const basicDataGridPremiumExampleScenePart = {
+  basicGrid: {
+    locator: byDataTestId('basic-grid-premium'),
+    driver: DataGridPremiumDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Basic DataGridPremium example from MUI's website
+ * @see https://mui.com/x/react-data-grid/
+ */
+export const basicDataGridPremiumExample: IExampleUnit<typeof basicDataGridPremiumExampleScenePart, JSX.Element> = {
+  ...basicDataGridPremiumUIExample,
+  scene: basicDataGridPremiumExampleScenePart,
+};
+//#endregion
+
+export const basicDataGridPremiumTestSuite: TestSuiteInfo<typeof basicDataGridPremiumExampleScenePart> = {
+  title: 'Basic DataGridPremium',
+  url: '/datagridpremium',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue }) => {
+    const engine = useTestEngine(basicDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('it should display at least 2 columns', async () => {
+      const count = await engine().parts.basicGrid.getColumnCount();
+      assertTrue(count >= 2);
+    });
+
+    test('it should display at least 2 rows', async () => {
+      const count = await engine().parts.basicGrid.getRowCount();
+      assertTrue(count >= 2);
+    });
+
+    test('Get cell should return cell with some text', async () => {
+      const text = await engine().parts.basicGrid.getCellText({ rowIndex: 1, columnIndex: 1 });
+      assertTrue((text ?? '').length > 1);
+    });
+
+    test('Header Row should contain columns desk, commodity ...', async () => {
+      const columnText = await engine().parts.basicGrid.getHeaderText();
+      const expectedColumns = ['Desk', 'Commodity'];
+      const columnTextSet = new Set(columnText);
+      const columnExists = expectedColumns.every(column => columnTextSet.has(column));
+      assertTrue(columnExists);
+    });
+
+    test('Data Row 1 should have content in all cells except the first one because it is a checkbox', async () => {
+      const rowText = await engine().parts.basicGrid.getRowText(1);
+      // Guard against a vacuous pass: an empty row would make `.every` trivially true.
+      assertTrue(rowText.length > 1);
+      const textCorrect = rowText.every((column, index) => {
+        if (index === 0) {
+          return column === '';
+        }
+        return column.length > 1;
+      });
+      assertTrue(textCorrect);
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { basicDataGridPremiumExample, basicDataGridPremiumTestSuite } from './BasicDataGridPremium.suite';
+
+export { basicDataGridPremiumExample, basicDataGridPremiumTestSuite };
+export const dataGridPremiumExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  basicDataGridPremiumExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.examples.tsx
@@ -1,0 +1,28 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import React, { JSX } from 'react';
+
+export const BasicDesktopDatePicker: React.FunctionComponent = () => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <div data-testid='basic-desktop-date-picker'>
+        <DesktopDatePicker defaultValue={new Date(2026, 5, 27)} />
+      </div>
+      {/* Second instance with a different value to prove locator disambiguation. */}
+      <div data-testid='second-desktop-date-picker'>
+        <DesktopDatePicker defaultValue={new Date(2020, 0, 15)} />
+      </div>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Basic DesktopDatePicker example from MUI's website
+ * @see https://mui.com/x/react-date-pickers/date-picker/
+ */
+export const basicDesktopDatePickerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic DesktopDatePicker',
+  ui: <BasicDesktopDatePicker />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
@@ -1,0 +1,51 @@
+import { DesktopDatePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicDesktopDatePickerUIExample } from './DesktopDatePicker.examples';
+
+export const desktopDatePickerExampleScenePart = {
+  picker: {
+    locator: byDataTestId('basic-desktop-date-picker'),
+    driver: DesktopDatePickerDriver,
+  },
+  secondPicker: {
+    locator: byDataTestId('second-desktop-date-picker'),
+    driver: DesktopDatePickerDriver,
+  },
+} satisfies ScenePart;
+
+export const desktopDatePickerExample: IExampleUnit<typeof desktopDatePickerExampleScenePart, JSX.Element> = {
+  ...basicDesktopDatePickerUIExample,
+  scene: desktopDatePickerExampleScenePart,
+};
+
+export const desktopDatePickerTestSuite: TestSuiteInfo<typeof desktopDatePickerExampleScenePart> = {
+  title: 'DesktopDatePicker',
+  url: '/datepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    const engine = useTestEngine(desktopDatePickerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('getValue reads the default value from the hidden input', async () => {
+      const value = await engine().parts.picker.getValue();
+      assertEqual(value?.getFullYear(), 2026);
+      assertEqual(value?.getMonth(), 5); // June (0-based)
+      assertEqual(value?.getDate(), 27);
+    });
+
+    test('getValueText returns the raw locale-formatted string', async () => {
+      const text = await engine().parts.picker.getValueText();
+      assertEqual(text, '06/27/2026');
+    });
+
+    test('two pickers are disambiguated - each reads its own value', async () => {
+      const first = await engine().parts.picker.getValue();
+      const second = await engine().parts.secondPicker.getValue();
+      assertEqual(first?.getFullYear(), 2026);
+      assertEqual(second?.getFullYear(), 2020);
+      assertEqual(second?.getMonth(), 0); // January
+      assertEqual(second?.getDate(), 15);
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { desktopDatePickerExample, desktopDatePickerTestSuite } from './DesktopDatePicker.suite';
+
+export { desktopDatePickerExample, desktopDatePickerTestSuite };
+export const datePickerExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  desktopDatePickerExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/index.ts
@@ -1,0 +1,3 @@
+export * from './datagridpremium';
+export * from './datepicker';
+export * from './treeview';

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.examples.tsx
@@ -1,0 +1,29 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import React, { JSX } from 'react';
+
+export const BasicSimpleTreeView: React.FunctionComponent = () => {
+  return (
+    <div data-testid='basic-tree-view' style={{ minHeight: 300, minWidth: 320 }}>
+      <SimpleTreeView>
+        <TreeItem itemId='fruits' label='Fruits'>
+          <TreeItem itemId='apple' label='Apple' />
+          <TreeItem itemId='banana' label='Banana' />
+        </TreeItem>
+        <TreeItem itemId='vegetables' label='Vegetables'>
+          <TreeItem itemId='carrot' label='Carrot' />
+        </TreeItem>
+      </SimpleTreeView>
+    </div>
+  );
+};
+
+/**
+ * Basic SimpleTreeView example from MUI's website
+ * @see https://mui.com/x/react-tree-view/simple-tree-view/
+ */
+export const basicSimpleTreeViewUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic SimpleTreeView',
+  ui: <BasicSimpleTreeView />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.suite.ts
@@ -1,0 +1,56 @@
+import { SimpleTreeViewDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicSimpleTreeViewUIExample } from './SimpleTreeView.examples';
+
+export const simpleTreeViewExampleScenePart = {
+  tree: {
+    locator: byDataTestId('basic-tree-view'),
+    driver: SimpleTreeViewDriver,
+  },
+} satisfies ScenePart;
+
+export const simpleTreeViewExample: IExampleUnit<typeof simpleTreeViewExampleScenePart, JSX.Element> = {
+  ...basicSimpleTreeViewUIExample,
+  scene: simpleTreeViewExampleScenePart,
+};
+
+export const simpleTreeViewTestSuite: TestSuiteInfo<typeof simpleTreeViewExampleScenePart> = {
+  title: 'SimpleTreeView',
+  url: '/treeview',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(simpleTreeViewExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('only top-level items are rendered initially (collapsed branches absent)', async () => {
+      assertEqual(await engine().parts.tree.getItemCount(), 2);
+      assertEqual(await engine().parts.tree.getItemIds(), ['fruits', 'vegetables']);
+    });
+
+    test('getItemLabel returns a specific item label', async () => {
+      assertEqual(await engine().parts.tree.getItemLabel('vegetables'), 'Vegetables');
+    });
+
+    test('a collapsed parent reports not expanded and hides its children', async () => {
+      assertFalse(await engine().parts.tree.isExpanded('fruits'));
+      assertFalse(await engine().parts.tree.itemExists('apple'));
+    });
+
+    test('expandItem reveals children and flips aria-expanded', async () => {
+      await engine().parts.tree.expandItem('fruits');
+      assertTrue(await engine().parts.tree.isExpanded('fruits'));
+      assertTrue(await engine().parts.tree.itemExists('apple'));
+      assertEqual(await engine().parts.tree.getItemCount(), 4);
+    });
+
+    test('collapseItem flips aria-expanded back to collapsed', async () => {
+      await engine().parts.tree.expandItem('fruits');
+      await engine().parts.tree.collapseItem('fruits');
+      // aria-expanded is the authoritative collapsed signal. Child <li>s linger in the DOM
+      // until MUI's Collapse transition finishes (which never runs under jsdom), so asserting
+      // their removal would be environment-dependent.
+      assertFalse(await engine().parts.tree.isExpanded('fruits'));
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/index.ts
@@ -1,0 +1,10 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { simpleTreeViewExample, simpleTreeViewTestSuite } from './SimpleTreeView.suite';
+
+export { simpleTreeViewExample, simpleTreeViewTestSuite };
+export const treeViewExamples: IExampleUnit<ScenePart, JSX.Element>[] = [simpleTreeViewExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/index.css
+++ b/package-tests/component-driver-mui-x-v9-test/src/index.css
@@ -1,0 +1,8 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+}

--- a/package-tests/component-driver-mui-x-v9-test/src/index.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/index.tsx
@@ -1,0 +1,23 @@
+import { ExampleApp } from '@atomic-testing/internal-react-example';
+import CssBaseline from '@mui/material/CssBaseline';
+import { StyledEngineProvider } from '@mui/material/styles';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import { tocs } from './directory';
+import { Home } from './Home';
+
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <StyledEngineProvider injectFirst>
+      <CssBaseline />
+      <BrowserRouter>
+        <ExampleApp home={Home} tocs={tocs} />
+      </BrowserRouter>
+    </StyledEngineProvider>
+  </React.StrictMode>
+);

--- a/package-tests/component-driver-mui-x-v9-test/src/vite-env.d.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package-tests/component-driver-mui-x-v9-test/tsconfig.json
+++ b/package-tests/component-driver-mui-x-v9-test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "declaration", "generator-build", "runtime"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/package-tests/component-driver-mui-x-v9-test/tsconfig.test.json
+++ b/package-tests/component-driver-mui-x-v9-test/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src", "__tests__/**/**.ts", "__tests__/**/**.tsx"]
+}

--- a/package-tests/component-driver-mui-x-v9-test/vite.config.ts
+++ b/package-tests/component-driver-mui-x-v9-test/vite.config.ts
@@ -1,0 +1,27 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+const port = 5129;
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': '/src', // Assuming your source code is in the 'src' directory
+    },
+    // MUI X v9 + the React 19 adapter pull React through several workspace links;
+    // dedupe keeps a single React copy so hooks don't throw "more than one copy of React".
+    dedupe: ['react', 'react-dom'],
+  },
+  server: {
+    host: true,
+    port,
+    // Having strictPort set to true along with hmr port locked to the same port
+    // would make sure hot-module-reload works properly
+    strictPort: true,
+    hmr: {
+      port,
+    },
+  },
+});

--- a/packages/component-driver-mui-x-v9/README.md
+++ b/packages/component-driver-mui-x-v9/README.md
@@ -1,0 +1,12 @@
+# @atomic-testing/component-driver-mui-x-v9
+
+Component drivers for [Material UI X](https://mui.com/x/) v9 components.
+They provide Atomic Testing wrappers for the latest MUI X widgets.
+
+## Installation
+
+```bash
+pnpm add @atomic-testing/component-driver-mui-x-v9
+```
+
+See the [docs](https://atomic-testing.dev/) for usage instructions.

--- a/packages/component-driver-mui-x-v9/jest.config.js
+++ b/packages/component-driver-mui-x-v9/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  displayName: 'component-driver-mui-x-v9',
+  testEnvironment: 'jsdom',
+};

--- a/packages/component-driver-mui-x-v9/package.json
+++ b/packages/component-driver-mui-x-v9/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@atomic-testing/component-driver-mui-x-v9",
+  "version": "0.81.0",
+  "description": "Atomic Testing Component driver to help drive Material UI X V9 components",
+  "keywords": [
+    "integration",
+    "integration-driver",
+    "material-ui",
+    "mui",
+    "react",
+    "testing",
+    "unit",
+    "v9"
+  ],
+  "license": "MIT",
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git",
+    "directory": "packages/component-driver-mui-x-v9"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check:type": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@atomic-testing/component-driver-html": "workspace:*",
+    "@atomic-testing/component-driver-mui-v9": "workspace:*",
+    "@atomic-testing/core": "workspace:*"
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridCellQuery.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridCellQuery.ts
@@ -1,0 +1,11 @@
+export interface CellQueryByColumnIndex {
+  rowIndex: number;
+  columnIndex: number;
+}
+
+export interface CellQueryByColumnField {
+  rowIndex: number;
+  columnField: string;
+}
+
+export type DataGridCellQuery = CellQueryByColumnIndex | CellQueryByColumnField;

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridDataRowDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridDataRowDriver.ts
@@ -1,0 +1,25 @@
+import { byRole, IComponentDriverOption, Interactor, locatorUtil, PartLocator } from '@atomic-testing/core';
+
+import { DataGridRowDriverBase } from './DataGridRowDriverBase';
+
+export class DataGridDataRowDriver extends DataGridRowDriverBase {
+  private readonly _dataCellLocator: PartLocator;
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts: {},
+    });
+
+    // v9 body cells are role="gridcell" (.MuiDataGrid-cell); the surrounding offset divs are
+    // role="none". (Earlier majors' role="cell" matches nothing here.)
+    this._dataCellLocator = locatorUtil.append(locator, byRole('gridcell'));
+  }
+
+  protected override getCellLocator(): PartLocator {
+    return this._dataCellLocator;
+  }
+
+  override get driverName(): string {
+    return 'MuiV9DataGridDataRowDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridFooterDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridFooterDriver.ts
@@ -1,0 +1,65 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssClass,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { DataGridPaginationActionDriver } from './DataGridPaginationActionDriver';
+
+const parts = {
+  paginationAction: {
+    locator: byCssClass('MuiTablePagination-actions'),
+    driver: DataGridPaginationActionDriver,
+  },
+  paginationDescription: {
+    locator: byCssClass('MuiTablePagination-displayedRows'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Driver for the footer (pagination) row of a Material UI v9 Data Grid component.
+ * @see https://mui.com/x/react-data-grid/
+ */
+export class DataGridFooterDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  async isPreviousPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('paginationAction');
+    return this.parts.paginationAction.isPreviousPageEnabled();
+  }
+
+  async gotoPreviousPage(): Promise<void> {
+    await this.enforcePartExistence('paginationAction');
+    await this.parts.paginationAction.gotoPreviousPage();
+  }
+
+  async isNextPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('paginationAction');
+    return this.parts.paginationAction.isNextPageEnabled();
+  }
+
+  async gotoNextPage(): Promise<void> {
+    await this.enforcePartExistence('paginationAction');
+    await this.parts.paginationAction.gotoNextPage();
+  }
+
+  async getPaginationDescription(): Promise<Optional<string>> {
+    await this.enforcePartExistence('paginationDescription');
+    return this.parts.paginationDescription.getText();
+  }
+
+  override get driverName(): string {
+    return 'MuiV9DataGridFooterDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridHeaderRowDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridHeaderRowDriver.ts
@@ -1,0 +1,27 @@
+import { byRole, IComponentDriverOption, Interactor, locatorUtil, PartLocator } from '@atomic-testing/core';
+
+import { DataGridRowDriverBase } from './DataGridRowDriverBase';
+
+export class DataGridHeaderRowDriver extends DataGridRowDriverBase {
+  private readonly _headerCellLocator: PartLocator;
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts: {},
+    });
+
+    this._headerCellLocator = locatorUtil.append(locator, byRole('columnheader'));
+  }
+
+  async getColumnCount(): Promise<number> {
+    return this.getCellCount();
+  }
+
+  protected override getCellLocator(): PartLocator {
+    return this._headerCellLocator;
+  }
+
+  override get driverName(): string {
+    return 'MuiV9DataGridHeaderRowDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPaginationActionDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPaginationActionDriver.ts
@@ -1,0 +1,59 @@
+import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+import {
+  byAttribute,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+const parts = {
+  previousButton: {
+    locator: byAttribute('aria-label', 'Go to previous page'),
+    driver: HTMLButtonDriver,
+  },
+  nextButton: {
+    locator: byAttribute('aria-label', 'Go to next page'),
+    driver: HTMLButtonDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Driver for the pagination next/previous controls in a Material UI v9 Data Grid footer.
+ * @see https://mui.com/x/react-data-grid/
+ */
+export class DataGridPaginationActionDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  async isPreviousPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('previousButton');
+    const isDisabled = await this.parts.previousButton.isDisabled();
+    return !isDisabled;
+  }
+
+  async gotoPreviousPage(): Promise<void> {
+    await this.enforcePartExistence('previousButton');
+    await this.parts.previousButton.click();
+  }
+
+  async isNextPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('nextButton');
+    const isDisabled = await this.parts.nextButton.isDisabled();
+    return !isDisabled;
+  }
+
+  async gotoNextPage(): Promise<void> {
+    await this.enforcePartExistence('nextButton');
+    await this.parts.nextButton.click();
+  }
+
+  override get driverName(): string {
+    return 'MuiV9DataGridPaginationActionDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -1,0 +1,231 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssClass,
+  byCssSelector,
+  byRole,
+  ComponentDriver,
+  ComponentDriverCtor,
+  IComponentDriverOption,
+  Interactor,
+  listHelper,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { DataGridCellQuery } from './DataGridCellQuery';
+import { DataGridDataRowDriver } from './DataGridDataRowDriver';
+import { DataGridFooterDriver } from './DataGridFooterDriver';
+import { DataGridHeaderRowDriver } from './DataGridHeaderRowDriver';
+
+const parts = {
+  headerRow: {
+    locator: byCssClass('MuiDataGrid-columnHeaders').chain(byCssSelector('[role=row]:first-of-type')),
+    driver: DataGridHeaderRowDriver,
+  },
+  loading: {
+    locator: byRole('progressbar'),
+    driver: HTMLElementDriver,
+  },
+  skeletonOverlay: {
+    locator: byCssClass('MuiDataGrid-main--hasSkeletonLoadingOverlay'),
+    driver: HTMLElementDriver,
+  },
+  footer: {
+    locator: byCssClass('MuiDataGrid-footerContainer'),
+    driver: DataGridFooterDriver,
+  },
+} satisfies ScenePart;
+
+const dataRowLocator = byCssSelector('[role=row][data-rowindex]');
+
+/**
+ * Driver for the Material UI v9 DataGridPremium component.
+ *
+ * Premium is a superset of Pro and the community DataGrid; all three render the
+ * same grid DOM (`.MuiDataGrid-*` classes, `role="row"`/`"gridcell"`/`"columnheader"`,
+ * `data-rowindex`/`data-colindex`/`data-field`), so this driver also works against
+ * DataGridPro and the community DataGrid.
+ *
+ * The grid root does not carry `data-testid`; to locate the component by test id,
+ * place the `data-testid` on the parent element wrapping the grid.
+ * @see https://mui.com/x/react-data-grid/
+ */
+export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  /**
+   * Checks if the data grid is currently loading.
+   * @returns A promise that resolves to a boolean indicating if the data grid is loading.
+   */
+  async isLoading(): Promise<boolean> {
+    const result = await Promise.all([this.parts.skeletonOverlay.isVisible(), this.parts.loading.isVisible()]);
+    return result.some(v => v);
+  }
+
+  /**
+   * Waits for the data grid to exit the loading state.
+   * @param timeoutMs The maximum time to wait for the load to complete, in milliseconds.
+   */
+  async waitForLoad(timeoutMs: number = 10000): Promise<void> {
+    await this.parts.headerRow.waitUntilComponentState();
+    await this.waitUntil({ probeFn: () => this.isLoading(), terminateCondition: false, timeoutMs });
+  }
+
+  /**
+   * The number of columns currently displayed in the data grid, note that the data grid
+   * uses virtualized rendering, therefore the column count heavily depends on the viewport size
+   * @returns The number of columns currently displayed in the data grid
+   */
+  async getColumnCount(): Promise<number> {
+    return this.parts.headerRow.getColumnCount();
+  }
+
+  /**
+   * The array text of the header row, note that columns not shown in the viewport may not be included because of virtualized rendering
+   * @returns The array of text of the header row
+   */
+  async getHeaderText(): Promise<string[]> {
+    return this.parts.headerRow.getRowText();
+  }
+
+  /**
+   * The number of rows currently displayed in the data grid, note that the data grid
+   * uses virtualized rendering, therefore the row count heavily depends on the viewport size
+   * @returns The number of columns currently displayed in the data grid
+   */
+  async getRowCount(): Promise<number> {
+    const gridRowLocator = locatorUtil.append(this.locator, dataRowLocator);
+    return listHelper.getListItemCount(this, gridRowLocator);
+  }
+
+  /**
+   * Return the data-row driver for the row at the specified index, or null if it does not exist.
+   * Data rows expose body cells (`role="cell"`), so this returns a {@link DataGridDataRowDriver}
+   * — not a header-row driver, which would look for `role="columnheader"` and find nothing in a
+   * body row.
+   * @param rowIndex
+   * @returns
+   */
+  async getRow(rowIndex: number): Promise<DataGridDataRowDriver | null> {
+    const rowLocator = locatorUtil.append(this.locator, byCssSelector(`[role=row][data-rowindex="${rowIndex}"]`));
+    const rowExists = await this.interactor.exists(rowLocator);
+    if (rowExists) {
+      return new DataGridDataRowDriver(rowLocator, this.interactor, this.commutableOption);
+    }
+
+    return null;
+  }
+
+  /**
+   * The array text of the specified row, note that columns not shown in the viewport may not be included because of virtualized rendering
+   * @param rowIndex The index of the row
+   * @returns The array of text of the specified row
+   */
+  async getRowText(rowIndex: number): Promise<string[]> {
+    const row = await this.getRow(rowIndex);
+    if (row != null) {
+      return row.getRowText();
+    }
+    throw new Error(`Row ${rowIndex} does not exist`);
+  }
+
+  /**
+   * Get the cell driver for the cell, if the cell does not exist, return null
+   * The cell driver is default to HTMLElementDriver, you can specify a different driver class
+   * @param query The query to locate the cell
+   * @param driverClass Optional, the driver class to use for the cell, default to HTMLElementDriver
+   * @returns
+   */
+  async getCell<DriverT extends ComponentDriver>(
+    query: DataGridCellQuery,
+    driverClass: ComponentDriverCtor<DriverT> = HTMLElementDriver as ComponentDriverCtor<DriverT>
+  ): Promise<DriverT | null> {
+    const rowDriver = await this.getRow(query.rowIndex);
+
+    if (rowDriver === null) {
+      return null;
+    }
+
+    if ('columnIndex' in query) {
+      return rowDriver.getCell(query.columnIndex, driverClass);
+    }
+
+    return rowDriver.getCell(query.columnField, driverClass);
+  }
+
+  /**
+   * Get the text content of the cell, if the cell does not exist, throw an error
+   * @param query The query to locate the cell
+   * @returns
+   */
+  async getCellText(query: DataGridCellQuery): Promise<string> {
+    const cell = await this.getCell(query);
+    if (cell != null) {
+      const text = await cell.getText();
+      return text!;
+    }
+
+    const columnIdentifier = 'columnIndex' in query ? query.columnIndex : query.columnField;
+    throw new Error(`Cell at row:${query.rowIndex} column:${columnIdentifier} does not exist`);
+  }
+
+  //#region Footer
+  /**
+   * Determine if the pagination footer is currently visible.
+   */
+  isFooterVisible(): Promise<boolean> {
+    return this.parts.footer.isVisible();
+  }
+
+  /**
+   * Check whether the "previous page" control is enabled.
+   */
+  async isPreviousPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('footer');
+    return this.parts.footer.isPreviousPageEnabled();
+  }
+
+  /**
+   * Navigate to the previous page using the grid footer control.
+   */
+  async gotoPreviousPage(): Promise<void> {
+    await this.enforcePartExistence('footer');
+    await this.parts.footer.gotoPreviousPage();
+  }
+
+  /**
+   * Check whether the "next page" control is enabled.
+   */
+  async isNextPageEnabled(): Promise<boolean> {
+    await this.enforcePartExistence('footer');
+    return this.parts.footer.isNextPageEnabled();
+  }
+
+  /**
+   * Navigate to the next page using the grid footer control.
+   */
+  async gotoNextPage(): Promise<void> {
+    await this.enforcePartExistence('footer');
+    await this.parts.footer.gotoNextPage();
+  }
+
+  /**
+   * Read the textual description of the current pagination state (e.g. "1–10 of 100").
+   */
+  async getPaginationDescription(): Promise<Optional<string>> {
+    await this.enforcePartExistence('footer');
+    return this.parts.footer.getPaginationDescription();
+  }
+  //#endregion Footer
+
+  override get driverName(): string {
+    return 'MuiV9DataGridPremiumDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridRowDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridRowDriverBase.ts
@@ -1,0 +1,77 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import {
+  byAttribute,
+  ComponentDriver,
+  ComponentDriverCtor,
+  listHelper,
+  locatorUtil,
+  PartLocator,
+} from '@atomic-testing/core';
+
+// In MUI7+, there is an extra div preceding the actual data cells. We need to skip it.
+const columnStartingIndex = 1;
+
+/**
+ * Base class for data grid row
+ */
+export abstract class DataGridRowDriverBase extends ComponentDriver {
+  protected async getCellCount(): Promise<number> {
+    let count = 0;
+    for await (const _ of listHelper.getListItemIterator(
+      this,
+      this.getCellLocator(),
+      HTMLElementDriver,
+      columnStartingIndex
+    )) {
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Get the text of each visible cell in the row.
+   * Caveat: Because of virtualization, the text of the cell may not be available until the cell is visible.
+   * @returns A promise array of text of each visible cell in the row
+   */
+  async getRowText(): Promise<string[]> {
+    const textList: string[] = [];
+    for await (const cell of listHelper.getListItemIterator(
+      this,
+      this.getCellLocator(),
+      HTMLElementDriver,
+      columnStartingIndex
+    )) {
+      const text = await cell.getText();
+      textList.push(text!.trim());
+    }
+    return textList;
+  }
+
+  /**
+   * Get the cell driver at the specified index or data field.
+   * Caveat: Because of virtualization, the cell may not be available until the cell is visible.
+   * @param cellIndexOrField number: column index, string: column field
+   * @param driverClass The driver class of the cell. Default is HTMLElementDriver
+   * @returns A promise of the cell driver, or null if the cell is not found
+   */
+  async getCell<DriverT extends ComponentDriver>(
+    cellIndexOrField: number | string, // number: column index, string: column field
+    driverClass: ComponentDriverCtor<DriverT> = HTMLElementDriver as ComponentDriverCtor<DriverT>
+  ): Promise<DriverT | null> {
+    let cellLocator: PartLocator;
+    if (typeof cellIndexOrField === 'number') {
+      cellLocator = byAttribute('data-colindex', cellIndexOrField.toString());
+    } else {
+      cellLocator = byAttribute('data-field', cellIndexOrField);
+    }
+    const locator = locatorUtil.append(this.locator, cellLocator);
+    const cellExists = await this.interactor.exists(locator);
+    if (cellExists) {
+      return new driverClass(locator, this.interactor, this.commutableOption);
+    }
+
+    return null;
+  }
+
+  protected abstract getCellLocator(): PartLocator;
+}

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/index.ts
@@ -1,0 +1,4 @@
+export * from './DataGridCellQuery';
+export { DataGridDataRowDriver } from './DataGridDataRowDriver';
+export { DataGridHeaderRowDriver } from './DataGridHeaderRowDriver';
+export { DataGridPremiumDriver } from './DataGridPremiumDriver';

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriver.ts
@@ -1,0 +1,19 @@
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+
+import { textEntryToDate } from './dateUtil';
+import { DesktopDatePickerDriverBase } from './DesktopDatePickerDriverBase';
+import { DatePickerCharacteristic } from './types';
+
+export class DesktopDatePickerDriver extends DesktopDatePickerDriverBase {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic = {
+      textEntryToValue: textEntryToDate,
+      defaultFormat: 'mm/dd/yyyy',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  get driverName(): string {
+    return 'MuiV9DesktopDatePicker';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
@@ -1,0 +1,77 @@
+import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssClass,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { DatePickerCharacteristic } from './types';
+
+// Since MUI X v6 the desktop pickers no longer use a plain editable <input>. The visible field
+// is a `PickersSectionList`: a `role="group"` of `contenteditable` `role="spinbutton"` section
+// spans (`.MuiPickersSectionList-sectionContent`, one per Month/Day/Year). A single hidden,
+// `aria-hidden` `<input class="MuiPickersInputBase-input">` mirrors the committed value as a
+// locale-formatted string for form submission — which is the stable, portable read path.
+//
+// NOTE: This base is read-only. A portable `setValue` requires typing real keystrokes into a
+// section span; the DOM interactor types via `userEvent.type` (real keys, works) but the
+// Playwright interactor types via `locator.fill` (innerText replacement, which MUI ignores).
+// Setting a value portably therefore needs a new keystroke primitive on `Interactor`,
+// tracked as a follow-up.
+const parts = {
+  // The hidden input mirrors the committed value as a formatted string (e.g. "06/27/2026").
+  valueInput: {
+    locator: byCssClass('MuiPickersInputBase-input'),
+    driver: HTMLTextInputDriver,
+  },
+} satisfies ScenePart;
+
+export abstract class DesktopDatePickerDriverBase extends ComponentDriver<typeof parts> {
+  constructor(
+    locator: PartLocator,
+    interactor: Interactor,
+    protected characteristic: DatePickerCharacteristic,
+    option?: Partial<IComponentDriverOption>
+  ) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  /**
+   * The committed value parsed into a `Date`, or `null` when the field is empty.
+   * Reads the hidden input that mirrors the field's locale-formatted value.
+   */
+  async getValue(): Promise<Date | null> {
+    const text = await this.getValueText();
+    if (text == null) {
+      return null;
+    }
+    const format = await this.getFormat();
+    return this.characteristic.textEntryToValue(text, format);
+  }
+
+  /**
+   * The raw locale-formatted text shown by the field (e.g. "06/27/2026"), or `undefined`
+   * when the field is empty.
+   */
+  async getValueText(): Promise<Optional<string>> {
+    await this.enforcePartExistence('valueInput');
+    const value = await this.interactor.getInputValue(this.parts.valueInput.locator);
+    return value != null && value.length > 0 ? value : undefined;
+  }
+
+  /**
+   * The v5 driver read the field's `placeholder` to discover the format, but the v9 section
+   * field has no placeholder attribute. The format is carried implicitly by the section spans,
+   * so fall back to the driver's declared default format.
+   */
+  async getFormat(defaultFormat: string = this.characteristic.defaultFormat): Promise<string> {
+    return defaultFormat;
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/dateUtil.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/dateUtil.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse a desktop date picker's committed value — the hidden input's locale-formatted string
+ * (e.g. "06/27/2026") — into a Date, or null when the field is empty or the value cannot be
+ * parsed. The explicit Invalid-Date guard avoids leaking `new Date('…')`'s implementation-defined
+ * behaviour for malformed input.
+ *
+ * The write direction (typing a value into the section field) and the time/datetime/range
+ * converters are deferred until the keystroke-based write path lands.
+ */
+export function textEntryToDate(text: string, _format: string): Date | null {
+  if (text.length < 6) {
+    return null;
+  }
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/index.ts
@@ -1,0 +1,4 @@
+export * as dateUtil from './dateUtil';
+export * from './DesktopDatePickerDriver';
+export * from './DesktopDatePickerDriverBase';
+export * from './types';

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/types.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/types.ts
@@ -1,0 +1,7 @@
+export interface DatePickerCharacteristic {
+  textEntryToValue: (text: string, format: string) => Date | null;
+  /**
+   * Format hint displayed in the input field
+   */
+  defaultFormat: string;
+}

--- a/packages/component-driver-mui-x-v9/src/components/treeview/SimpleTreeViewDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/treeview/SimpleTreeViewDriver.ts
@@ -1,0 +1,138 @@
+import {
+  byCssSelector,
+  byRole,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+// MUI X Tree View renders an accessible tree: a `[role=tree]` container whose items are
+// `<li role="treeitem">` carrying `aria-expanded` (expandable items only) and `aria-selected`
+// (when selection is enabled). Each item's own label lives in `.MuiTreeItem-label` inside its
+// `.MuiTreeItem-content`; child items live in a nested `<ul>` that is only rendered while the
+// parent is expanded (collapsed branches are absent from the DOM).
+//
+// Items are identified by the app-assigned `itemId`, which MUI emits as the suffix of the
+// element `id` (`mui-tree-view-<n>-<itemId>`). There is no dedicated `data-itemid`, so this
+// driver matches on the `id` suffix; the leading `-` keeps `apple` from matching `crabapple`.
+//
+// Tree items are NESTED `<li>`s, so the `:nth-of-type` list iteration used for flat lists
+// (grid cells, menu items) does not apply here — counts/ids are read via the portable
+// "all matching elements" form of `getAttribute`.
+const treeIdPrefix = /^mui-tree-view-\d+-/;
+
+// Single source of truth for matching one item by its app-assigned itemId (the id suffix).
+function itemSelector(itemId: string): string {
+  return `[role=treeitem][id$="-${itemId}"]`;
+}
+
+function itemLocator(itemId: string): PartLocator {
+  return byCssSelector(itemSelector(itemId));
+}
+
+function itemContentLocator(itemId: string): PartLocator {
+  // The clickable content row; clicking it toggles expansion for items that have children.
+  return byCssSelector(`${itemSelector(itemId)} > .MuiTreeItem-content`);
+}
+
+function itemLabelLocator(itemId: string): PartLocator {
+  // Scope to the item's OWN label (direct content), not descendant children's labels.
+  return byCssSelector(`${itemSelector(itemId)} > .MuiTreeItem-content .MuiTreeItem-label`);
+}
+
+/**
+ * Driver for the Material UI X v9 SimpleTreeView / RichTreeView components.
+ * @see https://mui.com/x/react-tree-view/
+ */
+export class SimpleTreeViewDriver extends ComponentDriver {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts: {},
+    });
+  }
+
+  /**
+   * The app-assigned `itemId`s of every currently rendered tree item, in document order.
+   * Because collapsed branches are not in the DOM, this reflects only the visible items.
+   */
+  async getItemIds(): Promise<string[]> {
+    const ids = await this.interactor.getAttribute(locatorUtil.append(this.locator, byRole('treeitem')), 'id', true);
+    return ids.map(id => id.replace(treeIdPrefix, ''));
+  }
+
+  /**
+   * The number of tree items currently rendered (visible items only).
+   */
+  async getItemCount(): Promise<number> {
+    return (await this.getItemIds()).length;
+  }
+
+  /**
+   * Whether the item identified by `itemId` is currently rendered in the tree.
+   */
+  async itemExists(itemId: string): Promise<boolean> {
+    return this.interactor.exists(locatorUtil.append(this.locator, itemLocator(itemId)));
+  }
+
+  /**
+   * The label text of a specific item, or `undefined` when the item is not rendered.
+   */
+  async getItemLabel(itemId: string): Promise<Optional<string>> {
+    const locator = locatorUtil.append(this.locator, itemLabelLocator(itemId));
+    if (!(await this.interactor.exists(locator))) {
+      return undefined;
+    }
+    return this.interactor.getText(locator);
+  }
+
+  /**
+   * Whether an expandable item is expanded. Reads `aria-expanded`; returns false for leaf
+   * items (which carry no `aria-expanded`) or items that are not rendered.
+   */
+  async isExpanded(itemId: string): Promise<boolean> {
+    const expanded = await this.interactor.getAttribute(
+      locatorUtil.append(this.locator, itemLocator(itemId)),
+      'aria-expanded'
+    );
+    return expanded === 'true';
+  }
+
+  /**
+   * Whether an item is selected. Reads `aria-selected`; only meaningful when the tree has
+   * selection enabled.
+   */
+  async isSelected(itemId: string): Promise<boolean> {
+    const selected = await this.interactor.getAttribute(
+      locatorUtil.append(this.locator, itemLocator(itemId)),
+      'aria-selected'
+    );
+    return selected === 'true';
+  }
+
+  /**
+   * Expand the item if it is collapsed; no-op when already expanded. After expansion the
+   * item's children become available in the DOM.
+   */
+  async expandItem(itemId: string): Promise<void> {
+    if (!(await this.isExpanded(itemId))) {
+      await this.interactor.click(locatorUtil.append(this.locator, itemContentLocator(itemId)));
+    }
+  }
+
+  /**
+   * Collapse the item if it is expanded; no-op when already collapsed.
+   */
+  async collapseItem(itemId: string): Promise<void> {
+    if (await this.isExpanded(itemId)) {
+      await this.interactor.click(locatorUtil.append(this.locator, itemContentLocator(itemId)));
+    }
+  }
+
+  override get driverName(): string {
+    return 'MuiV9SimpleTreeViewDriver';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/treeview/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/treeview/index.ts
@@ -1,0 +1,1 @@
+export { SimpleTreeViewDriver } from './SimpleTreeViewDriver';

--- a/packages/component-driver-mui-x-v9/src/index.ts
+++ b/packages/component-driver-mui-x-v9/src/index.ts
@@ -1,0 +1,3 @@
+export * from './components/datagrid';
+export * from './components/datepicker';
+export * from './components/treeview';

--- a/packages/component-driver-mui-x-v9/tsconfig.json
+++ b/packages/component-driver-mui-x-v9/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "declaration", "generator-build", "runtime"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true
+  }
+}

--- a/packages/component-driver-mui-x-v9/tsconfig.test.json
+++ b/packages/component-driver-mui-x-v9/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  },
+  "include": ["./src", "__tests__/**/**.ts", "__tests__/**/**.tsx"]
+}

--- a/packages/component-driver-mui-x-v9/tsdown.config.ts
+++ b/packages/component-driver-mui-x-v9/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsdown';
+
+import commonConfig from '../../tsdown.config.base.ts';
+
+export default defineConfig({
+  ...commonConfig,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,10 +525,10 @@ importers:
         version: 7.29.7(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-date-pickers':
         specifier: ^7.27.1
-        version: 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-date-pickers-pro':
         specifier: ^7.27.1
-        version: 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       exceljs:
         specifier: ^4.3.0
         version: 4.4.0
@@ -598,10 +598,10 @@ importers:
         version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-date-pickers':
         specifier: ^8.5.2
-        version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-date-pickers-pro':
         specifier: ^8.5.2
-        version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       exceljs:
         specifier: ^4.3.0
         version: 4.4.0
@@ -621,6 +621,94 @@ importers:
       '@atomic-testing/component-driver-mui-x-v8':
         specifier: workspace:*
         version: link:../../packages/component-driver-mui-x-v8
+      '@atomic-testing/internal-test-runner':
+        specifier: workspace:*
+        version: link:../../packages/internal-test-runner
+      '@atomic-testing/internal-test-runner-jest-adapter':
+        specifier: workspace:*
+        version: link:../../packages/internal-test-runner-jest-adapter
+      '@atomic-testing/playwright':
+        specifier: workspace:*
+        version: link:../../packages/playwright
+      '@atomic-testing/react-19':
+        specifier: workspace:*
+        version: link:../../packages/react-19
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+
+  package-tests/component-driver-mui-x-v9-test:
+    dependencies:
+      '@atomic-testing/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@atomic-testing/internal-mui-x-test-fixture':
+        specifier: workspace:*
+        version: link:../../packages/internal-mui-x-test-fixture
+      '@atomic-testing/internal-react-example':
+        specifier: workspace:*
+        version: link:../../packages/internal-react-example
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled':
+        specifier: ^11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/icons-material':
+        specifier: ^9.0.0
+        version: 9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material':
+        specifier: ^9.0.0
+        version: 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system':
+        specifier: ^9.0.0
+        version: 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-charts':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-generator':
+        specifier: ^9.7.0
+        version: 9.7.0(40fde8b2c5e74a8bd749ad4af8005570)
+      '@mui/x-data-grid-premium':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers-pro':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-tree-view':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.4.0
+      exceljs:
+        specifier: ^4.3.0
+        version: 4.4.0
+      react:
+        specifier: ^19.2.3
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.7.1
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@atomic-testing/component-driver-html':
+        specifier: workspace:*
+        version: link:../../packages/component-driver-html
+      '@atomic-testing/component-driver-mui-v9':
+        specifier: workspace:*
+        version: link:../../packages/component-driver-mui-v9
+      '@atomic-testing/component-driver-mui-x-v9':
+        specifier: workspace:*
+        version: link:../../packages/component-driver-mui-x-v9
       '@atomic-testing/internal-test-runner':
         specifier: workspace:*
         version: link:../../packages/internal-test-runner
@@ -833,6 +921,18 @@ importers:
       '@atomic-testing/component-driver-mui-v6':
         specifier: workspace:*
         version: link:../component-driver-mui-v6
+      '@atomic-testing/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/component-driver-mui-x-v9:
+    dependencies:
+      '@atomic-testing/component-driver-html':
+        specifier: workspace:*
+        version: link:../component-driver-html
+      '@atomic-testing/component-driver-mui-v9':
+        specifier: workspace:*
+        version: link:../component-driver-mui-v9
       '@atomic-testing/core':
         specifier: workspace:*
         version: link:../core
@@ -1290,6 +1390,16 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
@@ -1709,8 +1819,14 @@ packages:
   '@fast-csv/format@4.3.5':
     resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
 
+  '@fast-csv/format@5.0.7':
+    resolution: {integrity: sha512-VdypoRxv7PF+LsyPouTMKdB0d76hync+gLpgdNqfqVK44MsgW4oiCJSdrki2FisWT7v2QGUYDHjp4L7w5oO6gw==}
+
   '@fast-csv/parse@4.3.6':
     resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
+
+  '@fast-csv/parse@5.0.7':
+    resolution: {integrity: sha512-MeuDeQj0DVmIGWky8STaKtvj232Gpq8kjrOGplHJ99Os7OO5CetVfXvUGqX/3GHYFOUsz6FK8isWtDY2XTFNWw==}
 
   '@fingerprintjs/fingerprintjs@3.4.2':
     resolution: {integrity: sha512-3Ncze6JsJpB7BpYhqIgvBpfvEX1jsEKrad5hQBpyRQxtoAp6hx3+R46zqfsuQG4D9egQZ+xftQ0u4LPFMB7Wmg==}
@@ -1729,6 +1845,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -2123,19 +2242,6 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/styled-engine@6.4.11':
-    resolution: {integrity: sha512-74AUmlHXaGNbyUqdK/+NwDJOZqgRQw6BcNvhoWYLq3LGbLTkE+khaJ7soz6cIabE4CPYqO2/QAIU1Z/HEjjpcw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-
   '@mui/styled-engine@6.5.0':
     resolution: {integrity: sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==}
     engines: {node: '>=14.0.0'}
@@ -2191,22 +2297,6 @@ packages:
   '@mui/system@5.18.0':
     resolution: {integrity: sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==}
     engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/system@6.4.12':
-    resolution: {integrity: sha512-fgEfm1qxpKCztndESeL1L0sLwA2c7josZ2w42D8OM3pbLee4bH2twEjoMo6qf7z2rNw1Uc9EU9haXeMoq0oTdQ==}
-    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
@@ -2366,6 +2456,25 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/x-charts-vendor@9.4.0':
+    resolution: {integrity: sha512-1/p3RmRPGlzCtvpWwjwBCRoxJW1eDoQdml8MWq71Q1Oq0n36mTkFjzPTbcaJ52jigIIIQrMloqTUkhmEXwwBMg==}
+
+  '@mui/x-charts@9.7.0':
+    resolution: {integrity: sha512-BintTVKUM/9qUFzYSGZ6aMpftv3iRoquT5vuqOJAvRTb4wOqTO6/NtlBbGIm6HQotdenuGZ2N4xiiZQYEkL/pg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-data-grid-generator@5.17.26':
     resolution: {integrity: sha512-hF2MZk2NbDHnLIHt4Lw1dsVraDvwoQVIP6Y665DF3w0in33bn8e520fK0i9l3CXB4y1xTYnKybA4Ik64/bC2sQ==}
     engines: {node: '>=12.0.0'}
@@ -2405,6 +2514,21 @@ packages:
       '@emotion/styled': ^11.8.1
       '@mui/icons-material': ^5.4.1 || ^6.0.0 || ^7.0.0
       '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-data-grid-generator@9.7.0':
+    resolution: {integrity: sha512-qjw94GfPM41T5KPo2hGoDY3aMGKxZNNUnF4isxKY8kQA9xiR31BfHiHFVukFX5m2qv8XhxKlX9VpzceuOFn2tg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/icons-material': ^7.3.0 || ^9.0.0
+      '@mui/material': ^7.3.0 || ^9.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/react':
@@ -2454,6 +2578,22 @@ packages:
       '@emotion/styled': ^11.8.1
       '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
       '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-data-grid-premium@9.7.0':
+    resolution: {integrity: sha512-jw8nQ9Q/Kc2wK2rvJukaZPDmzFLZmPUaQ/aA7ujxraJrA904h2O5B0JMlFDP6mDEMnY+QpvaskrrMb8KTX2q6g==}
+    engines: {node: '>=14.17.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -2512,6 +2652,22 @@ packages:
       '@emotion/styled':
         optional: true
 
+  '@mui/x-data-grid-pro@9.7.0':
+    resolution: {integrity: sha512-nsloekgaIJfo4BMunGkZmfhm9Dx6355NXeUrKaTN9D6fXPXgV9PtEZTRlbFZm0GpBt5wu53iiN2zY/65iMIHPQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-data-grid@5.17.26':
     resolution: {integrity: sha512-eGJq9J0g9cDGLFfMmugOadZx0mJeOd/yQpHwEa5gUXyONS6qF0OhXSWyDOhDdA3l2TOoQzotMN5dY/T4Wl1KYA==}
     engines: {node: '>=12.0.0'}
@@ -2554,6 +2710,22 @@ packages:
       '@emotion/styled': ^11.8.1
       '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
       '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-data-grid@9.7.0':
+    resolution: {integrity: sha512-VqcYklIlhK1GSvHdsBzk6NxqQguzquqSyxL+yNEUwZpJgLIDJp16/kxV1wTaFJN8uRhUSo8SOnsVIsBr6zZwVg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -2666,6 +2838,43 @@ packages:
       '@emotion/styled': ^11.8.1
       '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
       '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
+        optional: true
+
+  '@mui/x-date-pickers-pro@9.7.0':
+    resolution: {integrity: sha512-JjO0LNDubfOt5bNxPUO1FXMn1f8nJ7rdFw9DGvjZqSLWv4waVhJhiv1cOEjiQzn5KXY2mA99mV0LxJuRZosUeQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
       date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
       date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
       dayjs: ^1.10.7
@@ -2834,6 +3043,50 @@ packages:
       moment-jalaali:
         optional: true
 
+  '@mui/x-date-pickers@9.7.0':
+    resolution: {integrity: sha512-gW/tz5LKhuwl5/naP/gv4jT3e3Fcf9gXEemvsWX6gVnO4IkO/GUJ55UbPQVooLCaJRAR/WBwMXgen7nIrBTBMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
+        optional: true
+
+  '@mui/x-internal-exceljs-fork@5.0.0':
+    resolution: {integrity: sha512-gn73zruZbZFspNDRGVxhXG500VNHvCUrqTk/pL9c4Jh7NX/O2wg1OCBl73jxAjZgwP4QAVX/4LnjVIQlM/RWNA==}
+    engines: {node: '>=14.17.0'}
+
+  '@mui/x-internal-gestures@9.7.0':
+    resolution: {integrity: sha512-GUg9bQ79bdGFrGbD0E8CxsXemb2yEIgGDYZ4NDQAgnjf8CL/xFNoi0zE12BYREtINOS2mgD0gHMW8pXvPx+McA==}
+
   '@mui/x-internals@7.29.0':
     resolution: {integrity: sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==}
     engines: {node: '>=14.0.0'}
@@ -2845,6 +3098,12 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@mui/x-internals@9.7.0':
+    resolution: {integrity: sha512-fdBwh96L78QFZXB1oS2v8y33gXap3A6Tc0+AJYxYzLsRwx05WnaWhtHEwNV2x7zLXLaZ4ux0CCAJIgZ6kTP4FA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@mui/x-license-pro@5.17.12':
@@ -2873,9 +3132,42 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@mui/x-license@9.7.0':
+    resolution: {integrity: sha512-AKmldgu0KHg0nA8d9vecZh8UrGvNZ/j0VYNRAtlagn3VSd7RBmIFWRrpIwQVyz6YCWw2O7eOJ51kBmZnQIOV/Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mui/x-telemetry@8.5.3':
     resolution: {integrity: sha512-vBLVBXCBWY44HonjRefpYjowEXa25k2AtAXkWk2tHfL3/unnnexrYPosuo/p4giIWer0pMy/bPqGY2qM0xlM+g==}
     engines: {node: '>=14.0.0'}
+
+  '@mui/x-telemetry@9.7.0':
+    resolution: {integrity: sha512-mHd70oLUX9ZCMZPoeJRAL+kX8h0b+bhbkiEhY4qwTge0XmbJYoYxHUDrZmAeCn6E9F/3Gf2z2/54lEWltg+EKw==}
+    engines: {node: '>=14.0.0'}
+
+  '@mui/x-tree-view@9.7.0':
+    resolution: {integrity: sha512-kQjElE7Sx5STTW3DHxv4bHdvYRLzLdLziD7Her0F4+snIZ3k7QMAUfRsm3Oed9rvzU3MbvqRRlFRfvFKdM9kmw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-virtualizer@0.5.0':
+    resolution: {integrity: sha512-L87mSQnUtPGoAX8AZstQEr2I2/8hy41FWOQoL3g6iG/UzvF+VP8zJ9pF07qiEg+sH+iwnAxShLRlCrqEBS1qSw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -3752,6 +4044,39 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3760,6 +4085,9 @@ packages:
 
   '@types/format-util@1.0.4':
     resolution: {integrity: sha512-xrCYOdHh5zA3LUrn6CvspYwlzSWxPso11Lx32WnAG6KvLCRecKZ/Rh21PLXUkzUFsQmrGcx/traJAFjR6dVS5Q==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -4218,6 +4546,9 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  bezier-easing@3.0.1:
+    resolution: {integrity: sha512-vvvg10Anq7py0+KkIqlwJpUVdde9Z8kSzeUzAkQNYAJdA3mZnLG9r9ExdwtjcASCYER6UkNHdBNHHMnVimnU7A==}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -4348,6 +4679,10 @@ packages:
     resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
     engines: {node: '>=8'}
 
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -4412,6 +4747,9 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  core-js-pure@3.49.0:
+    resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -4456,9 +4794,56 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -4725,6 +5110,10 @@ packages:
     resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
     engines: {node: '>=10.0.0'}
 
+  fast-csv@5.0.7:
+    resolution: {integrity: sha512-KirK9wYIUXF/xTYmg/jv9ehUWbQ4Faf6XutuJKlEz72eoqKMMLdCnz+rGDeBSjpV2wwkHQnLSuJ5i+FRRnzZwA==}
+    engines: {node: '>=10.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4759,6 +5148,9 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  flatqueue@3.1.0:
+    resolution: {integrity: sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4950,6 +5342,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
@@ -4989,6 +5385,11 @@ packages:
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-docker@4.0.0:
+    resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
+    engines: {node: '>=20'}
     hasBin: true
 
   is-expression@4.0.0:
@@ -5479,6 +5880,10 @@ packages:
 
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -6012,6 +6417,9 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -6470,6 +6878,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -6478,6 +6891,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -6965,6 +7379,17 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.0
 
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@date-io/core@2.17.0': {}
@@ -7334,6 +7759,10 @@ snapshots:
       lodash.isfunction: 3.0.9
       lodash.isnil: 4.0.0
 
+  '@fast-csv/format@5.0.7':
+    dependencies:
+      lodash.escaperegexp: 4.1.2
+
   '@fast-csv/parse@4.3.6':
     dependencies:
       '@types/node': 14.18.63
@@ -7342,6 +7771,12 @@ snapshots:
       lodash.isfunction: 3.0.9
       lodash.isnil: 4.0.0
       lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
+
+  '@fast-csv/parse@5.0.7':
+    dependencies:
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
       lodash.uniq: 4.5.0
 
   '@fingerprintjs/fingerprintjs@3.4.2':
@@ -7364,6 +7799,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
@@ -7609,7 +8046,7 @@ snapshots:
 
   '@mui/base@5.0.0-beta.70(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@floating-ui/react-dom': 2.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.23)
       '@mui/utils': 6.4.9(@types/react@18.3.23)(react@18.3.1)
@@ -7689,6 +8126,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
+  '@mui/icons-material@9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -7735,7 +8180,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/core-downloads-tracker': 6.4.12
-      '@mui/system': 6.4.12(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.23)
       '@mui/utils': 6.4.9(@types/react@18.3.23)(react@18.3.1)
       '@popperjs/core': 2.11.8
@@ -7756,7 +8201,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/core-downloads-tracker': 6.4.12
-      '@mui/system': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/types': 7.2.24(@types/react@19.2.17)
       '@mui/utils': 6.4.9(@types/react@19.2.17)(react@19.2.7)
       '@popperjs/core': 2.11.8
@@ -7908,7 +8353,7 @@ snapshots:
   '@mui/private-theming@7.2.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/utils': 7.2.0(@types/react@19.1.8)(react@19.1.0)
+      '@mui/utils': 7.3.11(@types/react@19.1.8)(react@19.1.0)
       prop-types: 15.8.1
       react: 19.1.0
     optionalDependencies:
@@ -7962,32 +8407,6 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
 
-  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/sheet': 1.4.0
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
-
-  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/sheet': 1.4.0
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 19.2.7
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-
   '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -8001,13 +8420,26 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
 
+  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+
   '@mui/styled-engine@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
-      csstype: 3.1.3
+      csstype: 3.2.3
       prop-types: 15.8.1
       react: 19.1.0
     optionalDependencies:
@@ -8082,38 +8514,6 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@types/react': 18.3.23
 
-  '@mui/system@6.4.12(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/private-theming': 6.4.9(@types/react@18.3.23)(react@18.3.1)
-      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.23)
-      '@mui/utils': 6.4.9(@types/react@18.3.23)(react@18.3.1)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
-      '@types/react': 18.3.23
-
-  '@mui/system@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/private-theming': 6.4.9(@types/react@19.2.17)(react@19.2.7)
-      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
-      '@mui/types': 7.2.24(@types/react@19.2.17)
-      '@mui/utils': 6.4.9(@types/react@19.2.17)(react@19.2.7)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 19.2.7
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@types/react': 19.2.17
-
   '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -8129,6 +8529,22 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@types/react': 18.3.23
+
+  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/private-theming': 6.4.9(@types/react@19.2.17)(react@19.2.7)
+      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@mui/types': 7.2.24(@types/react@19.2.17)
+      '@mui/utils': 6.4.9(@types/react@19.2.17)(react@19.2.7)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@types/react': 19.2.17
 
   '@mui/system@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -8224,6 +8640,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
+  '@mui/types@7.4.12(@types/react@19.1.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+    optionalDependencies:
+      '@types/react': 19.1.8
+
   '@mui/types@7.4.12(@types/react@19.2.17)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -8256,7 +8678,7 @@ snapshots:
 
   '@mui/utils@5.17.1(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/types': 7.2.24(@types/react@18.3.23)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -8268,7 +8690,7 @@ snapshots:
 
   '@mui/utils@5.17.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/types': 7.2.24(@types/react@19.2.17)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -8280,7 +8702,7 @@ snapshots:
 
   '@mui/utils@6.4.9(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/types': 7.2.24(@types/react@18.3.23)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -8292,7 +8714,7 @@ snapshots:
 
   '@mui/utils@6.4.9(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/types': 7.2.24(@types/react@19.2.17)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -8338,6 +8760,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
+  '@mui/utils@7.3.11(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 7.4.12(@types/react@19.1.8)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-is: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.1.8
+
   '@mui/utils@7.3.11(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -8373,6 +8807,56 @@ snapshots:
       react-is: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@mui/x-charts-vendor@9.4.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/d3-array': 3.2.2
+      '@types/d3-color': 3.1.3
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-color: 3.1.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      flatqueue: 3.1.0
+      internmap: 2.0.3
+
+  '@mui/x-charts@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-charts-vendor': 9.4.0
+      '@mui/x-internal-gestures': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      bezier-easing: 3.0.1
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@mui/x-data-grid-generator@5.17.26(@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8445,9 +8929,30 @@ snapshots:
       - '@types/react'
       - react-dom
 
+  '@mui/x-data-grid-generator@9.7.0(40fde8b2c5e74a8bd749ad4af8005570)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/icons-material': 9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-premium': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-pro': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      chance: 1.1.13
+      clsx: 2.1.1
+      lru-cache: 11.5.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@mui/system'
+      - '@types/react'
+      - react-dom
+
   '@mui/x-data-grid-premium@5.17.26(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
@@ -8466,7 +8971,7 @@ snapshots:
 
   '@mui/x-data-grid-premium@6.20.5(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
@@ -8485,10 +8990,10 @@ snapshots:
 
   '@mui/x-data-grid-premium@7.29.7(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-data-grid': 7.29.7(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-data-grid-pro': 7.29.7(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
@@ -8511,7 +9016,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-data-grid': 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-data-grid-pro': 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-internals': 8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
@@ -8519,6 +9024,28 @@ snapshots:
       '@types/format-util': 1.0.4
       clsx: 2.1.1
       exceljs: 4.4.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-data-grid-premium@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-data-grid': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-pro': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internal-exceljs-fork': 5.0.0
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-license': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -8620,9 +9147,28 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-data-grid-pro@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-data-grid': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-license': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-data-grid@5.17.26(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
@@ -8636,7 +9182,7 @@ snapshots:
 
   '@mui/x-data-grid@5.17.26(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 5.17.1(@types/react@19.2.17)(react@19.2.7)
@@ -8667,7 +9213,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -8686,13 +9232,33 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-internals': 8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.5.0(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-data-grid@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-virtualizer': 0.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
@@ -8745,13 +9311,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers-pro@7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-date-pickers-pro@7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-date-pickers': 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers': 7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-license': 7.29.1(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
@@ -8762,17 +9328,18 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
       dayjs: 1.11.13
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers-pro@8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-date-pickers-pro@8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-date-pickers': 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers': 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-internals': 8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-license': 8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
@@ -8783,6 +9350,29 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
+      dayjs: 1.11.13
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-date-pickers-pro@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-date-pickers': 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-license': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
       dayjs: 1.11.13
     transitivePeerDependencies:
       - '@types/react'
@@ -8832,7 +9422,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-date-pickers@7.29.4(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8848,11 +9438,12 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
       dayjs: 1.11.13
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-date-pickers@8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8868,14 +9459,54 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
       dayjs: 1.11.13
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-date-pickers@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(dayjs@1.11.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
+      dayjs: 1.11.13
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internal-exceljs-fork@5.0.0':
+    dependencies:
+      '@types/node': 14.18.63
+      dayjs: 1.11.13
+      fast-csv: 5.0.7
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+
+  '@mui/x-internal-gestures@9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - react-dom
+
   '@mui/x-internals@7.29.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
       - '@types/react'
@@ -8884,15 +9515,28 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       reselect: 5.1.1
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-internals@9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      core-js-pure: 3.49.0
+      react: 19.2.7
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+
   '@mui/x-license-pro@5.17.12(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:
@@ -8900,7 +9544,7 @@ snapshots:
 
   '@mui/x-license-pro@5.17.12(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.29.7
       '@mui/utils': 5.17.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -8917,7 +9561,7 @@ snapshots:
   '@mui/x-license@7.29.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -8926,13 +9570,24 @@ snapshots:
   '@mui/x-license@8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/utils': 7.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-internals': 8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/x-telemetry': 8.5.3
       react: 19.2.7
     transitivePeerDependencies:
       - '@mui/system'
       - '@types/react'
+
+  '@mui/x-license@9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-telemetry': 9.7.0
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
 
   '@mui/x-telemetry@8.5.3':
     dependencies:
@@ -8942,6 +9597,45 @@ snapshots:
       conf: 11.0.2
       is-docker: 3.0.0
       node-machine-id: 1.1.12
+
+  '@mui/x-telemetry@9.7.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@fingerprintjs/fingerprintjs': 3.4.2
+      ci-info: 4.4.0
+      is-docker: 4.0.0
+      node-machine-id: 1.1.12
+
+  '@mui/x-tree-view@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-virtualizer@0.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -9675,11 +10369,43 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/format-util@1.0.4': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -10231,6 +10957,8 @@ snapshots:
     dependencies:
       open: 8.4.2
 
+  bezier-easing@3.0.1: {}
+
   big-integer@1.6.52: {}
 
   binary@0.3.0:
@@ -10356,6 +11084,8 @@ snapshots:
 
   ci-info@4.2.0: {}
 
+  ci-info@4.4.0: {}
+
   cjs-module-lexer@1.4.3: {}
 
   cliui@8.0.1:
@@ -10420,6 +11150,8 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-js-pure@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   cosmiconfig@7.1.0:
@@ -10472,11 +11204,53 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@3.0.2:
     dependencies:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+
+  date-fns@4.4.0: {}
 
   dayjs@1.11.13: {}
 
@@ -10556,7 +11330,7 @@ snapshots:
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.29.7
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   domexception@4.0.0:
     dependencies:
@@ -10785,6 +11559,11 @@ snapshots:
       '@fast-csv/format': 4.3.5
       '@fast-csv/parse': 4.3.6
 
+  fast-csv@5.0.7:
+    dependencies:
+      '@fast-csv/format': 5.0.7
+      '@fast-csv/parse': 5.0.7
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -10811,6 +11590,8 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  flatqueue@3.1.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -10996,6 +11777,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  internmap@2.0.3: {}
+
   is-arguments@1.2.0:
     dependencies:
       call-bound: 1.0.4
@@ -11032,6 +11815,8 @@ snapshots:
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
+
+  is-docker@4.0.0: {}
 
   is-expression@4.0.0:
     dependencies:
@@ -11714,6 +12499,8 @@ snapshots:
 
   lru-cache@11.1.0: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -12288,6 +13075,8 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  reselect@5.2.0: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -12748,6 +13537,10 @@ snapshots:
       requires-port: 1.0.0
 
   use-sync-external-store@1.5.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -15,7 +15,8 @@
     "packages/component-driver-mui-x-v5",
     "packages/component-driver-mui-x-v6",
     "packages/component-driver-mui-x-v7",
-    "packages/component-driver-mui-x-v8"
+    "packages/component-driver-mui-x-v8",
+    "packages/component-driver-mui-x-v9"
   ],
   "name": "Atomic Testing",
   "entryPointStrategy": "packages",


### PR DESCRIPTION

## Summary

Adds @atomic-testing/component-driver-mui-x-v9 and its test fixture, targeting
@mui/x-*@9 and depending on the new component-driver-mui-v9 Core package. Covers
DataGrid (Premium), a read-capable Desktop Date Picker, and Tree View — all verified
in jsdom and across Chromium/Firefox/WebKit. Implements #890 (Tiers 1–3 partial;
remaining work tracked in #903/#904/#905).

## Key Changes

- DataGrid Premium driver (v8→v9 port) + footer/pagination/row/cell/header drivers
- Tree View driver + read-side Desktop Date Picker driver (v9 section field DOM)
- New mui-x-v9-test fixture (DOM 13/13, e2e 39/39); README/docs/typedoc updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
