### PR TITLE
test(component-driver-mui): re-enable v6 e2e webServer now that boot is unblocked

### DIFF
--- a/package-tests/component-driver-mui-v6-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-v6-test/playwright.config.ts
@@ -85,11 +85,13 @@ export default defineConfig({
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   // outputDir: 'test-results/',
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'pnpm start',
-  //   timeout: 120 * 1000,
-  //   url: baseUrl,
-  //   reuseExistingServer: true,
-  // },
+  /* Run your local dev server before starting the tests. Re-enabled now that the
+   * Vite 8 / Rolldown dep-optimizer regression that left #root empty (#877) no longer
+   * reproduces — the app boots and v6 e2e runs across chromium/firefox/webkit. */
+  webServer: {
+    command: 'pnpm start',
+    timeout: 120 * 1000,
+    url: baseUrl,
+    reuseExistingServer: true,
+  },
 });


### PR DESCRIPTION

The MUI v6 Playwright e2e was reported blocked by a Vite 8 / Rolldown dep-optimizer regression
that left #root empty ("init_emotion_react_browser_development_esm is not defined"). On the
current toolchain (Vite 8.0.16) the app boots cleanly and v6 e2e runs green across chromium,
firefox and webkit — verified with a cold dep cache — so no dep-optimizer workaround is needed.
Re-enable the commented-out webServer block so v6 e2e is self-contained again.

## Key Changes

- Re-enable the `webServer` block in the v6 test package's playwright.config.ts so
  `pnpm test:e2e` (and CI) auto-starts the Vite dev server and waits for it.

Closes #877
