### PR TITLE
fix(component-driver-mui): v9 Rating clear and fractional setValue

### DIFF
--- a/package-tests/component-driver-mui-v9-test/src/examples/rating/Rating.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/rating/Rating.suite.ts
@@ -54,6 +54,18 @@ export const basicRatingTestSuite: TestSuiteInfo<typeof basicRatingExample.scene
       assertEqual(value, 4);
     });
 
+    test('Can set a fractional rating value', async () => {
+      await engine().parts.basic.setValue(3.5);
+      const value = await engine().parts.basic.getValue();
+      assertEqual(value, 3.5);
+    });
+
+    test('Can clear the rating to null', async () => {
+      await engine().parts.basic.setValue(null);
+      const value = await engine().parts.basic.getValue();
+      assertEqual(value, null);
+    });
+
     test('Readonly rating should exist', async () => {
       const exists = await engine().parts.readonly.exists();
       assertTrue(exists);

--- a/packages/component-driver-mui-v9/src/components/RatingDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/RatingDriver.ts
@@ -1,7 +1,6 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
 import {
   byCssClass,
-  byCssSelector,
   byInputType,
   byValue,
   ComponentDriver,
@@ -92,24 +91,17 @@ export class RatingDriver extends ComponentDriver<typeof parts> implements IInpu
       return true;
     }
 
-    // Clearing (value == null) reuses MUI's "click the selected star again to
-    // reset" behaviour by re-clicking the current value's label. This resets the
-    // rating in real browsers but not in jsdom, where MUI's clear path depends on
-    // pointer coordinates that jsdom does not provide; the empty radio (`value=""`)
-    // that jsdom could click has no `<label>` and is not reliably clickable in
-    // browsers. A fully portable clear needs a coordinate-free click primitive on
-    // the Interactor. TODO(#68): revisit once that primitive exists.
-    const valueToClick = value ?? currentValue;
-    if (valueToClick == null) {
-      return true;
-    }
-
-    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(valueToClick.toString(), 'Same'));
+    // Activate the visually-hidden `<input type="radio">` whose `value` attribute
+    // matches the target — the empty-string radio (MUI's "no rating") for a clear.
+    // `activate` is coordinate-free, so it reaches inputs a positional click cannot:
+    // the half-star label for fractional values is zero-width and unclickable in a
+    // real browser (#86), and the clear radio has no `<label>` at all (#68). This
+    // unifies integer, fractional, and clear on one portable path.
+    const targetValue = value == null ? '' : value.toString();
+    const targetLocator = locatorUtil.append(this.parts.choices.locator, byValue(targetValue, 'Same'));
     const targetExists = await this.interactor.exists(targetLocator);
     if (targetExists) {
-      const id = await this.interactor.getAttribute(targetLocator, 'id');
-      const labelLocator = locatorUtil.append(this.locator, byCssSelector(`label[for="${id}"]`));
-      await this.interactor.click(labelLocator);
+      await this.interactor.activate(targetLocator);
     }
     // TODO: throw error if the value does not exist
     return targetExists;


### PR DESCRIPTION

The v9 RatingDriver still set values by clicking a star's `<label>`, which cannot
reach MUI's zero-width half-star label (fractional) or the label-less "no rating"
radio (clear) in a real browser. Route setValue through the coordinate-free
`activate` primitive instead, matching the v6/v7 drivers, so integer, fractional,
and clear all resolve on one portable path proven in jsdom and all three browsers.

## Key Changes

- v9 RatingDriver.setValue now activates the hidden `<input type="radio">` whose
  `value` matches the target (empty string for a clear), dropping the label click.
- Add v9 suite coverage for fractional (`setValue(3.5)`) and clear (`setValue(null)`).

Closes #68
Closes #86

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
