### PR TITLE
test(component-driver-mui): settle SlideIn dialog open before sampling

### DIFF
--- a/package-tests/component-driver-mui-v6-test/src/examples/dialog/SlideInDialog.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/dialog/SlideInDialog.suite.ts
@@ -47,6 +47,9 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Clicking open trigger should open dialog', async () => {
       await engine().parts.openTrigger.click();
+      // The Slide transition (theme default ~225ms) keeps the container mounted, so isOpen()
+      // relies on visibility crossing the threshold; settle the open before sampling.
+      await engine().parts.dialog.waitForOpen();
       const isOpen = await engine().parts.dialog.isOpen();
       assertTrue(isOpen);
     });
@@ -61,6 +64,7 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Dialog title should be correct', async () => {
       await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
       const title = await engine().parts.dialog.getTitle();
       assertEqual(title, "Use Google's location service?");
     });

--- a/package-tests/component-driver-mui-v7-test/src/examples/dialog/SlideInDialog.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/dialog/SlideInDialog.suite.ts
@@ -47,6 +47,9 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Clicking open trigger should open dialog', async () => {
       await engine().parts.openTrigger.click();
+      // The Slide transition (theme default ~225ms) keeps the container mounted, so isOpen()
+      // relies on visibility crossing the threshold; settle the open before sampling.
+      await engine().parts.dialog.waitForOpen();
       const isOpen = await engine().parts.dialog.isOpen();
       assertTrue(isOpen);
     });
@@ -61,6 +64,7 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Dialog title should be correct', async () => {
       await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
       const title = await engine().parts.dialog.getTitle();
       assertEqual(title, "Use Google's location service?");
     });

--- a/package-tests/component-driver-mui-v9-test/src/examples/dialog/SlideInDialog.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/dialog/SlideInDialog.suite.ts
@@ -47,6 +47,9 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Clicking open trigger should open dialog', async () => {
       await engine().parts.openTrigger.click();
+      // The Slide transition (theme default ~225ms) keeps the container mounted, so isOpen()
+      // relies on visibility crossing the threshold; settle the open before sampling.
+      await engine().parts.dialog.waitForOpen();
       const isOpen = await engine().parts.dialog.isOpen();
       assertTrue(isOpen);
     });
@@ -61,6 +64,7 @@ export const slideinDialogTestSuite: TestSuiteInfo<typeof slideInDialogExample.s
 
     test('Dialog title should be correct', async () => {
       await engine().parts.openTrigger.click();
+      await engine().parts.dialog.waitForOpen();
       const title = await engine().parts.dialog.getTitle();
       assertEqual(title, "Use Google's location service?");
     });


### PR DESCRIPTION

The SlideIn dialog example wraps Dialog in a keepMounted Slide transition, so the container
stays mounted and isOpen() depends on visibility crossing the opacity threshold mid-slide.
The "open" and "title" tests sampled isOpen()/getTitle() immediately after the trigger click
with no settle, intermittently reading the dialog as not-yet-open. Insert waitForOpen() before
sampling, mirroring the close test's existing waitForClose(). Test-only; applied to v6/v7/v9.

## Key Changes

- Add `await dialog.waitForOpen()` after the open-trigger click in the SlideIn "open" and
  "title" tests across the v6, v7, and v9 example suites.

Addresses the SlideIn portion of #240. The separate AlertDialog backdrop-click e2e flake is a
geometry/actionability (occlusion) stall that a settle cannot fix; it is split into #928 for the
geometry-free dismiss (Interactor 2B+2A) work.
