### PR TITLE
ci: prevent partial publishes and bump GitHub Actions off node20

### DIFF
--- a/.github/actions/builderui-setup/action.yaml
+++ b/.github/actions/builderui-setup/action.yaml
@@ -1,17 +1,17 @@
 # https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
 name: 'Setup Form Builder UI environment'
-description: 'Setup Form Builder UI environment with PNPM and Node.js 20'
+description: 'Setup Form Builder UI environment with PNPM and Node.js 22'
 
 runs:
   using: 'composite'
   steps:
     - name: Use Node.js 22
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
 
     - name: PNPM Setup
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false

--- a/.github/actions/deps-setup/action.yaml
+++ b/.github/actions/deps-setup/action.yaml
@@ -6,12 +6,12 @@ runs:
   using: 'composite'
   steps:
     - name: Use Node.js 22
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
 
     - name: PNPM Setup
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false

--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -20,13 +20,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup with build
         uses: ./.github/actions/builderui-setup
 
       - name: Cache built packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             packages/*/build
@@ -34,7 +34,7 @@ jobs:
           key: build-packages-${{ github.sha }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: built-packages
           path: |
@@ -52,13 +52,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup dependencies only
         uses: ./.github/actions/deps-setup
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: built-packages
           path: packages
@@ -78,13 +78,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup dependencies only
         uses: ./.github/actions/deps-setup
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: built-packages
           path: packages
@@ -126,13 +126,13 @@ jobs:
             directory: 'vue-3-test'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup dependencies only
         uses: ./.github/actions/deps-setup
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: built-packages
           path: packages
@@ -155,15 +155,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: PNPM Setup
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
           run_install: false

--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup dependencies only
         uses: ./.github/actions/deps-setup

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup dependencies only
         uses: ./.github/actions/deps-setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/agent-docs/RELEASING.md
+++ b/agent-docs/RELEASING.md
@@ -13,8 +13,13 @@ using **npm Trusted Publishing (OIDC)** — no long-lived npm token.
    (with provenance), and commits the version bump back to `main`.
 4. Verify: `npm view @atomic-testing/core version` → `X.Y.Z`.
 
-`publish.sh` is idempotent — it skips any `name@version` already on the registry,
-so re-running after a partial publish resumes instead of failing.
+`publish.sh` publishes in **dependency (topological) order** — `core`/`dom-core`
+before the drivers that pin them, computed by
+[`scripts/publishOrder.js`](../scripts/publishOrder.js) — and **preflights** that
+every package already exists on npm, aborting _before_ any publish (naming the
+offender) if one is missing, so a forgotten bootstrap can't half-ship a release.
+It is also idempotent: it skips any `name@version` already on the registry, so
+re-running after a partial publish resumes instead of failing.
 
 ### If a release fails
 
@@ -39,7 +44,8 @@ On expiry, releases fail at **checkout** with the cryptic
 
 npm can't attach a trusted publisher before a package exists, so a new package's
 first publish can't use OIDC. Bootstrap it once, **before** the first release that
-includes it:
+includes it — otherwise `publish.sh`'s preflight aborts the whole release (cleanly,
+naming the un-bootstrapped package) rather than half-publishing it:
 
 1. On a clean checkout of `main` containing the new package: `pnpm install`
 2. `npm login` (npm CLI ≥ 11.10.0; account 2FA enabled)

--- a/examples/example-mui-signup-form/.github/workflows/deploy-gh-pages.yml
+++ b/examples/example-mui-signup-form/.github/workflows/deploy-gh-pages.yml
@@ -13,12 +13,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
@@ -31,7 +31,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/publish.sh
+++ b/publish.sh
@@ -38,21 +38,55 @@ declare -a exclude=(
 )
 
 
-cd packages
+# Publish dependencies before dependents (topological order). pnpm rewrites
+# workspace:* deps to EXACT version pins at publish time, so a dependency must be
+# on npm before the packages that pin it — otherwise a partial publish strands a
+# dependent referencing a version that was never published. publishOrder.js
+# derives the order from packages/*; the exclude list is passed in so it stays a
+# single source of truth (no second copy to keep in sync).
+order_raw="$(node scripts/publishOrder.js "${exclude[@]}")"
+publish_order=()
+while IFS= read -r folder; do
+  [[ -n "$folder" ]] && publish_order+=("$folder")
+done <<< "$order_raw"
 
-for dir in */; do
-  pkg="${dir%/}"  # strip trailing slash
+if (( ${#publish_order[@]} == 0 )); then
+  echo "ERROR: publishOrder.js produced no packages — aborting." >&2
+  exit 1
+fi
 
-  # check if $pkg is in the exclude list
-  skip=false
-  for ex in "${exclude[@]}"; do
-    if [[ "$pkg" == "$ex" ]]; then
-      skip=true
-      break
+# Preflight (publish mode only): every package must ALREADY exist on npm. OIDC
+# trusted publishing can't attach to a package that doesn't exist yet, so a
+# brand-new package's first publish fails with ENEEDAUTH. Catch that here and
+# fail fast BEFORE touching the registry, instead of aborting mid-loop and
+# leaving a half-published, broken release. Bootstrap new packages once with
+# ./bootstrap-new-package.sh (see header).
+if [[ "$BUILD_ONLY" == false ]]; then
+  echo "→ Preflight: verifying every package exists on npm…"
+  missing=()
+  for pkg in "${publish_order[@]}"; do
+    pkgName="$(node -p "require('./packages/$pkg/package.json').name")"
+    if ! npm view "$pkgName" version > /dev/null 2>&1; then
+      missing+=("$pkg  ($pkgName)")
     fi
   done
-  $skip && continue
+  if (( ${#missing[@]} )); then
+    {
+      echo "ERROR: these package(s) are not on npm yet, so OIDC publishing will fail (ENEEDAUTH):"
+      printf '   - %s\n' "${missing[@]}"
+      echo
+      echo "Bootstrap each NEW package once (creates it + attaches the trusted publisher):"
+      echo "    ./bootstrap-new-package.sh <package-folder-name>"
+      echo "Aborting before any package is published to avoid a partial release."
+    } >&2
+    exit 1
+  fi
+  echo "  ✓ all ${#publish_order[@]} package(s) exist on npm"
+fi
 
+cd packages
+
+for pkg in "${publish_order[@]}"; do
   echo "→ Processing $pkg"
   pushd "$pkg" > /dev/null
 

--- a/scripts/publishOrder.js
+++ b/scripts/publishOrder.js
@@ -1,0 +1,70 @@
+// Prints the folders under packages/ in topological PUBLISH order — every
+// package's internal @atomic-testing/* dependencies are printed before it — one
+// folder name per line.
+//
+// Why dependency order matters: `pnpm publish` rewrites `workspace:*` deps to an
+// EXACT version pin at publish time, so a dependency must already exist on npm
+// before the packages that pin it. Publishing deps-first means a failed/partial
+// publish can never strand an already-published package that references a
+// version of a dependency which was never published.
+//
+// Folders to skip are passed as CLI args (the exclude list lives in publish.sh;
+// passing it in keeps a single source of truth instead of a second copy here).
+// Only runtime edges (dependencies / peerDependencies / optionalDependencies)
+// are considered — devDependencies are irrelevant to a published artifact's
+// resolvability and would introduce spurious cycles (test fixtures dev-depend on
+// the very drivers that depend on core). Exits non-zero on a dependency cycle so
+// a release aborts loudly rather than publishing in an undefined order.
+
+const fs = require('fs');
+const path = require('path');
+
+const exclude = new Set(process.argv.slice(2));
+const packagesDir = path.join(process.cwd(), 'packages');
+
+const folders = fs.readdirSync(packagesDir).filter(folder => {
+  if (exclude.has(folder)) return false;
+  return fs.existsSync(path.join(packagesDir, folder, 'package.json'));
+});
+
+const nameToFolder = {};
+const internalDeps = {};
+for (const folder of folders) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(packagesDir, folder, 'package.json'), 'utf8'));
+  nameToFolder[pkg.name] = folder;
+  const runtimeDeps = { ...pkg.dependencies, ...pkg.peerDependencies, ...pkg.optionalDependencies };
+  internalDeps[folder] = Object.keys(runtimeDeps).filter(name => name.startsWith('@atomic-testing/'));
+}
+
+const VISITING = 1;
+const DONE = 2;
+const state = {};
+const order = [];
+
+function visit(folder, trail) {
+  if (state[folder] === DONE) {
+    return;
+  }
+  if (state[folder] === VISITING) {
+    console.error(`Dependency cycle detected: ${[...trail, folder].join(' -> ')}`);
+    process.exit(1);
+  }
+  state[folder] = VISITING;
+  for (const depName of internalDeps[folder]) {
+    const depFolder = nameToFolder[depName];
+    // Edges to excluded (frozen / already-published) packages resolve to no
+    // folder and are intentionally ignored.
+    if (depFolder && depFolder !== folder) {
+      visit(depFolder, [...trail, folder]);
+    }
+  }
+  state[folder] = DONE;
+  order.push(folder);
+}
+
+// Sort first so the order is deterministic among independent packages.
+for (const folder of [...folders].sort()) {
+  visit(folder, []);
+}
+
+process.stdout.write(`${order.join('\n')}\n`);


### PR DESCRIPTION

The v0.87.0 release published only part of the package set: a brand-new
package (component-driver-mui-x-v9) was never bootstrapped for OIDC, so its
first publish hit ENEEDAUTH and publish.sh (alphabetical order, set -e)
aborted — stranding core and every later package. Because pnpm publish
exact-pins workspace:* deps, the leaf packages that did publish referenced
core/dom-core/react-* versions that were never published, making the release
uninstallable from a clean cache.

This hardens the pipeline so a forgotten bootstrap fails fast instead of
half-shipping a release, and clears the deprecated Node 20 action runtime.

- Publish in dependency (topological) order via scripts/publishOrder.js, and
  preflight that every package exists on npm — aborting before any publish if
  one is missing (verified it flags exactly component-driver-mui-x-v9).
- Bump GitHub Actions off the deprecated node20 runtime: checkout v7,
  setup-node v6, pnpm/action-setup v6, cache v6, upload-artifact v7,
  download-artifact v8 (all verified drop-in for this repo's usage).
- Document the new ordering/preflight in agent-docs/RELEASING.md; broader
  release-robustness follow-ups tracked in #921.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
