### PR TITLE
ci: Include Sapling SCM detecion in PR generation

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,11 +1,48 @@
 Generate a pull request title and description based on the current changes.
 
-## Workflow
+## VCS Detection
 
-1. Run `sl diff -r main` to get the diff
-2. Analyze changes and generate PR content
-3. Run `sl metaedit -m "..."` with the title and description
-4. Run `sl pr submit` to create the PR
+Detect which version control system is in use:
+
+1. Run `sl root 2>/dev/null` - if successful, use **Sapling** workflow
+2. Otherwise, run `git rev-parse --show-toplevel 2>/dev/null` - if successful, use **Git** workflow
+3. If neither succeeds, inform the user they're not in a recognized repository
+
+## Base Branch Detection
+
+Auto-detect the base branch (check in order):
+
+1. `main`
+2. `master`
+3. Default branch from remote (e.g., `git symbolic-ref refs/remotes/origin/HEAD` or `sl config paths.default`)
+
+## Getting the Diff
+
+### Git
+
+Use three-dot diff to compare against the merge-base (avoids noise from upstream changes):
+
+```bash
+git diff <base>...HEAD
+```
+
+### Sapling
+
+First, detect if we're in a stack by checking if the parent commit is a draft:
+
+```bash
+sl log -r ".^ and draft()" --template "{node}"
+```
+
+- **If parent is public (empty result)**: Not in a stack, diff against parent:
+
+  ```bash
+  sl diff -r ".^"
+  ```
+
+- **If parent is draft (has result)**: We're in a stack. Ask the user:
+  - **"Current commit only"**: `sl diff -r ".^"`
+  - **"Entire stack from base"**: `sl diff -r "ancestor(., <base>)"`
 
 ## Title Guidelines
 
@@ -16,9 +53,7 @@ Generate a pull request title and description based on the current changes.
 ## Description Format
 
 ```markdown
-## Summary
-
-[2-3 sentences explaining what this PR does, why, and any benefits]
+[2-3 sentences explaining what this PR does, why, and any benefits, you MUST keep each line under 100 characters]
 
 ## Key Changes
 
@@ -30,4 +65,16 @@ Generate a pull request title and description based on the current changes.
 ## After Generating
 
 Present the title and description to the user, then ask if they want to create the PR.
-If yes, use `sl metaedit` and `sl pr submit`.
+
+### If Using Git
+
+1. Check if `gh` CLI is installed: `gh --version 2>/dev/null`
+2. **If installed**: Ask user if they want to create/update the PR
+   - Create: `gh pr create --title "..." --body "..."`
+   - Update (if PR exists): `gh pr edit --title "..." --body "..."`
+3. **If not installed**: Inform the user that PRs can be created automatically with the GitHub CLI, and provide installation link: <https://cli.github.com/>
+
+### If Using Sapling
+
+1. Update the commit message: `sl metaedit -m "..."`
+2. Submit the PR: `sl pr submit`


### PR DESCRIPTION

Problem

PR command assumes Git, but at times the worktree uses Sapling instead of Git, while Agent is knowledgable with Sapling.

Solution

Add instruction in command to detect SCM first.
