### PR TITLE
feat(component-driver-mui): add consistent state accessors for v6/v7

### DIFF
--- a/package-tests/component-driver-mui-v6-test/__tests__/StateAccessorsDriver.dom.test.ts
+++ b/package-tests/component-driver-mui-v6-test/__tests__/StateAccessorsDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-18';
+
+import { stateAccessorsExample, stateAccessorsTestSuite } from '../src/examples';
+
+testRunner(stateAccessorsTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof stateAccessorsExample.scene) => {
+    return createTestEngine(stateAccessorsExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-v6-test/__tests__/StateAccessorsDriver.e2e.test.ts
+++ b/package-tests/component-driver-mui-v6-test/__tests__/StateAccessorsDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { stateAccessorsTestSuite } from '../src/examples';
+
+testRunner(stateAccessorsTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-v6-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/directory.tsx
@@ -29,6 +29,7 @@ import { nativeSelectUIExample } from './examples/select/NativeSelect.examples';
 import { basicSliderUIExample } from './examples/slider/BasicSlider.examples';
 import { basicSnackbarUIExample } from './examples/snackbar/BasicSnackbar.examples';
 import { basicSpeedDialUIExample } from './examples/speedDial/BasicSpeedDial.example';
+import { stateAccessorsUIExample } from './examples/stateAccessors/StateAccessors.example';
 import { basicStepperUIExample } from './examples/stepper/BasicStepper.example';
 import { basicSwitchUIExample } from './examples/switch/BasicSwitch.examples';
 import { basicTablePaginationUIExample } from './examples/tablePagination/BasicTablePagination.example';
@@ -147,6 +148,11 @@ export const tocs: ExampleToc[] = [
     label: 'SpeedDial',
     path: '/speed-dial',
     ui: <ExampleList examples={[basicSpeedDialUIExample]} />,
+  },
+  {
+    label: 'State Accessors',
+    path: '/state-accessors',
+    ui: <ExampleList examples={[stateAccessorsUIExample]} />,
   },
   {
     label: 'Stepper',

--- a/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -105,5 +105,17 @@ export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteE
       assertFalse(await engine().parts.select.hasNoOptions());
       assertFalse(await engine().parts.select.isLoading());
     });
+
+    test('getOptions lists the currently visible options', async () => {
+      await engine().parts.select.parts.input.setValue('Godfather');
+      const options = await engine().parts.select.getOptions();
+      assertTrue(options.includes('The Godfather'));
+    });
+
+    test('clear empties the current selection', async () => {
+      await engine().parts.select.setValue('The Shawshank Redemption');
+      await engine().parts.select.clear();
+      assertEqual(await engine().parts.select.getValue(), '');
+    });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/index.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/index.ts
@@ -19,6 +19,7 @@ export * from './select';
 export * from './slider';
 export * from './snackbar';
 export * from './speedDial';
+export * from './stateAccessors';
 export * from './stepper';
 export * from './switch';
 export * from './tablePagination';

--- a/package-tests/component-driver-mui-v6-test/src/examples/menu/AccountMenu.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/menu/AccountMenu.suite.ts
@@ -63,6 +63,17 @@ export const accountMenuTestSuite: TestSuiteInfo<typeof accountMenuExample.scene
         const isDisabled = await item?.isDisabled();
         assertTrue(isDisabled);
       });
+
+      test('getMenuItemCount reports the number of items', async () => {
+        assertEqual(await engine().parts.menu.getMenuItemCount(), 5);
+      });
+
+      test('getMenuItemByIndex returns the item at that position', async () => {
+        const first = await engine().parts.menu.getMenuItemByIndex(0);
+        assertEqual(await first?.label(), 'Profile');
+        const outOfRange = await engine().parts.menu.getMenuItemByIndex(99);
+        assertEqual(outOfRange, null);
+      });
     });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/progress/Progress.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/progress/Progress.suite.ts
@@ -117,5 +117,15 @@ export const progressTestSuite: TestSuiteInfo<typeof basicProgressExampleScenePa
       const determinate = await engine().parts.linearBuffer.isDeterminate();
       assertTrue(determinate);
     });
+
+    test('linear buffer should report its buffer value', async () => {
+      const buffer = await engine().parts.linearBuffer.getBufferValue();
+      assertEqual(buffer, 85);
+    });
+
+    test('a non-buffer progress has no buffer value', async () => {
+      const buffer = await engine().parts.linear.getBufferValue();
+      assertEqual(buffer, null);
+    });
   },
 };

--- a/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/StateAccessors.example.tsx
+++ b/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/StateAccessors.example.tsx
@@ -1,0 +1,86 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import Badge from '@mui/material/Badge';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Slider from '@mui/material/Slider';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import React from 'react';
+
+const marks = [
+  { value: 0, label: '0°C' },
+  { value: 20, label: '20°C' },
+  { value: 37, label: '37°C' },
+];
+
+/**
+ * A grid of components in specific states (required, error, loading, disabled, dot/invisible
+ * badge, multi-select, marked slider, …) used to exercise the cross-cutting state accessors.
+ */
+export const StateAccessors: React.FunctionComponent = () => {
+  return (
+    <Box sx={{ display: 'grid', gap: 2, p: 2 }}>
+      <TextField data-testid='required-error-field' label='Email' required error placeholder='you@example.com' />
+      <TextField data-testid='plain-field' label='Name' />
+
+      <FormControlLabel control={<Checkbox data-testid='required-checkbox' required />} label='Accept' />
+      <FormControlLabel control={<Switch data-testid='required-switch' required />} label='Enable' />
+
+      <Select data-testid='multi-select' multiple value={['1', '2']} required>
+        <MenuItem value='1'>One</MenuItem>
+        <MenuItem value='2'>Two</MenuItem>
+        <MenuItem value='3'>Three</MenuItem>
+      </Select>
+
+      <Button data-testid='loading-button' loading>
+        Save
+      </Button>
+      <Button data-testid='disabled-link-button' href='#' disabled>
+        Link
+      </Button>
+
+      <Chip data-testid='disabled-chip' label='Tag' disabled />
+
+      <Badge data-testid='dot-badge' variant='dot' color='primary'>
+        <span>A</span>
+      </Badge>
+      <Badge data-testid='invisible-badge' badgeContent={4} invisible>
+        <span>B</span>
+      </Badge>
+      <Badge data-testid='visible-badge' badgeContent={4} color='primary'>
+        <span>C</span>
+      </Badge>
+
+      <Slider
+        data-testid='marked-slider'
+        defaultValue={20}
+        min={0}
+        max={100}
+        step={10}
+        marks={marks}
+        valueLabelDisplay='auto'
+        getAriaValueText={(v: number) => `${v} degrees`}
+      />
+
+      <ToggleButtonGroup data-testid='toggle-group' value='left' exclusive>
+        <ToggleButton value='left'>Left</ToggleButton>
+        <ToggleButton value='center' disabled>
+          Center
+        </ToggleButton>
+        <ToggleButton value='right'>Right</ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+};
+
+export const stateAccessorsUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'State Accessors',
+  ui: <StateAccessors />,
+};

--- a/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/StateAccessors.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/StateAccessors.suite.ts
@@ -1,0 +1,99 @@
+import {
+  BadgeDriver,
+  ButtonDriver,
+  CheckboxDriver,
+  ChipDriver,
+  SelectDriver,
+  SliderDriver,
+  SwitchDriver,
+  TextFieldDriver,
+  ToggleButtonGroupDriver,
+} from '@atomic-testing/component-driver-mui-v6';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+
+import { stateAccessorsUIExample } from './StateAccessors.example';
+
+export const stateAccessorsScenePart = {
+  requiredErrorField: { locator: byDataTestId('required-error-field'), driver: TextFieldDriver },
+  plainField: { locator: byDataTestId('plain-field'), driver: TextFieldDriver },
+  requiredCheckbox: { locator: byDataTestId('required-checkbox'), driver: CheckboxDriver },
+  requiredSwitch: { locator: byDataTestId('required-switch'), driver: SwitchDriver },
+  multiSelect: { locator: byDataTestId('multi-select'), driver: SelectDriver },
+  loadingButton: { locator: byDataTestId('loading-button'), driver: ButtonDriver },
+  disabledLinkButton: { locator: byDataTestId('disabled-link-button'), driver: ButtonDriver },
+  disabledChip: { locator: byDataTestId('disabled-chip'), driver: ChipDriver },
+  dotBadge: { locator: byDataTestId('dot-badge'), driver: BadgeDriver },
+  invisibleBadge: { locator: byDataTestId('invisible-badge'), driver: BadgeDriver },
+  visibleBadge: { locator: byDataTestId('visible-badge'), driver: BadgeDriver },
+  markedSlider: { locator: byDataTestId('marked-slider'), driver: SliderDriver },
+  toggleGroup: { locator: byDataTestId('toggle-group'), driver: ToggleButtonGroupDriver },
+} satisfies ScenePart;
+
+export const stateAccessorsExample: IExampleUnit<typeof stateAccessorsScenePart, JSX.Element> = {
+  ...stateAccessorsUIExample,
+  scene: stateAccessorsScenePart,
+};
+
+export const stateAccessorsTestSuite: TestSuiteInfo<typeof stateAccessorsExample.scene> = {
+  title: 'State Accessors',
+  url: '/state-accessors',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(stateAccessorsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('TextField reports required, error and placeholder', async () => {
+      assertTrue(await engine().parts.requiredErrorField.isRequired());
+      assertTrue(await engine().parts.requiredErrorField.isError());
+      assertEqual(await engine().parts.requiredErrorField.getPlaceholder(), 'you@example.com');
+    });
+
+    test('A plain TextField reports not required, no error, no placeholder', async () => {
+      assertFalse(await engine().parts.plainField.isRequired());
+      assertFalse(await engine().parts.plainField.isError());
+      assertEqual(await engine().parts.plainField.getPlaceholder(), undefined);
+    });
+
+    test('Checkbox and Switch report required', async () => {
+      assertTrue(await engine().parts.requiredCheckbox.isRequired());
+      assertTrue(await engine().parts.requiredSwitch.isRequired());
+    });
+
+    test('A multiple Select reports its values as an array and is required', async () => {
+      assertEqual(await engine().parts.multiSelect.getSelectedValues(), ['1', '2']);
+      assertTrue(await engine().parts.multiSelect.isRequired());
+    });
+
+    test('Button reports loading and link-button disabled', async () => {
+      assertTrue(await engine().parts.loadingButton.isLoading());
+      assertTrue(await engine().parts.disabledLinkButton.isDisabled());
+    });
+
+    test('Chip reports disabled', async () => {
+      assertTrue(await engine().parts.disabledChip.isDisabled());
+    });
+
+    test('Badge distinguishes dot, invisible and visible', async () => {
+      assertTrue(await engine().parts.dotBadge.isDot());
+      assertTrue(await engine().parts.invisibleBadge.isInvisible());
+      assertFalse(await engine().parts.invisibleBadge.isBadgeVisible());
+      assertTrue(await engine().parts.visibleBadge.isBadgeVisible());
+      assertFalse(await engine().parts.visibleBadge.isDot());
+    });
+
+    test('Slider reports min/max/step, marks and value text', async () => {
+      assertEqual(await engine().parts.markedSlider.getMin(), 0);
+      assertEqual(await engine().parts.markedSlider.getMax(), 100);
+      assertEqual(await engine().parts.markedSlider.getStep(), 10);
+      assertEqual(await engine().parts.markedSlider.getMarks(), ['0°C', '20°C', '37°C']);
+      assertEqual(await engine().parts.markedSlider.getValueText(), '20 degrees');
+    });
+
+    test('ToggleButtonGroup exposes per-option access and disabled state', async () => {
+      assertEqual(await engine().parts.toggleGroup.getButtonCount(), 3);
+      assertTrue(await engine().parts.toggleGroup.isOptionDisabled('center'));
+      assertFalse(await engine().parts.toggleGroup.isOptionDisabled('left'));
+      const right = await engine().parts.toggleGroup.getButtonByLabel('Right');
+      assertTrue((await right?.getValue()) === 'right');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/index.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/stateAccessors/index.ts
@@ -1,0 +1,11 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { stateAccessorsUIExample } from './StateAccessors.example';
+import { stateAccessorsExample, stateAccessorsTestSuite } from './StateAccessors.suite';
+
+export { stateAccessorsUIExample, stateAccessorsExample, stateAccessorsTestSuite };
+
+export const stateAccessorsExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  stateAccessorsExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-v7-test/__tests__/StateAccessorsDriver.dom.test.ts
+++ b/package-tests/component-driver-mui-v7-test/__tests__/StateAccessorsDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-18';
+
+import { stateAccessorsExample, stateAccessorsTestSuite } from '../src/examples';
+
+testRunner(stateAccessorsTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof stateAccessorsExample.scene) => {
+    return createTestEngine(stateAccessorsExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-v7-test/__tests__/StateAccessorsDriver.e2e.test.ts
+++ b/package-tests/component-driver-mui-v7-test/__tests__/StateAccessorsDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { stateAccessorsTestSuite } from '../src/examples';
+
+testRunner(stateAccessorsTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-v7-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/directory.tsx
@@ -29,6 +29,7 @@ import { nativeSelectUIExample } from './examples/select/NativeSelect.examples';
 import { basicSliderUIExample } from './examples/slider/BasicSlider.examples';
 import { basicSnackbarUIExample } from './examples/snackbar/BasicSnackbar.examples';
 import { basicSpeedDialUIExample } from './examples/speedDial/BasicSpeedDial.example';
+import { stateAccessorsUIExample } from './examples/stateAccessors/StateAccessors.example';
 import { basicStepperUIExample } from './examples/stepper/BasicStepper.example';
 import { basicSwitchUIExample } from './examples/switch/BasicSwitch.examples';
 import { basicTablePaginationUIExample } from './examples/tablePagination/BasicTablePagination.example';
@@ -147,6 +148,11 @@ export const tocs: ExampleToc[] = [
     label: 'SpeedDial',
     path: '/speed-dial',
     ui: <ExampleList examples={[basicSpeedDialUIExample]} />,
+  },
+  {
+    label: 'State Accessors',
+    path: '/state-accessors',
+    ui: <ExampleList examples={[stateAccessorsUIExample]} />,
   },
   {
     label: 'Stepper',

--- a/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/autocomplete/BasicAutoComplete.suite.ts
@@ -105,5 +105,17 @@ export const basicAutoCompleteTestSuite: TestSuiteInfo<typeof basicAutoCompleteE
       assertFalse(await engine().parts.select.hasNoOptions());
       assertFalse(await engine().parts.select.isLoading());
     });
+
+    test('getOptions lists the currently visible options', async () => {
+      await engine().parts.select.parts.input.setValue('Godfather');
+      const options = await engine().parts.select.getOptions();
+      assertTrue(options.includes('The Godfather'));
+    });
+
+    test('clear empties the current selection', async () => {
+      await engine().parts.select.setValue('The Shawshank Redemption');
+      await engine().parts.select.clear();
+      assertEqual(await engine().parts.select.getValue(), '');
+    });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/index.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/index.ts
@@ -19,6 +19,7 @@ export * from './select';
 export * from './slider';
 export * from './snackbar';
 export * from './speedDial';
+export * from './stateAccessors';
 export * from './stepper';
 export * from './switch';
 export * from './tablePagination';

--- a/package-tests/component-driver-mui-v7-test/src/examples/menu/AccountMenu.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/menu/AccountMenu.suite.ts
@@ -63,6 +63,17 @@ export const accountMenuTestSuite: TestSuiteInfo<typeof accountMenuExample.scene
         const isDisabled = await item?.isDisabled();
         assertTrue(isDisabled);
       });
+
+      test('getMenuItemCount reports the number of items', async () => {
+        assertEqual(await engine().parts.menu.getMenuItemCount(), 5);
+      });
+
+      test('getMenuItemByIndex returns the item at that position', async () => {
+        const first = await engine().parts.menu.getMenuItemByIndex(0);
+        assertEqual(await first?.label(), 'Profile');
+        const outOfRange = await engine().parts.menu.getMenuItemByIndex(99);
+        assertEqual(outOfRange, null);
+      });
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/progress/Progress.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/progress/Progress.suite.ts
@@ -117,5 +117,15 @@ export const progressTestSuite: TestSuiteInfo<typeof basicProgressExampleScenePa
       const determinate = await engine().parts.linearBuffer.isDeterminate();
       assertTrue(determinate);
     });
+
+    test('linear buffer should report its buffer value', async () => {
+      const buffer = await engine().parts.linearBuffer.getBufferValue();
+      assertEqual(buffer, 85);
+    });
+
+    test('a non-buffer progress has no buffer value', async () => {
+      const buffer = await engine().parts.linear.getBufferValue();
+      assertEqual(buffer, null);
+    });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/StateAccessors.example.tsx
+++ b/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/StateAccessors.example.tsx
@@ -1,0 +1,86 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import Badge from '@mui/material/Badge';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Slider from '@mui/material/Slider';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import React from 'react';
+
+const marks = [
+  { value: 0, label: '0°C' },
+  { value: 20, label: '20°C' },
+  { value: 37, label: '37°C' },
+];
+
+/**
+ * A grid of components in specific states (required, error, loading, disabled, dot/invisible
+ * badge, multi-select, marked slider, …) used to exercise the cross-cutting state accessors.
+ */
+export const StateAccessors: React.FunctionComponent = () => {
+  return (
+    <Box sx={{ display: 'grid', gap: 2, p: 2 }}>
+      <TextField data-testid='required-error-field' label='Email' required error placeholder='you@example.com' />
+      <TextField data-testid='plain-field' label='Name' />
+
+      <FormControlLabel control={<Checkbox data-testid='required-checkbox' required />} label='Accept' />
+      <FormControlLabel control={<Switch data-testid='required-switch' required />} label='Enable' />
+
+      <Select data-testid='multi-select' multiple value={['1', '2']} required>
+        <MenuItem value='1'>One</MenuItem>
+        <MenuItem value='2'>Two</MenuItem>
+        <MenuItem value='3'>Three</MenuItem>
+      </Select>
+
+      <Button data-testid='loading-button' loading>
+        Save
+      </Button>
+      <Button data-testid='disabled-link-button' href='#' disabled>
+        Link
+      </Button>
+
+      <Chip data-testid='disabled-chip' label='Tag' disabled />
+
+      <Badge data-testid='dot-badge' variant='dot' color='primary'>
+        <span>A</span>
+      </Badge>
+      <Badge data-testid='invisible-badge' badgeContent={4} invisible>
+        <span>B</span>
+      </Badge>
+      <Badge data-testid='visible-badge' badgeContent={4} color='primary'>
+        <span>C</span>
+      </Badge>
+
+      <Slider
+        data-testid='marked-slider'
+        defaultValue={20}
+        min={0}
+        max={100}
+        step={10}
+        marks={marks}
+        valueLabelDisplay='auto'
+        getAriaValueText={(v: number) => `${v} degrees`}
+      />
+
+      <ToggleButtonGroup data-testid='toggle-group' value='left' exclusive>
+        <ToggleButton value='left'>Left</ToggleButton>
+        <ToggleButton value='center' disabled>
+          Center
+        </ToggleButton>
+        <ToggleButton value='right'>Right</ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+};
+
+export const stateAccessorsUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'State Accessors',
+  ui: <StateAccessors />,
+};

--- a/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/StateAccessors.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/StateAccessors.suite.ts
@@ -1,0 +1,99 @@
+import {
+  BadgeDriver,
+  ButtonDriver,
+  CheckboxDriver,
+  ChipDriver,
+  SelectDriver,
+  SliderDriver,
+  SwitchDriver,
+  TextFieldDriver,
+  ToggleButtonGroupDriver,
+} from '@atomic-testing/component-driver-mui-v7';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+
+import { stateAccessorsUIExample } from './StateAccessors.example';
+
+export const stateAccessorsScenePart = {
+  requiredErrorField: { locator: byDataTestId('required-error-field'), driver: TextFieldDriver },
+  plainField: { locator: byDataTestId('plain-field'), driver: TextFieldDriver },
+  requiredCheckbox: { locator: byDataTestId('required-checkbox'), driver: CheckboxDriver },
+  requiredSwitch: { locator: byDataTestId('required-switch'), driver: SwitchDriver },
+  multiSelect: { locator: byDataTestId('multi-select'), driver: SelectDriver },
+  loadingButton: { locator: byDataTestId('loading-button'), driver: ButtonDriver },
+  disabledLinkButton: { locator: byDataTestId('disabled-link-button'), driver: ButtonDriver },
+  disabledChip: { locator: byDataTestId('disabled-chip'), driver: ChipDriver },
+  dotBadge: { locator: byDataTestId('dot-badge'), driver: BadgeDriver },
+  invisibleBadge: { locator: byDataTestId('invisible-badge'), driver: BadgeDriver },
+  visibleBadge: { locator: byDataTestId('visible-badge'), driver: BadgeDriver },
+  markedSlider: { locator: byDataTestId('marked-slider'), driver: SliderDriver },
+  toggleGroup: { locator: byDataTestId('toggle-group'), driver: ToggleButtonGroupDriver },
+} satisfies ScenePart;
+
+export const stateAccessorsExample: IExampleUnit<typeof stateAccessorsScenePart, JSX.Element> = {
+  ...stateAccessorsUIExample,
+  scene: stateAccessorsScenePart,
+};
+
+export const stateAccessorsTestSuite: TestSuiteInfo<typeof stateAccessorsExample.scene> = {
+  title: 'State Accessors',
+  url: '/state-accessors',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(stateAccessorsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('TextField reports required, error and placeholder', async () => {
+      assertTrue(await engine().parts.requiredErrorField.isRequired());
+      assertTrue(await engine().parts.requiredErrorField.isError());
+      assertEqual(await engine().parts.requiredErrorField.getPlaceholder(), 'you@example.com');
+    });
+
+    test('A plain TextField reports not required, no error, no placeholder', async () => {
+      assertFalse(await engine().parts.plainField.isRequired());
+      assertFalse(await engine().parts.plainField.isError());
+      assertEqual(await engine().parts.plainField.getPlaceholder(), undefined);
+    });
+
+    test('Checkbox and Switch report required', async () => {
+      assertTrue(await engine().parts.requiredCheckbox.isRequired());
+      assertTrue(await engine().parts.requiredSwitch.isRequired());
+    });
+
+    test('A multiple Select reports its values as an array and is required', async () => {
+      assertEqual(await engine().parts.multiSelect.getSelectedValues(), ['1', '2']);
+      assertTrue(await engine().parts.multiSelect.isRequired());
+    });
+
+    test('Button reports loading and link-button disabled', async () => {
+      assertTrue(await engine().parts.loadingButton.isLoading());
+      assertTrue(await engine().parts.disabledLinkButton.isDisabled());
+    });
+
+    test('Chip reports disabled', async () => {
+      assertTrue(await engine().parts.disabledChip.isDisabled());
+    });
+
+    test('Badge distinguishes dot, invisible and visible', async () => {
+      assertTrue(await engine().parts.dotBadge.isDot());
+      assertTrue(await engine().parts.invisibleBadge.isInvisible());
+      assertFalse(await engine().parts.invisibleBadge.isBadgeVisible());
+      assertTrue(await engine().parts.visibleBadge.isBadgeVisible());
+      assertFalse(await engine().parts.visibleBadge.isDot());
+    });
+
+    test('Slider reports min/max/step, marks and value text', async () => {
+      assertEqual(await engine().parts.markedSlider.getMin(), 0);
+      assertEqual(await engine().parts.markedSlider.getMax(), 100);
+      assertEqual(await engine().parts.markedSlider.getStep(), 10);
+      assertEqual(await engine().parts.markedSlider.getMarks(), ['0°C', '20°C', '37°C']);
+      assertEqual(await engine().parts.markedSlider.getValueText(), '20 degrees');
+    });
+
+    test('ToggleButtonGroup exposes per-option access and disabled state', async () => {
+      assertEqual(await engine().parts.toggleGroup.getButtonCount(), 3);
+      assertTrue(await engine().parts.toggleGroup.isOptionDisabled('center'));
+      assertFalse(await engine().parts.toggleGroup.isOptionDisabled('left'));
+      const right = await engine().parts.toggleGroup.getButtonByLabel('Right');
+      assertTrue((await right?.getValue()) === 'right');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/index.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/stateAccessors/index.ts
@@ -1,0 +1,11 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { stateAccessorsUIExample } from './StateAccessors.example';
+import { stateAccessorsExample, stateAccessorsTestSuite } from './StateAccessors.suite';
+
+export { stateAccessorsUIExample, stateAccessorsExample, stateAccessorsTestSuite };
+
+export const stateAccessorsExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
+  stateAccessorsExample,
+] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/AutoCompleteDriver.ts
@@ -120,6 +120,41 @@ export class AutoCompleteDriver extends ComponentDriver<typeof parts> implements
     return false;
   }
 
+  /**
+   * Open the popup (if closed) and return the visible option labels in order. Opens by
+   * clicking the input; returns `[]` when the popup renders no listbox (e.g. no options).
+   */
+  async getOptions(): Promise<string[]> {
+    if (!(await this.interactor.exists(this.parts.dropdown.locator))) {
+      await this.parts.input.click();
+    }
+    if (!(await this.interactor.exists(this.parts.dropdown.locator))) {
+      return [];
+    }
+    const optionItemLocator = locatorUtil.append(this.parts.dropdown.locator, optionLocator);
+    const result: string[] = [];
+    for await (const optionDriver of listHelper.getListItemIterator(this, optionItemLocator, HTMLElementDriver)) {
+      const text = await optionDriver.getText();
+      if (text != null) {
+        result.push(text.trim());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Clear the current selection via the clear (✕) indicator. The indicator is
+   * hover-gated, so the root is hovered first to reveal it; a no-op when there is
+   * nothing to clear (no clear indicator rendered).
+   */
+  async clear(): Promise<void> {
+    const clearButton = locatorUtil.append(this.locator, byCssClass('MuiAutocomplete-clearIndicator'));
+    if (await this.interactor.exists(clearButton)) {
+      await this.interactor.hover(this.locator);
+      await this.interactor.click(clearButton);
+    }
+  }
+
   async isDisabled(): Promise<boolean> {
     return this.parts.input.isDisabled();
   }

--- a/packages/component-driver-mui-v6/src/components/BadgeDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/BadgeDriver.ts
@@ -37,6 +37,35 @@ export class BadgeDriver extends ComponentDriver<typeof parts> {
     return content ?? null;
   }
 
+  /**
+   * Whether the badge bubble is currently hidden. The `.MuiBadge-badge` node is always
+   * mounted (so inherited `isVisible`/`getContent` cannot distinguish shown from hidden);
+   * MUI toggles visibility with the `MuiBadge-invisible` class.
+   */
+  async isInvisible(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.parts.contentDisplay.locator, 'MuiBadge-invisible');
+  }
+
+  /**
+   * Whether the badge bubble is currently shown (the badge node exists and is not
+   * marked invisible).
+   */
+  async isBadgeVisible(): Promise<boolean> {
+    const exists = await this.interactor.exists(this.parts.contentDisplay.locator);
+    if (!exists) {
+      return false;
+    }
+    return !(await this.isInvisible());
+  }
+
+  /**
+   * Whether the badge is a dot variant (`variant="dot"` → `MuiBadge-dot`), which renders
+   * a marker with no content.
+   */
+  async isDot(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.parts.contentDisplay.locator, 'MuiBadge-dot');
+  }
+
   override get driverName(): string {
     return 'MuiV6BadgeDriver';
   }

--- a/packages/component-driver-mui-v6/src/components/ButtonDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ButtonDriver.ts
@@ -1,13 +1,37 @@
 import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+import { IDisableableDriver } from '@atomic-testing/core';
 
 /**
  * Driver for Material UI v6 Button component.
  * @see https://mui.com/material-ui/react-button/
  */
-export class ButtonDriver extends HTMLButtonDriver {
+export class ButtonDriver extends HTMLButtonDriver implements IDisableableDriver {
   async getValue(): Promise<string | null> {
     const val = await this.interactor.getAttribute(this.locator, 'value');
     return val ?? null;
+  }
+
+  /**
+   * Whether the button is disabled. A MUI Button rendered as a `<button>` carries the
+   * native `disabled` attribute, but as an anchor/link-button (`href`) it cannot — it
+   * uses `aria-disabled` + the `Mui-disabled` class instead. Check all three so a
+   * visibly-disabled link button is not reported as enabled.
+   */
+  override async isDisabled(): Promise<boolean> {
+    const [nativeDisabled, ariaDisabled, muiDisabled] = await Promise.all([
+      this.interactor.getAttribute(this.locator, 'disabled'),
+      this.interactor.getAttribute(this.locator, 'aria-disabled'),
+      this.interactor.hasCssClass(this.locator, 'Mui-disabled'),
+    ]);
+    return nativeDisabled != null || ariaDisabled === 'true' || muiDisabled;
+  }
+
+  /**
+   * Whether the button is in the loading state. MUI v6 moved `loading` into the core
+   * Button, which adds the `MuiButton-loading` class and a `.MuiButton-loadingIndicator`.
+   */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, 'MuiButton-loading');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/CheckboxDriver.ts
@@ -4,8 +4,10 @@ import {
   byTagName,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   locatorUtil,
   Optional,
@@ -26,7 +28,7 @@ export type CheckboxScenePartDriver = ScenePartDriver<CheckboxScenePart>;
 
 export class CheckboxDriver
   extends ComponentDriver<CheckboxScenePart>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IDisableableDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -63,6 +65,13 @@ export class CheckboxDriver
 
   isReadonly(): Promise<boolean> {
     return this.parts.checkbox.isReadonly();
+  }
+
+  /**
+   * Whether the checkbox is required (MUI sets the native `required` attribute on the input).
+   */
+  async isRequired(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.parts.checkbox.locator, 'required')) != null;
   }
 
   /**

--- a/packages/component-driver-mui-v6/src/components/ChipDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ChipDriver.ts
@@ -4,6 +4,7 @@ import {
   byDataTestId,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   Interactor,
   PartLocator,
   ScenePart,
@@ -24,12 +25,20 @@ export const parts = {
  * Driver for Material UI v6 Chip component.
  * @see https://mui.com/material-ui/react-chip/
  */
-export class ChipDriver extends ComponentDriver<typeof parts> {
+export class ChipDriver extends ComponentDriver<typeof parts> implements IDisableableDriver {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: parts,
     });
+  }
+
+  /**
+   * Whether the chip is disabled. A Chip has no native form control; MUI marks the
+   * disabled state with the `Mui-disabled` class on the chip root.
+   */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, 'Mui-disabled');
   }
 
   /**

--- a/packages/component-driver-mui-v6/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/InputDriver.ts
@@ -5,6 +5,8 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
@@ -25,7 +27,10 @@ type TextFieldInputType = 'singleLine' | 'multiline';
 /**
  * A driver for the Material UI v6 Input, FilledInput, OutlinedInput, and StandardInput components.
  */
-export class InputDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class InputDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -101,6 +106,25 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    return inputType === 'singleLine' ? this.parts.singlelineInput.locator : this.parts.multilineInput.locator;
+  }
+
+  /**
+   * Whether the input is required (MUI sets the native `required` attribute).
+   */
+  async isRequired(): Promise<boolean> {
+    return (await this.interactor.getAttribute(await this.getValueInputLocator(), 'required')) != null;
+  }
+
+  /**
+   * Whether the input is in the error state (`error` prop → `aria-invalid="true"`).
+   */
+  async isError(): Promise<boolean> {
+    return (await this.interactor.getAttribute(await this.getValueInputLocator(), 'aria-invalid')) === 'true';
   }
 
   /**

--- a/packages/component-driver-mui-v6/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/MenuDriver.ts
@@ -59,6 +59,21 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
     }
   }
 
+  /**
+   * The number of items (role `menuitem`) in the open menu.
+   */
+  async getMenuItemCount(): Promise<number> {
+    return listHelper.getListItemCount(this, menuItemLocator);
+  }
+
+  /**
+   * Get the menu item at the given zero-based index, or `null` if out of range.
+   * Complements the existing label-based {@link getMenuItemByLabel}.
+   */
+  async getMenuItemByIndex(index: number): Promise<MenuItemDriver | null> {
+    return listHelper.getListItemByIndex(this, menuItemLocator, index, MenuItemDriver);
+  }
+
   get driverName(): string {
     return 'MuiV6MenuDriver';
   }

--- a/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ProgressDriver.ts
@@ -1,13 +1,13 @@
-import { ComponentDriver } from '@atomic-testing/core';
+import { byCssClass, ComponentDriver, locatorUtil } from '@atomic-testing/core';
 
 /**
  * Driver for the Material UI v6 Progress components (`LinearProgress` / `CircularProgress`).
  *
  * A progress indicator is a read-only, non-interactive status component: it has no
  * user-settable value and renders no form controls. The driver therefore only reads
- * state (`getValue` from `aria-valuenow`, `getType`, `isDeterminate`) and deliberately
- * does NOT implement `IInputDriver` — an earlier version mistakenly modelled it on a
- * radio-group input, exposing a nonsensical `setValue`.
+ * state (`getValue` from `aria-valuenow`, `getType`, `isDeterminate`, `getBufferValue`) and
+ * deliberately does NOT implement `IInputDriver` — an earlier version mistakenly modelled it
+ * on a radio-group input, exposing a nonsensical `setValue`.
  *
  * @see https://mui.com/material-ui/react-progress/
  */
@@ -34,9 +34,23 @@ export class ProgressDriver extends ComponentDriver {
     return val != null;
   }
 
-  // The buffer value of variant="buffer" (derivable from the bar2 transform,
-  // e.g. style="transform: translateX(-15%)" → 85) is not yet exposed; tracked
-  // as getBufferValue in the state-accessor work (#872).
+  /**
+   * The buffer value of a `variant="buffer"` LinearProgress, or `null` when there is no
+   * buffer bar. MUI has no `aria-` attribute for the buffer, so it is derived from the
+   * second bar's `transform: translateX(-N%)` (buffer = 100 − N).
+   */
+  async getBufferValue(): Promise<number | null> {
+    const bufferBar = locatorUtil.append(this.locator, byCssClass('MuiLinearProgress-bar2Buffer'));
+    if (!(await this.interactor.exists(bufferBar))) {
+      return null;
+    }
+    const style = await this.interactor.getAttribute(bufferBar, 'style');
+    const match = style?.match(/translateX\(\s*(-?[\d.]+)%\)/);
+    if (match == null) {
+      return null;
+    }
+    return 100 + parseFloat(match[1]!);
+  }
 
   get driverName(): string {
     return 'MuiV6ProgressDriver';

--- a/packages/component-driver-mui-v6/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SelectDriver.ts
@@ -13,6 +13,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
   listHelper,
   locatorUtil,
   Nullable,
@@ -53,7 +54,10 @@ export interface MenuItemGetOption {
 }
 const optionLocator = byRole('option');
 
-export class SelectDriver extends ComponentDriver<SelectScenePart> implements IInputDriver<string | null> {
+export class SelectDriver
+  extends ComponentDriver<SelectScenePart>
+  implements IInputDriver<string | null>, IRequirableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -215,6 +219,29 @@ export class SelectDriver extends ComponentDriver<SelectScenePart> implements II
       // Cannot determine readonly state of a select input.
       return false;
     }
+  }
+
+  /**
+   * Whether the select is required. MUI mirrors the value into a hidden `<input>` that
+   * carries the native `required` attribute (the native select carries it directly).
+   */
+  async isRequired(): Promise<boolean> {
+    const isNative = await this.isNative();
+    const locator = isNative ? this.parts.nativeSelect.locator : this.parts.input.locator;
+    return (await this.interactor.getAttribute(locator, 'required')) != null;
+  }
+
+  /**
+   * The selected values of a `multiple` select as an array. MUI stores a multi-select's
+   * value as a comma-joined string in the hidden input (what {@link getValue} returns),
+   * so this splits it; an empty selection yields `[]`.
+   */
+  async getSelectedValues(): Promise<string[]> {
+    const value = await this.getValue();
+    if (value == null || value === '') {
+      return [];
+    }
+    return value.split(',');
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/SliderDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SliderDriver.ts
@@ -6,6 +6,7 @@ import {
   IInputDriver,
   Interactor,
   locatorUtil,
+  Optional,
   PartLocator,
   ScenePart,
   ScenePartDriver,
@@ -101,6 +102,66 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
     await this.enforcePartExistence('input');
     const disabled = await this.parts.input.isDisabled();
     return disabled;
+  }
+
+  /**
+   * The minimum value of the slider (the input's native `min` attribute).
+   */
+  async getMin(): Promise<number> {
+    await this.enforcePartExistence('input');
+    return parseFloat((await this.interactor.getAttribute(this.parts.input.locator, 'min'))!);
+  }
+
+  /**
+   * The maximum value of the slider (the input's native `max` attribute).
+   */
+  async getMax(): Promise<number> {
+    await this.enforcePartExistence('input');
+    return parseFloat((await this.interactor.getAttribute(this.parts.input.locator, 'max'))!);
+  }
+
+  /**
+   * The slider's step increment, or `null` when stepping is disabled (`step={null}`,
+   * i.e. the thumb may only land on marks).
+   */
+  async getStep(): Promise<number | null> {
+    await this.enforcePartExistence('input');
+    const step = await this.interactor.getAttribute(this.parts.input.locator, 'step');
+    const parsed = parseFloat(step!);
+    return isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * The accessible value text of the active thumb (`aria-valuetext`, set via
+   * `getAriaValueText`/`valueLabelFormat`), or `undefined` when none.
+   */
+  async getValueText(): Promise<Optional<string>> {
+    await this.enforcePartExistence('input');
+    return (await this.interactor.getAttribute(this.parts.input.locator, 'aria-valuetext')) ?? undefined;
+  }
+
+  /**
+   * The labels of the slider's marks, in document order. Returns `[]` when the slider
+   * has no labelled marks. Mark labels are addressed by their `data-index` (0,1,2,…)
+   * rather than `:nth-of-type`, because they are spans interleaved with the slider's
+   * other spans (rail/track/thumb) — a position `:nth-of-type` cannot express portably.
+   */
+  async getMarks(): Promise<string[]> {
+    const result: string[] = [];
+    for (let index = 0; ; index++) {
+      const markLocator = locatorUtil.append(
+        this.locator,
+        byCssSelector(`.MuiSlider-markLabel[data-index="${index}"]`)
+      );
+      if (!(await this.interactor.exists(markLocator))) {
+        break;
+      }
+      const text = await this.interactor.getText(markLocator);
+      if (text != null) {
+        result.push(text.trim());
+      }
+    }
+    return result;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/SwitchDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SwitchDriver.ts
@@ -3,8 +3,10 @@ import {
   byAttribute,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   PartLocator,
   ScenePart,
@@ -19,7 +21,7 @@ export const parts = {
 
 export class SwitchDriver
   extends ComponentDriver<typeof parts>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IDisableableDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -54,6 +56,14 @@ export class SwitchDriver
   async isReadonly(): Promise<boolean> {
     // MUI v5 does not have a readonly state for the switch
     return Promise.resolve(false);
+  }
+
+  /**
+   * Whether the switch is required (MUI sets the native `required` attribute on the input).
+   */
+  async isRequired(): Promise<boolean> {
+    await this.enforcePartExistence('input');
+    return (await this.interactor.getAttribute(this.parts.input.locator, 'required')) != null;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/TextFieldDriver.ts
@@ -7,6 +7,9 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
+  locatorUtil,
   Optional,
   PartLocator,
   ScenePart,
@@ -57,7 +60,10 @@ type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 /**
  * A driver for the Material UI v6 TextField component with single line or multiline text input.
  */
-export class TextFieldDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class TextFieldDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -65,7 +71,7 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
     });
   }
 
-  private async getInputType(): Promise<TextFieldInputType> {
+  async getInputType(): Promise<TextFieldInputType> {
     const result = await Promise.all([
       this.parts.singlelineInput.exists(),
       this.parts.richSelectInputDetect.exists(),
@@ -159,6 +165,50 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  /**
+   * Locator of the element that carries the native validation attributes
+   * (`required`, `aria-invalid`, `placeholder`). For text/multiline that is the
+   * visible input/textarea; for a select TextField it is the hidden value input.
+   */
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    switch (inputType) {
+      case 'singleLine':
+        return this.parts.singlelineInput.locator;
+      case 'multiline':
+        return this.parts.multilineInput.locator;
+      case 'select':
+        return locatorUtil.append(this.locator, byCssSelector('input'));
+    }
+  }
+
+  /**
+   * Whether the field is required. MUI sets the native `required` attribute on the
+   * underlying input (present with an empty value), so a first-class accessor saves
+   * consumers from reaching into the nested input themselves.
+   */
+  async isRequired(): Promise<boolean> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'required')) != null;
+  }
+
+  /**
+   * Whether the field is in the error state. MUI's `error` prop sets
+   * `aria-invalid="true"` on the underlying input.
+   */
+  async isError(): Promise<boolean> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'aria-invalid')) === 'true';
+  }
+
+  /**
+   * The input's placeholder text, or `undefined` when none is set.
+   */
+  async getPlaceholder(): Promise<Optional<string>> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'placeholder')) ?? undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v6/src/components/ToggleButtonGroupDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/ToggleButtonGroupDriver.ts
@@ -38,6 +38,53 @@ export class ToggleButtonGroupDriver extends ComponentDriver implements IInputDr
     return true;
   }
 
+  /**
+   * The number of toggle buttons in the group.
+   */
+  async getButtonCount(): Promise<number> {
+    return listHelper.getListItemCount(this, this.itemLocator);
+  }
+
+  /**
+   * Get the toggle button at the given zero-based index, or `null` if out of range.
+   */
+  async getButtonByIndex(index: number): Promise<ToggleButtonDriver | null> {
+    return listHelper.getListItemByIndex(this, this.itemLocator, index, ToggleButtonDriver);
+  }
+
+  /**
+   * Get the toggle button whose `value` matches, or `null` if none.
+   */
+  async getButtonByValue(value: string): Promise<ToggleButtonDriver | null> {
+    for await (const itemDriver of listHelper.getListItemIterator(this, this.itemLocator, ToggleButtonDriver)) {
+      if ((await itemDriver.getValue()) === value) {
+        return itemDriver;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the toggle button whose visible label (text content) matches, or `null` if none.
+   */
+  async getButtonByLabel(label: string): Promise<ToggleButtonDriver | null> {
+    for await (const itemDriver of listHelper.getListItemIterator(this, this.itemLocator, ToggleButtonDriver)) {
+      if ((await itemDriver.getText())?.trim() === label) {
+        return itemDriver;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Whether the option with the given `value` is disabled. Returns `false` when no such
+   * option exists.
+   */
+  async isOptionDisabled(value: string): Promise<boolean> {
+    const button = await this.getButtonByValue(value);
+    return button != null && (await button.isDisabled());
+  }
+
   get driverName(): string {
     return 'MuiV6ToggleButtonGroupDriver';
   }

--- a/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/AutoCompleteDriver.ts
@@ -120,6 +120,41 @@ export class AutoCompleteDriver extends ComponentDriver<typeof parts> implements
     return false;
   }
 
+  /**
+   * Open the popup (if closed) and return the visible option labels in order. Opens by
+   * clicking the input; returns `[]` when the popup renders no listbox (e.g. no options).
+   */
+  async getOptions(): Promise<string[]> {
+    if (!(await this.interactor.exists(this.parts.dropdown.locator))) {
+      await this.parts.input.click();
+    }
+    if (!(await this.interactor.exists(this.parts.dropdown.locator))) {
+      return [];
+    }
+    const optionItemLocator = locatorUtil.append(this.parts.dropdown.locator, optionLocator);
+    const result: string[] = [];
+    for await (const optionDriver of listHelper.getListItemIterator(this, optionItemLocator, HTMLElementDriver)) {
+      const text = await optionDriver.getText();
+      if (text != null) {
+        result.push(text.trim());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Clear the current selection via the clear (✕) indicator. The indicator is
+   * hover-gated, so the root is hovered first to reveal it; a no-op when there is
+   * nothing to clear (no clear indicator rendered).
+   */
+  async clear(): Promise<void> {
+    const clearButton = locatorUtil.append(this.locator, byCssClass('MuiAutocomplete-clearIndicator'));
+    if (await this.interactor.exists(clearButton)) {
+      await this.interactor.hover(this.locator);
+      await this.interactor.click(clearButton);
+    }
+  }
+
   async isDisabled(): Promise<boolean> {
     return this.parts.input.isDisabled();
   }

--- a/packages/component-driver-mui-v7/src/components/BadgeDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/BadgeDriver.ts
@@ -37,6 +37,35 @@ export class BadgeDriver extends ComponentDriver<typeof parts> {
     return content ?? null;
   }
 
+  /**
+   * Whether the badge bubble is currently hidden. The `.MuiBadge-badge` node is always
+   * mounted (so inherited `isVisible`/`getContent` cannot distinguish shown from hidden);
+   * MUI toggles visibility with the `MuiBadge-invisible` class.
+   */
+  async isInvisible(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.parts.contentDisplay.locator, 'MuiBadge-invisible');
+  }
+
+  /**
+   * Whether the badge bubble is currently shown (the badge node exists and is not
+   * marked invisible).
+   */
+  async isBadgeVisible(): Promise<boolean> {
+    const exists = await this.interactor.exists(this.parts.contentDisplay.locator);
+    if (!exists) {
+      return false;
+    }
+    return !(await this.isInvisible());
+  }
+
+  /**
+   * Whether the badge is a dot variant (`variant="dot"` → `MuiBadge-dot`), which renders
+   * a marker with no content.
+   */
+  async isDot(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.parts.contentDisplay.locator, 'MuiBadge-dot');
+  }
+
   override get driverName(): string {
     return 'MuiV7BadgeDriver';
   }

--- a/packages/component-driver-mui-v7/src/components/ButtonDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ButtonDriver.ts
@@ -1,13 +1,37 @@
 import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+import { IDisableableDriver } from '@atomic-testing/core';
 
 /**
  * Driver for Material UI v7 Button component.
  * @see https://mui.com/material-ui/react-button/
  */
-export class ButtonDriver extends HTMLButtonDriver {
+export class ButtonDriver extends HTMLButtonDriver implements IDisableableDriver {
   async getValue(): Promise<string | null> {
     const val = await this.interactor.getAttribute(this.locator, 'value');
     return val ?? null;
+  }
+
+  /**
+   * Whether the button is disabled. A MUI Button rendered as a `<button>` carries the
+   * native `disabled` attribute, but as an anchor/link-button (`href`) it cannot — it
+   * uses `aria-disabled` + the `Mui-disabled` class instead. Check all three so a
+   * visibly-disabled link button is not reported as enabled.
+   */
+  override async isDisabled(): Promise<boolean> {
+    const [nativeDisabled, ariaDisabled, muiDisabled] = await Promise.all([
+      this.interactor.getAttribute(this.locator, 'disabled'),
+      this.interactor.getAttribute(this.locator, 'aria-disabled'),
+      this.interactor.hasCssClass(this.locator, 'Mui-disabled'),
+    ]);
+    return nativeDisabled != null || ariaDisabled === 'true' || muiDisabled;
+  }
+
+  /**
+   * Whether the button is in the loading state. MUI v7 moved `loading` into the core
+   * Button, which adds the `MuiButton-loading` class and a `.MuiButton-loadingIndicator`.
+   */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, 'MuiButton-loading');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/CheckboxDriver.ts
@@ -4,8 +4,10 @@ import {
   byTagName,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   locatorUtil,
   Optional,
@@ -26,7 +28,7 @@ export type CheckboxScenePartDriver = ScenePartDriver<CheckboxScenePart>;
 
 export class CheckboxDriver
   extends ComponentDriver<CheckboxScenePart>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IDisableableDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -63,6 +65,13 @@ export class CheckboxDriver
 
   isReadonly(): Promise<boolean> {
     return this.parts.checkbox.isReadonly();
+  }
+
+  /**
+   * Whether the checkbox is required (MUI sets the native `required` attribute on the input).
+   */
+  async isRequired(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.parts.checkbox.locator, 'required')) != null;
   }
 
   /**

--- a/packages/component-driver-mui-v7/src/components/ChipDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ChipDriver.ts
@@ -4,6 +4,7 @@ import {
   byDataTestId,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   Interactor,
   PartLocator,
   ScenePart,
@@ -24,12 +25,20 @@ export const parts = {
  * Driver for Material UI v7 Chip component.
  * @see https://mui.com/material-ui/react-chip/
  */
-export class ChipDriver extends ComponentDriver<typeof parts> {
+export class ChipDriver extends ComponentDriver<typeof parts> implements IDisableableDriver {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
       parts: parts,
     });
+  }
+
+  /**
+   * Whether the chip is disabled. A Chip has no native form control; MUI marks the
+   * disabled state with the `Mui-disabled` class on the chip root.
+   */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasCssClass(this.locator, 'Mui-disabled');
   }
 
   /**

--- a/packages/component-driver-mui-v7/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/InputDriver.ts
@@ -5,6 +5,8 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
@@ -25,7 +27,10 @@ type TextFieldInputType = 'singleLine' | 'multiline';
 /**
  * A driver for the Material UI v7 Input, FilledInput, OutlinedInput, and StandardInput components.
  */
-export class InputDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class InputDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -101,6 +106,25 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    return inputType === 'singleLine' ? this.parts.singlelineInput.locator : this.parts.multilineInput.locator;
+  }
+
+  /**
+   * Whether the input is required (MUI sets the native `required` attribute).
+   */
+  async isRequired(): Promise<boolean> {
+    return (await this.interactor.getAttribute(await this.getValueInputLocator(), 'required')) != null;
+  }
+
+  /**
+   * Whether the input is in the error state (`error` prop → `aria-invalid="true"`).
+   */
+  async isError(): Promise<boolean> {
+    return (await this.interactor.getAttribute(await this.getValueInputLocator(), 'aria-invalid')) === 'true';
   }
 
   /**

--- a/packages/component-driver-mui-v7/src/components/MenuDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/MenuDriver.ts
@@ -59,6 +59,21 @@ export class MenuDriver extends ComponentDriver<typeof parts> {
     }
   }
 
+  /**
+   * The number of items (role `menuitem`) in the open menu.
+   */
+  async getMenuItemCount(): Promise<number> {
+    return listHelper.getListItemCount(this, menuItemLocator);
+  }
+
+  /**
+   * Get the menu item at the given zero-based index, or `null` if out of range.
+   * Complements the existing label-based {@link getMenuItemByLabel}.
+   */
+  async getMenuItemByIndex(index: number): Promise<MenuItemDriver | null> {
+    return listHelper.getListItemByIndex(this, menuItemLocator, index, MenuItemDriver);
+  }
+
   get driverName(): string {
     return 'MuiV7MenuDriver';
   }

--- a/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ProgressDriver.ts
@@ -1,13 +1,13 @@
-import { ComponentDriver } from '@atomic-testing/core';
+import { byCssClass, ComponentDriver, locatorUtil } from '@atomic-testing/core';
 
 /**
  * Driver for the Material UI v7 Progress components (`LinearProgress` / `CircularProgress`).
  *
  * A progress indicator is a read-only, non-interactive status component: it has no
  * user-settable value and renders no form controls. The driver therefore only reads
- * state (`getValue` from `aria-valuenow`, `getType`, `isDeterminate`) and deliberately
- * does NOT implement `IInputDriver` — an earlier version mistakenly modelled it on a
- * radio-group input, exposing a nonsensical `setValue`.
+ * state (`getValue` from `aria-valuenow`, `getType`, `isDeterminate`, `getBufferValue`) and
+ * deliberately does NOT implement `IInputDriver` — an earlier version mistakenly modelled it
+ * on a radio-group input, exposing a nonsensical `setValue`.
  *
  * @see https://mui.com/material-ui/react-progress/
  */
@@ -34,9 +34,23 @@ export class ProgressDriver extends ComponentDriver {
     return val != null;
   }
 
-  // The buffer value of variant="buffer" (derivable from the bar2 transform,
-  // e.g. style="transform: translateX(-15%)" → 85) is not yet exposed; tracked
-  // as getBufferValue in the state-accessor work (#872).
+  /**
+   * The buffer value of a `variant="buffer"` LinearProgress, or `null` when there is no
+   * buffer bar. MUI has no `aria-` attribute for the buffer, so it is derived from the
+   * second bar's `transform: translateX(-N%)` (buffer = 100 − N).
+   */
+  async getBufferValue(): Promise<number | null> {
+    const bufferBar = locatorUtil.append(this.locator, byCssClass('MuiLinearProgress-bar2Buffer'));
+    if (!(await this.interactor.exists(bufferBar))) {
+      return null;
+    }
+    const style = await this.interactor.getAttribute(bufferBar, 'style');
+    const match = style?.match(/translateX\(\s*(-?[\d.]+)%\)/);
+    if (match == null) {
+      return null;
+    }
+    return 100 + parseFloat(match[1]!);
+  }
 
   get driverName(): string {
     return 'MuiV7ProgressDriver';

--- a/packages/component-driver-mui-v7/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SelectDriver.ts
@@ -13,6 +13,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
   listHelper,
   locatorUtil,
   Nullable,
@@ -53,7 +54,10 @@ export interface MenuItemGetOption {
 }
 const optionLocator = byRole('option');
 
-export class SelectDriver extends ComponentDriver<SelectScenePart> implements IInputDriver<string | null> {
+export class SelectDriver
+  extends ComponentDriver<SelectScenePart>
+  implements IInputDriver<string | null>, IRequirableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -215,6 +219,29 @@ export class SelectDriver extends ComponentDriver<SelectScenePart> implements II
       // Cannot determine readonly state of a select input.
       return false;
     }
+  }
+
+  /**
+   * Whether the select is required. MUI mirrors the value into a hidden `<input>` that
+   * carries the native `required` attribute (the native select carries it directly).
+   */
+  async isRequired(): Promise<boolean> {
+    const isNative = await this.isNative();
+    const locator = isNative ? this.parts.nativeSelect.locator : this.parts.input.locator;
+    return (await this.interactor.getAttribute(locator, 'required')) != null;
+  }
+
+  /**
+   * The selected values of a `multiple` select as an array. MUI stores a multi-select's
+   * value as a comma-joined string in the hidden input (what {@link getValue} returns),
+   * so this splits it; an empty selection yields `[]`.
+   */
+  async getSelectedValues(): Promise<string[]> {
+    const value = await this.getValue();
+    if (value == null || value === '') {
+      return [];
+    }
+    return value.split(',');
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/SliderDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SliderDriver.ts
@@ -6,6 +6,7 @@ import {
   IInputDriver,
   Interactor,
   locatorUtil,
+  Optional,
   PartLocator,
   ScenePart,
   ScenePartDriver,
@@ -101,6 +102,66 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
     await this.enforcePartExistence('input');
     const disabled = await this.parts.input.isDisabled();
     return disabled;
+  }
+
+  /**
+   * The minimum value of the slider (the input's native `min` attribute).
+   */
+  async getMin(): Promise<number> {
+    await this.enforcePartExistence('input');
+    return parseFloat((await this.interactor.getAttribute(this.parts.input.locator, 'min'))!);
+  }
+
+  /**
+   * The maximum value of the slider (the input's native `max` attribute).
+   */
+  async getMax(): Promise<number> {
+    await this.enforcePartExistence('input');
+    return parseFloat((await this.interactor.getAttribute(this.parts.input.locator, 'max'))!);
+  }
+
+  /**
+   * The slider's step increment, or `null` when stepping is disabled (`step={null}`,
+   * i.e. the thumb may only land on marks).
+   */
+  async getStep(): Promise<number | null> {
+    await this.enforcePartExistence('input');
+    const step = await this.interactor.getAttribute(this.parts.input.locator, 'step');
+    const parsed = parseFloat(step!);
+    return isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * The accessible value text of the active thumb (`aria-valuetext`, set via
+   * `getAriaValueText`/`valueLabelFormat`), or `undefined` when none.
+   */
+  async getValueText(): Promise<Optional<string>> {
+    await this.enforcePartExistence('input');
+    return (await this.interactor.getAttribute(this.parts.input.locator, 'aria-valuetext')) ?? undefined;
+  }
+
+  /**
+   * The labels of the slider's marks, in document order. Returns `[]` when the slider
+   * has no labelled marks. Mark labels are addressed by their `data-index` (0,1,2,…)
+   * rather than `:nth-of-type`, because they are spans interleaved with the slider's
+   * other spans (rail/track/thumb) — a position `:nth-of-type` cannot express portably.
+   */
+  async getMarks(): Promise<string[]> {
+    const result: string[] = [];
+    for (let index = 0; ; index++) {
+      const markLocator = locatorUtil.append(
+        this.locator,
+        byCssSelector(`.MuiSlider-markLabel[data-index="${index}"]`)
+      );
+      if (!(await this.interactor.exists(markLocator))) {
+        break;
+      }
+      const text = await this.interactor.getText(markLocator);
+      if (text != null) {
+        result.push(text.trim());
+      }
+    }
+    return result;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/SwitchDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SwitchDriver.ts
@@ -3,8 +3,10 @@ import {
   byAttribute,
   ComponentDriver,
   IComponentDriverOption,
+  IDisableableDriver,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   PartLocator,
   ScenePart,
@@ -19,7 +21,7 @@ export const parts = {
 
 export class SwitchDriver
   extends ComponentDriver<typeof parts>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IDisableableDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -54,6 +56,14 @@ export class SwitchDriver
   async isReadonly(): Promise<boolean> {
     // MUI v5 does not have a readonly state for the switch
     return Promise.resolve(false);
+  }
+
+  /**
+   * Whether the switch is required (MUI sets the native `required` attribute on the input).
+   */
+  async isRequired(): Promise<boolean> {
+    await this.enforcePartExistence('input');
+    return (await this.interactor.getAttribute(this.parts.input.locator, 'required')) != null;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/TextFieldDriver.ts
@@ -7,6 +7,9 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
+  locatorUtil,
   Optional,
   PartLocator,
   ScenePart,
@@ -57,7 +60,10 @@ type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 /**
  * A driver for the Material UI v7 TextField component with single line or multiline text input.
  */
-export class TextFieldDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class TextFieldDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -65,7 +71,7 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
     });
   }
 
-  private async getInputType(): Promise<TextFieldInputType> {
+  async getInputType(): Promise<TextFieldInputType> {
     const result = await Promise.all([
       this.parts.singlelineInput.exists(),
       this.parts.richSelectInputDetect.exists(),
@@ -159,6 +165,50 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  /**
+   * Locator of the element that carries the native validation attributes
+   * (`required`, `aria-invalid`, `placeholder`). For text/multiline that is the
+   * visible input/textarea; for a select TextField it is the hidden value input.
+   */
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    switch (inputType) {
+      case 'singleLine':
+        return this.parts.singlelineInput.locator;
+      case 'multiline':
+        return this.parts.multilineInput.locator;
+      case 'select':
+        return locatorUtil.append(this.locator, byCssSelector('input'));
+    }
+  }
+
+  /**
+   * Whether the field is required. MUI sets the native `required` attribute on the
+   * underlying input (present with an empty value), so a first-class accessor saves
+   * consumers from reaching into the nested input themselves.
+   */
+  async isRequired(): Promise<boolean> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'required')) != null;
+  }
+
+  /**
+   * Whether the field is in the error state. MUI's `error` prop sets
+   * `aria-invalid="true"` on the underlying input.
+   */
+  async isError(): Promise<boolean> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'aria-invalid')) === 'true';
+  }
+
+  /**
+   * The input's placeholder text, or `undefined` when none is set.
+   */
+  async getPlaceholder(): Promise<Optional<string>> {
+    const locator = await this.getValueInputLocator();
+    return (await this.interactor.getAttribute(locator, 'placeholder')) ?? undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v7/src/components/ToggleButtonGroupDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/ToggleButtonGroupDriver.ts
@@ -38,6 +38,53 @@ export class ToggleButtonGroupDriver extends ComponentDriver implements IInputDr
     return true;
   }
 
+  /**
+   * The number of toggle buttons in the group.
+   */
+  async getButtonCount(): Promise<number> {
+    return listHelper.getListItemCount(this, this.itemLocator);
+  }
+
+  /**
+   * Get the toggle button at the given zero-based index, or `null` if out of range.
+   */
+  async getButtonByIndex(index: number): Promise<ToggleButtonDriver | null> {
+    return listHelper.getListItemByIndex(this, this.itemLocator, index, ToggleButtonDriver);
+  }
+
+  /**
+   * Get the toggle button whose `value` matches, or `null` if none.
+   */
+  async getButtonByValue(value: string): Promise<ToggleButtonDriver | null> {
+    for await (const itemDriver of listHelper.getListItemIterator(this, this.itemLocator, ToggleButtonDriver)) {
+      if ((await itemDriver.getValue()) === value) {
+        return itemDriver;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the toggle button whose visible label (text content) matches, or `null` if none.
+   */
+  async getButtonByLabel(label: string): Promise<ToggleButtonDriver | null> {
+    for await (const itemDriver of listHelper.getListItemIterator(this, this.itemLocator, ToggleButtonDriver)) {
+      if ((await itemDriver.getText())?.trim() === label) {
+        return itemDriver;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Whether the option with the given `value` is disabled. Returns `false` when no such
+   * option exists.
+   */
+  async isOptionDisabled(value: string): Promise<boolean> {
+    const button = await this.getButtonByValue(value);
+    return button != null && (await button.isDisabled());
+  }
+
   get driverName(): string {
     return 'MuiV7ToggleButtonGroupDriver';
   }

--- a/packages/core/src/drivers/driverTypes.ts
+++ b/packages/core/src/drivers/driverTypes.ts
@@ -13,6 +13,29 @@ export interface IToggleDriver {
   setSelected(selected: boolean): Promise<void>;
 }
 
+/**
+ * A driver whose component can be disabled. Implemented uniformly so the obvious
+ * assertion `expect(await driver.isDisabled()).toBe(true)` works across components,
+ * rather than each consumer reaching into a component-specific attribute or class.
+ */
+export interface IDisableableDriver {
+  isDisabled(): Promise<boolean>;
+}
+
+/**
+ * A driver whose component can be marked required (a form control).
+ */
+export interface IRequirableDriver {
+  isRequired(): Promise<boolean>;
+}
+
+/**
+ * A driver whose component can be in an invalid/error state (a form control).
+ */
+export interface IValidatableDriver {
+  isError(): Promise<boolean>;
+}
+
 export interface IClickableDriver {
   click(option?: ClickOption): Promise<void>;
 }

--- a/packages/core/src/drivers/index.ts
+++ b/packages/core/src/drivers/index.ts
@@ -2,10 +2,13 @@ export { ComponentDriver } from './ComponentDriver';
 export { ContainerDriver } from './ContainerDriver';
 export type {
   IClickableDriver,
+  IDisableableDriver,
   IFormFieldDriver,
   IInputDriver,
   IMouseInteractableDriver,
+  IRequirableDriver,
   IToggleDriver,
+  IValidatableDriver,
 } from './driverTypes';
 export type { ListComponentDriverOption, ListComponentDriverSpecificOption } from './ListComponentDriver';
 export { ListComponentDriver } from './ListComponentDriver';


### PR DESCRIPTION

Adds first-class state accessors so the obvious assertion (e.g. isRequired/isError/isDisabled/
isLoading) can be written without reaching into a component's nested input or class names. Three
shared mixin interfaces in core keep the behavior uniform, and the long tail of per-component
gaps from the audit is closed in the same pass. Verified in jsdom (v6 + v7) and Playwright
(v7, chromium/firefox/webkit) via a new State Accessors example plus targeted suite additions.

## Key Changes

- core: add IDisableableDriver/IRequirableDriver/IValidatableDriver; add isRequired/isError/
  getPlaceholder/getInputType to TextField & Input, isRequired to Checkbox/Switch/Select, and
  Select getSelectedValues.
- Button isLoading + link-button-aware isDisabled; Chip isDisabled; Badge isDot/isInvisible/
  isBadgeVisible; ToggleButtonGroup per-option access + isOptionDisabled; Menu getMenuItemByIndex/
  getMenuItemCount.
- Slider getMin/getMax/getStep/getMarks/getValueText; Progress getBufferValue; AutoComplete
  getOptions/clear.

Closes #872
