### PR TITLE
fix(component-driver-mui): TablePagination getRowsPerPage returns Optional<number> for v6/v7

### DIFF
--- a/package-tests/component-driver-mui-v6-test/src/examples/tablePagination/BasicTablePagination.example.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/examples/tablePagination/BasicTablePagination.example.tsx
@@ -9,6 +9,7 @@ const ControlledTablePagination = (props: {
   count: number;
   initialRowsPerPage: number;
   initialPage: number;
+  rowsPerPageOptions?: Array<number | { value: number; label: string }>;
 }) => {
   const [page, setPage] = React.useState(props.initialPage);
   const [rowsPerPage, setRowsPerPage] = React.useState(props.initialRowsPerPage);
@@ -20,7 +21,7 @@ const ControlledTablePagination = (props: {
       count={props.count}
       page={page}
       rowsPerPage={rowsPerPage}
-      rowsPerPageOptions={[5, 10, 25]}
+      rowsPerPageOptions={props.rowsPerPageOptions ?? [5, 10, 25]}
       onPageChange={(_e, next: number) => setPage(next)}
       onRowsPerPageChange={e => {
         setRowsPerPage(Number.parseInt(e.target.value, 10));
@@ -32,11 +33,20 @@ const ControlledTablePagination = (props: {
 
 export const BasicTablePaginationExample = () => {
   // Two instances verify per-root scoping: `alpha` sits on the first page (prev
-  // disabled) while `beta` is mid-range (both controls enabled).
+  // disabled) while `beta` is mid-range (both controls enabled). `gamma` selects
+  // MUI's "All" option, whose real value is `-1` — distinct from a read failure,
+  // which getRowsPerPage reports as `undefined`.
   return (
     <Box>
       <ControlledTablePagination testId='alpha-table-pagination' count={13} initialRowsPerPage={5} initialPage={0} />
       <ControlledTablePagination testId='beta-table-pagination' count={42} initialRowsPerPage={10} initialPage={1} />
+      <ControlledTablePagination
+        testId='gamma-table-pagination'
+        count={13}
+        initialRowsPerPage={-1}
+        initialPage={0}
+        rowsPerPageOptions={[5, { value: -1, label: 'All' }]}
+      />
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/tablePagination/BasicTablePagination.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/tablePagination/BasicTablePagination.suite.ts
@@ -13,6 +13,10 @@ export const basicTablePaginationExampleScenePart = {
     locator: byDataTestId('beta-table-pagination'),
     driver: TablePaginationDriver,
   },
+  gamma: {
+    locator: byDataTestId('gamma-table-pagination'),
+    driver: TablePaginationDriver,
+  },
 } satisfies ScenePart;
 
 export const basicTablePaginationExample: IExampleUnit<typeof basicTablePaginationExampleScenePart, JSX.Element> = {
@@ -66,6 +70,12 @@ export const basicTablePaginationTestSuite: TestSuiteInfo<typeof basicTablePagin
     test('previousPage returns false on the first page', async () => {
       assertFalse(await engine().parts.alpha.previousPage());
       assertEqual(await engine().parts.alpha.getDisplayedRowsText(), '1–5 of 13');
+    });
+
+    test('reports the "All" option as its real value -1, not a read failure', async () => {
+      // MUI's "All" option has value -1; getRowsPerPage returns it verbatim and
+      // reserves undefined for the unreadable case, so the two never collide.
+      assertEqual(await engine().parts.gamma.getRowsPerPage(), -1);
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/tablePagination/BasicTablePagination.example.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/examples/tablePagination/BasicTablePagination.example.tsx
@@ -9,6 +9,7 @@ const ControlledTablePagination = (props: {
   count: number;
   initialRowsPerPage: number;
   initialPage: number;
+  rowsPerPageOptions?: Array<number | { value: number; label: string }>;
 }) => {
   const [page, setPage] = React.useState(props.initialPage);
   const [rowsPerPage, setRowsPerPage] = React.useState(props.initialRowsPerPage);
@@ -20,7 +21,7 @@ const ControlledTablePagination = (props: {
       count={props.count}
       page={page}
       rowsPerPage={rowsPerPage}
-      rowsPerPageOptions={[5, 10, 25]}
+      rowsPerPageOptions={props.rowsPerPageOptions ?? [5, 10, 25]}
       onPageChange={(_e, next: number) => setPage(next)}
       onRowsPerPageChange={e => {
         setRowsPerPage(Number.parseInt(e.target.value, 10));
@@ -32,11 +33,20 @@ const ControlledTablePagination = (props: {
 
 export const BasicTablePaginationExample = () => {
   // Two instances verify per-root scoping: `alpha` sits on the first page (prev
-  // disabled) while `beta` is mid-range (both controls enabled).
+  // disabled) while `beta` is mid-range (both controls enabled). `gamma` selects
+  // MUI's "All" option, whose real value is `-1` — distinct from a read failure,
+  // which getRowsPerPage reports as `undefined`.
   return (
     <Box>
       <ControlledTablePagination testId='alpha-table-pagination' count={13} initialRowsPerPage={5} initialPage={0} />
       <ControlledTablePagination testId='beta-table-pagination' count={42} initialRowsPerPage={10} initialPage={1} />
+      <ControlledTablePagination
+        testId='gamma-table-pagination'
+        count={13}
+        initialRowsPerPage={-1}
+        initialPage={0}
+        rowsPerPageOptions={[5, { value: -1, label: 'All' }]}
+      />
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/tablePagination/BasicTablePagination.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/tablePagination/BasicTablePagination.suite.ts
@@ -13,6 +13,10 @@ export const basicTablePaginationExampleScenePart = {
     locator: byDataTestId('beta-table-pagination'),
     driver: TablePaginationDriver,
   },
+  gamma: {
+    locator: byDataTestId('gamma-table-pagination'),
+    driver: TablePaginationDriver,
+  },
 } satisfies ScenePart;
 
 export const basicTablePaginationExample: IExampleUnit<typeof basicTablePaginationExampleScenePart, JSX.Element> = {
@@ -66,6 +70,12 @@ export const basicTablePaginationTestSuite: TestSuiteInfo<typeof basicTablePagin
     test('previousPage returns false on the first page', async () => {
       assertFalse(await engine().parts.alpha.previousPage());
       assertEqual(await engine().parts.alpha.getDisplayedRowsText(), '1–5 of 13');
+    });
+
+    test('reports the "All" option as its real value -1, not a read failure', async () => {
+      // MUI's "All" option has value -1; getRowsPerPage returns it verbatim and
+      // reserves undefined for the unreadable case, so the two never collide.
+      assertEqual(await engine().parts.gamma.getRowsPerPage(), -1);
     });
   },
 };

--- a/packages/component-driver-mui-v6/src/components/TablePaginationDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/TablePaginationDriver.ts
@@ -26,13 +26,15 @@ export class TablePaginationDriver extends ComponentDriver {
   }
 
   /**
-   * The current rows-per-page value (read from the select's hidden input), or
-   * `-1` when it cannot be parsed.
+   * The current rows-per-page value, read from the select's hidden input, or
+   * `undefined` when it cannot be read/parsed. MUI's "All" option is not a parse
+   * failure — it has the real value `-1` and is returned verbatim, so the
+   * not-readable sentinel must not reuse `-1`.
    */
-  async getRowsPerPage(): Promise<number> {
+  async getRowsPerPage(): Promise<Optional<number>> {
     const value = await this.rowsPerPageSelect.getValue();
     const parsed = Number.parseInt(value ?? '', 10);
-    return Number.isNaN(parsed) ? -1 : parsed;
+    return Number.isNaN(parsed) ? undefined : parsed;
   }
 
   /**
@@ -96,11 +98,13 @@ export class TablePaginationDriver extends ComponentDriver {
   }
 
   private async clickNavButton(navLocator: PartLocator): Promise<boolean> {
-    const locator = locatorUtil.append(this.locator, navLocator);
-    if (!(await this.interactor.exists(locator)) || (await this.interactor.isDisabled(locator))) {
+    // Clicking an absent or disabled control is a no-op; isNavDisabled already
+    // treats a missing control as disabled, so reuse it instead of repeating the
+    // exists/isDisabled checks.
+    if (await this.isNavDisabled(navLocator)) {
       return false;
     }
-    await this.interactor.click(locator);
+    await this.interactor.click(locatorUtil.append(this.locator, navLocator));
     return true;
   }
 

--- a/packages/component-driver-mui-v7/src/components/TablePaginationDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/TablePaginationDriver.ts
@@ -26,13 +26,15 @@ export class TablePaginationDriver extends ComponentDriver {
   }
 
   /**
-   * The current rows-per-page value (read from the select's hidden input), or
-   * `-1` when it cannot be parsed.
+   * The current rows-per-page value, read from the select's hidden input, or
+   * `undefined` when it cannot be read/parsed. MUI's "All" option is not a parse
+   * failure — it has the real value `-1` and is returned verbatim, so the
+   * not-readable sentinel must not reuse `-1`.
    */
-  async getRowsPerPage(): Promise<number> {
+  async getRowsPerPage(): Promise<Optional<number>> {
     const value = await this.rowsPerPageSelect.getValue();
     const parsed = Number.parseInt(value ?? '', 10);
-    return Number.isNaN(parsed) ? -1 : parsed;
+    return Number.isNaN(parsed) ? undefined : parsed;
   }
 
   /**
@@ -96,11 +98,13 @@ export class TablePaginationDriver extends ComponentDriver {
   }
 
   private async clickNavButton(navLocator: PartLocator): Promise<boolean> {
-    const locator = locatorUtil.append(this.locator, navLocator);
-    if (!(await this.interactor.exists(locator)) || (await this.interactor.isDisabled(locator))) {
+    // Clicking an absent or disabled control is a no-op; isNavDisabled already
+    // treats a missing control as disabled, so reuse it instead of repeating the
+    // exists/isDisabled checks.
+    if (await this.isNavDisabled(navLocator)) {
       return false;
     }
-    await this.interactor.click(locator);
+    await this.interactor.click(locatorUtil.append(this.locator, navLocator));
     return true;
   }
 


### PR DESCRIPTION

getRowsPerPage() returned a `-1` sentinel on a parse failure, which collides
with MUI's real "All" rows-per-page option (its value is literally -1): a caller
could not distinguish "all rows" from "couldn't read the value". Return
Optional<number> instead — `undefined` when unreadable, the real number
(including -1 for "All") otherwise.

Also dedupe clickNavButton against isNavDisabled (both already treat an absent
control as a no-op), and add a `gamma` example instance + test proving the
"All"/-1 value round-trips distinctly from the undefined read-failure path.

Found while code-reviewing the merged Group-D drivers (PR #887). Scope is v6/v7
per the issue's scope-narrowing comment (MUI 5 EOL); v5/v9 carry the same driver
and are intentionally out of scope here.

Fixes #880

Verified: jsdom + Playwright (chromium/firefox/webkit) green for v6 and v7;
tsgo/oxfmt/oxlint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
