### PR TITLE
test(component-driver-mui): pin Stepper zero-step contract and document the stride invariant for v6/v7

### DIFF
--- a/package-tests/component-driver-mui-v6-test/src/examples/stepper/BasicStepper.example.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/examples/stepper/BasicStepper.example.tsx
@@ -36,6 +36,10 @@ export const BasicStepperExample = () => {
           </Step>
         ))}
       </Stepper>
+
+      {/* An empty stepper pins the zero-step contract (count 0, active index -1,
+          getSteps []) so it can't silently regress. */}
+      <Stepper data-testid='empty-stepper' activeStep={0} />
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/stepper/BasicStepper.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/stepper/BasicStepper.suite.ts
@@ -13,6 +13,10 @@ export const basicStepperExampleScenePart = {
     locator: byDataTestId('other-stepper'),
     driver: StepperDriver,
   },
+  empty: {
+    locator: byDataTestId('empty-stepper'),
+    driver: StepperDriver,
+  },
 } satisfies ScenePart;
 
 export const basicStepperExample: IExampleUnit<typeof basicStepperExampleScenePart, JSX.Element> = {
@@ -56,6 +60,12 @@ export const basicStepperTestSuite: TestSuiteInfo<typeof basicStepperExampleScen
 
     test('returns false for an out-of-range step', async () => {
       assertFalse(await engine().parts.stepper.goToStep(99));
+    });
+
+    test('handles a stepper with no steps', async () => {
+      assertEqual(await engine().parts.empty.getStepCount(), 0);
+      assertEqual(await engine().parts.empty.getActiveStepIndex(), -1);
+      assertEqual(await engine().parts.empty.getSteps(), []);
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/stepper/BasicStepper.example.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/examples/stepper/BasicStepper.example.tsx
@@ -36,6 +36,10 @@ export const BasicStepperExample = () => {
           </Step>
         ))}
       </Stepper>
+
+      {/* An empty stepper pins the zero-step contract (count 0, active index -1,
+          getSteps []) so it can't silently regress. */}
+      <Stepper data-testid='empty-stepper' activeStep={0} />
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/stepper/BasicStepper.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/stepper/BasicStepper.suite.ts
@@ -13,6 +13,10 @@ export const basicStepperExampleScenePart = {
     locator: byDataTestId('other-stepper'),
     driver: StepperDriver,
   },
+  empty: {
+    locator: byDataTestId('empty-stepper'),
+    driver: StepperDriver,
+  },
 } satisfies ScenePart;
 
 export const basicStepperExample: IExampleUnit<typeof basicStepperExampleScenePart, JSX.Element> = {
@@ -56,6 +60,12 @@ export const basicStepperTestSuite: TestSuiteInfo<typeof basicStepperExampleScen
 
     test('returns false for an out-of-range step', async () => {
       assertFalse(await engine().parts.stepper.goToStep(99));
+    });
+
+    test('handles a stepper with no steps', async () => {
+      assertEqual(await engine().parts.empty.getStepCount(), 0);
+      assertEqual(await engine().parts.empty.getActiveStepIndex(), -1);
+      assertEqual(await engine().parts.empty.getSteps(), []);
     });
   },
 };

--- a/packages/component-driver-mui-v6/src/components/StepperDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/StepperDriver.ts
@@ -20,6 +20,10 @@ const stepLabelLocator = byCssSelector('.MuiStepLabel-label');
  * as alternating `<div>` children (step, connector, step, …), so the step at
  * `index` is the `2*index+1`-th element of its type; nth-of-type addresses it
  * without the connectors shifting positions.
+ *
+ * The `2*index+1` stride encodes this interleaved-connector layout and is a
+ * per-MUI-version invariant: v9 renders the connector inside each step (stride
+ * `index+1`), so a MUI major bump must re-verify it.
  */
 function stepLabelAt(index: number): PartLocator {
   return byCssSelector(`.MuiStep-root:nth-of-type(${2 * index + 1}) .MuiStepLabel-label`);

--- a/packages/component-driver-mui-v7/src/components/StepperDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/StepperDriver.ts
@@ -20,6 +20,10 @@ const stepLabelLocator = byCssSelector('.MuiStepLabel-label');
  * as alternating `<div>` children (step, connector, step, …), so the step at
  * `index` is the `2*index+1`-th element of its type; nth-of-type addresses it
  * without the connectors shifting positions.
+ *
+ * The `2*index+1` stride encodes this interleaved-connector layout and is a
+ * per-MUI-version invariant: v9 renders the connector inside each step (stride
+ * `index+1`), so a MUI major bump must re-verify it.
  */
 function stepLabelAt(index: number): PartLocator {
   return byCssSelector(`.MuiStep-root:nth-of-type(${2 * index + 1}) .MuiStepLabel-label`);


### PR DESCRIPTION

Code review of the merged StepperDriver (PR #887) found no correctness issues:
the 2*index+1 positional addressing, the class-list/label alignment, the
label-as-state-source choice, and the -1/empty handling are all sound for the
documented supported layouts. This is preventive hardening, not a fix.

- Add a `handles a stepper with no steps` test (empty-stepper instance) pinning
  the zero-step contract: getStepCount 0, getActiveStepIndex -1, getSteps [].
- Document that the 2*index+1 stride encodes v7's interleaved-connector layout
  and is a per-MUI-version invariant — v9 moved the connector inside each step
  (stride index+1), so a MUI major bump must re-verify it.

Scope is v6/v7 per the issue's scope-narrowing comment (MUI 5 EOL); v5/v9 carry
the same driver and are out of scope here.

Fixes #882

Verified: jsdom + Playwright (chromium/firefox/webkit) green for v6 and v7;
tsgo/oxfmt/oxlint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
