### PR TITLE
feat(component-driver-mui): add OverlayDriver.closeByEscape for v6/v7

### DIFF
--- a/package-tests/component-driver-mui-v6-test/src/examples/drawer/BasicDrawer.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/drawer/BasicDrawer.suite.ts
@@ -66,6 +66,13 @@ export const basicDrawerTestSuite: TestSuiteInfo<typeof basicDrawerExampleSceneP
       assertFalse(await engine().parts.drawer.isOpen());
     });
 
+    test('closes when Escape is pressed', async () => {
+      await engine().parts.openTrigger.click();
+      await engine().parts.drawer.waitForOpen();
+      assertTrue(await engine().parts.drawer.closeByEscape());
+      assertFalse(await engine().parts.drawer.isOpen());
+    });
+
     test('reports no anchor when closed', async () => {
       assertEqual(await engine().parts.drawer.getAnchor(), undefined);
     });

--- a/package-tests/component-driver-mui-v7-test/src/examples/drawer/BasicDrawer.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/drawer/BasicDrawer.suite.ts
@@ -66,6 +66,13 @@ export const basicDrawerTestSuite: TestSuiteInfo<typeof basicDrawerExampleSceneP
       assertFalse(await engine().parts.drawer.isOpen());
     });
 
+    test('closes when Escape is pressed', async () => {
+      await engine().parts.openTrigger.click();
+      await engine().parts.drawer.waitForOpen();
+      assertTrue(await engine().parts.drawer.closeByEscape());
+      assertFalse(await engine().parts.drawer.isOpen());
+    });
+
     test('reports no anchor when closed', async () => {
       assertEqual(await engine().parts.drawer.getAnchor(), undefined);
     });

--- a/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
@@ -8,16 +8,11 @@ const defaultTransitionDuration = 250;
  * Popover and SpeedDial are prospective consumers). It owns the open/close
  * lifecycle that {@link DialogDriver} first proved out: `isOpen` derived from the
  * visible surface, `waitForOpen`/`waitForClose` spanning the transition, and
- * `closeByBackdrop`.
+ * dismissal via `closeByBackdrop`/`closeByEscape`.
  *
  * Subclasses supply {@link getSurfaceLocator} (the element whose visibility means
  * "open") and, when the overlay is portal-rendered, override
  * `overriddenParentLocator()`/`overrideLocatorRelativePosition()` to re-root.
- *
- * `closeByEscape` is intentionally absent: keyboard dismissal needs a key-press
- * primitive the `Interactor` interface does not yet expose, which would have to be
- * added to every interactor (DOM/React/Vue/Playwright). It is deferred rather than
- * partially implemented.
  */
 export abstract class OverlayDriver<ContentT extends ScenePart, T extends ScenePart = {}> extends ContainerDriver<
   ContentT,
@@ -92,6 +87,26 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
       // onClick listens for. (A separate trailing click would race the dismissal
       // and miss the unmounting backdrop in Playwright.)
       await this.interactor.click(backdrop);
+    }
+    return this.waitForClose(timeoutMs);
+  }
+
+  /**
+   * Dismiss by pressing `Escape` on the overlay surface, then wait for the close
+   * transition. MUI's Modal handles a `keydown` of `Escape` (reason
+   * `"escapeKeyDown"`) at the portal root; the event bubbles there from the
+   * focused surface — a code path distinct from {@link closeByBackdrop} and
+   * unreachable by any click, since a click never produces a key event. The
+   * surface is the focus-holding element while the overlay is open, mirroring how
+   * {@link DialogDriver} presses Escape on its container. Whether it actually
+   * closes depends on the consumer honoring the dismissal (and
+   * `disableEscapeKeyDown`); the returned boolean reflects the observed close, not
+   * merely the key press.
+   */
+  async closeByEscape(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
+    const surface = this.getSurfaceLocator();
+    if (await this.interactor.exists(surface)) {
+      await this.interactor.pressKey(surface, 'Escape');
     }
     return this.waitForClose(timeoutMs);
   }

--- a/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
@@ -8,16 +8,11 @@ const defaultTransitionDuration = 250;
  * Popover and SpeedDial are prospective consumers). It owns the open/close
  * lifecycle that {@link DialogDriver} first proved out: `isOpen` derived from the
  * visible surface, `waitForOpen`/`waitForClose` spanning the transition, and
- * `closeByBackdrop`.
+ * dismissal via `closeByBackdrop`/`closeByEscape`.
  *
  * Subclasses supply {@link getSurfaceLocator} (the element whose visibility means
  * "open") and, when the overlay is portal-rendered, override
  * `overriddenParentLocator()`/`overrideLocatorRelativePosition()` to re-root.
- *
- * `closeByEscape` is intentionally absent: keyboard dismissal needs a key-press
- * primitive the `Interactor` interface does not yet expose, which would have to be
- * added to every interactor (DOM/React/Vue/Playwright). It is deferred rather than
- * partially implemented.
  */
 export abstract class OverlayDriver<ContentT extends ScenePart, T extends ScenePart = {}> extends ContainerDriver<
   ContentT,
@@ -92,6 +87,26 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
       // onClick listens for. (A separate trailing click would race the dismissal
       // and miss the unmounting backdrop in Playwright.)
       await this.interactor.click(backdrop);
+    }
+    return this.waitForClose(timeoutMs);
+  }
+
+  /**
+   * Dismiss by pressing `Escape` on the overlay surface, then wait for the close
+   * transition. MUI's Modal handles a `keydown` of `Escape` (reason
+   * `"escapeKeyDown"`) at the portal root; the event bubbles there from the
+   * focused surface — a code path distinct from {@link closeByBackdrop} and
+   * unreachable by any click, since a click never produces a key event. The
+   * surface is the focus-holding element while the overlay is open, mirroring how
+   * {@link DialogDriver} presses Escape on its container. Whether it actually
+   * closes depends on the consumer honoring the dismissal (and
+   * `disableEscapeKeyDown`); the returned boolean reflects the observed close, not
+   * merely the key press.
+   */
+  async closeByEscape(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
+    const surface = this.getSurfaceLocator();
+    if (await this.interactor.exists(surface)) {
+      await this.interactor.pressKey(surface, 'Escape');
     }
     return this.waitForClose(timeoutMs);
   }


### PR DESCRIPTION

OverlayDriver omitted closeByEscape, its JSDoc claiming keyboard dismissal needs
"a key-press primitive the Interactor interface does not yet expose". That is no
longer true: pressKey is on the Interactor interface and implemented in every
interactor (DOM/React/Vue/Playwright), and DialogDriver already ships a working
closeByEscape built on it. Issue #881 explicitly lists closeByEscape() in the
requested overlay API.

Add closeByEscape() to OverlayDriver — pressing Escape on the focus-holding
surface (guarded by exists, mirroring closeByBackdrop), then waiting for the
close transition. Drawer inherits it for free; no Drawer code change and no new
Interactor methods. Replace the stale "intentionally absent" JSDoc and add a
"closes when Escape is pressed" test to the v6/v7 Drawer suites.

Found while code-reviewing the merged Group-D drivers (PR #887). Scope is v6/v7
per the issue's scope-narrowing comment (MUI 5 EOL); the same OverlayDriver also
lives in v5/v9 and is intentionally out of scope here. Migrating Dialog/Menu to
this base is tracked separately (#871).

Fixes #881

Verified: jsdom + Playwright (chromium/firefox/webkit) green for v6 and v7;
tsgo/oxfmt/oxlint clean. (Firefox needs reduced Playwright workers to avoid a
pre-existing parallel-context flake unrelated to this change.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
