### PR TITLE
feat: add setRangeValue primitive and MUI v6/v7 Slider setValue

### DIFF
--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -50,6 +50,7 @@ Package: [@atomic-testing/component-driver-html](https://github.com/atomic-testi
 | HTMLHiddenInputDriver      | Driver for `<input type="hidden">` elements                               |
 | HTMLOptionDriver           | Driver for `<option>` elements                                            |
 | HTMLRadioButtonGroupDriver | Driver for a group of HTML radio buttons                                  |
+| HTMLRangeInputDriver       | Driver for `<input type="range">` (slider) elements                       |
 | HTMLSelectDriver           | Driver for `<select>` element, support both single and multiple selection |
 | HTMLTextInputDriver        | Driver for `<input type="text">` elements                                 |
 | HTMLTextAreaDriver         | Driver for `<textarea>` elements                                          |

--- a/package-tests/component-driver-html-test/__tests__/HTMLRangeInputDriver.dom.test.ts
+++ b/package-tests/component-driver-html-test/__tests__/HTMLRangeInputDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { rangeInputExample, rangeInputExampleTestSuite } from '../src/examples';
+
+testRunner(rangeInputExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof rangeInputExample.scene) => {
+    return createTestEngine(rangeInputExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-html-test/__tests__/HTMLRangeInputDriver.e2e.test.ts
+++ b/package-tests/component-driver-html-test/__tests__/HTMLRangeInputDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { rangeInputExampleTestSuite } from '../src/examples';
+
+testRunner(rangeInputExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-html-test/src/directory.tsx
+++ b/package-tests/component-driver-html-test/src/directory.tsx
@@ -17,6 +17,7 @@ import { hoverMouseEventUIExample } from './examples/mouseEvent/Hover.examples';
 import { mouseLocationMouseEventUIExample } from './examples/mouseEvent/MouseLocation.examples';
 import { mouseOverMouseEventUIExample } from './examples/mouseEvent/MouseOver.examples';
 import { uncontrolledRadioButtonGroupUIExample } from './examples/radioButtonGroup/Uncontrolled.examples';
+import { rangeInputUIExample } from './examples/rangeInput/RangeInput.examples';
 import { scrollUIExample } from './examples/scroll/Scroll.examples';
 import { multipleSelectUIExample } from './examples/select/MultipleSelect.examples';
 import { singleSelectUIExample } from './examples/select/SingleSelect.examples';
@@ -71,6 +72,11 @@ export const tocs: ExampleToc[] = [
     label: 'Activate',
     path: '/activate',
     ui: <ExampleList examples={[activateUIExample]} />,
+  },
+  {
+    label: 'Range Input',
+    path: '/range-input',
+    ui: <ExampleList examples={[rangeInputUIExample]} />,
   },
   {
     label: 'Context Menu',

--- a/package-tests/component-driver-html-test/src/examples/index.ts
+++ b/package-tests/component-driver-html-test/src/examples/index.ts
@@ -9,6 +9,7 @@ export * from './input';
 export * from './keyboardEvent';
 export * from './mouseEvent';
 export * from './radioButtonGroup';
+export * from './rangeInput';
 export * from './scroll';
 export * from './select';
 export * from './anchor';

--- a/package-tests/component-driver-html-test/src/examples/rangeInput/RangeInput.examples.tsx
+++ b/package-tests/component-driver-html-test/src/examples/rangeInput/RangeInput.examples.tsx
@@ -1,0 +1,48 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX, useCallback } from 'react';
+
+// Two independent step=1 range inputs, each echoing its value into a sibling
+// <div>. The echo proves a change event actually fired (the controlled state
+// updated), not merely that the value attribute was poked; two instances catch a
+// too-broad locator that would drive the wrong slider.
+export const RangeInputExample = () => {
+  const [primary, setPrimary] = React.useState(20);
+  const [secondary, setSecondary] = React.useState(10);
+
+  const primary_onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setPrimary(Number(e.target.value));
+  }, []);
+  const secondary_onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSecondary(Number(e.target.value));
+  }, []);
+
+  return (
+    <React.Fragment>
+      <input
+        data-testid='range-primary'
+        type='range'
+        min={0}
+        max={100}
+        step={1}
+        value={primary}
+        onChange={primary_onChange}
+      />
+      <div data-testid='range-primary-value'>{primary}</div>
+      <input
+        data-testid='range-secondary'
+        type='range'
+        min={0}
+        max={100}
+        step={1}
+        value={secondary}
+        onChange={secondary_onChange}
+      />
+      <div data-testid='range-secondary-value'>{secondary}</div>
+    </React.Fragment>
+  );
+};
+
+export const rangeInputUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Range input (slider)',
+  ui: <RangeInputExample />,
+};

--- a/package-tests/component-driver-html-test/src/examples/rangeInput/RangeInput.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/rangeInput/RangeInput.suite.ts
@@ -1,0 +1,58 @@
+import { HTMLElementDriver, HTMLRangeInputDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { rangeInputUIExample } from './RangeInput.examples';
+
+export const rangeInputExampleScenePart = {
+  primary: {
+    locator: byDataTestId('range-primary'),
+    driver: HTMLRangeInputDriver,
+  },
+  primaryValue: {
+    locator: byDataTestId('range-primary-value'),
+    driver: HTMLElementDriver,
+  },
+  secondary: {
+    locator: byDataTestId('range-secondary'),
+    driver: HTMLRangeInputDriver,
+  },
+  secondaryValue: {
+    locator: byDataTestId('range-secondary-value'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const rangeInputExample: IExampleUnit<typeof rangeInputExampleScenePart, JSX.Element> = {
+  ...rangeInputUIExample,
+  scene: rangeInputExampleScenePart,
+};
+
+export const rangeInputExampleTestSuite: TestSuiteInfo<typeof rangeInputExample.scene> = {
+  title: 'Range input: setRangeValue primitive',
+  url: '/range-input',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${rangeInputExample.title}`, () => {
+      const engine = useTestEngine(rangeInputExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`Reads the initial value`, async () => {
+        assertEqual(await engine().parts.primary.getValue(), 20);
+      });
+
+      test(`setValue updates the value and fires change`, async () => {
+        await engine().parts.primary.setValue(40);
+        assertEqual(await engine().parts.primary.getValue(), 40);
+        // The echoed text confirms the controlled onChange ran, not just an attribute poke.
+        assertEqual(await engine().parts.primaryValue.getText(), '40');
+      });
+
+      test(`setValue targets one slider without disturbing its sibling`, async () => {
+        await engine().parts.primary.setValue(40);
+        await engine().parts.secondary.setValue(70);
+        assertEqual(await engine().parts.primary.getValue(), 40);
+        assertEqual(await engine().parts.secondary.getValue(), 70);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-html-test/src/examples/rangeInput/index.ts
+++ b/package-tests/component-driver-html-test/src/examples/rangeInput/index.ts
@@ -1,0 +1,8 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { rangeInputExample, rangeInputExampleTestSuite } from './RangeInput.suite';
+
+export { rangeInputExample, rangeInputExampleTestSuite };
+
+export const rangeInputExamples = [rangeInputExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-v6-test/src/examples/slider/BasicSlider.suite.ts
+++ b/package-tests/component-driver-mui-v6-test/src/examples/slider/BasicSlider.suite.ts
@@ -48,10 +48,16 @@ export const basicSliderTestSuite: TestSuiteInfo<typeof basicSliderExampleSceneP
       assertTrue(await engine().parts.range.exists());
     });
 
-    test.skip('it should be able to set value on basic slider', async () => {
+    test('it should be able to set value on basic slider', async () => {
       await engine().parts.basic.setValue(50);
       const value = await engine().parts.basic.getValue();
       assertEqual(value, 50);
+    });
+
+    test('it should set every thumb of a range slider in order', async () => {
+      await engine().parts.range.setRangeValues([20, 70]);
+      const values = await engine().parts.range.getRangeValues();
+      assertEqual(values, [20, 70]);
     });
   },
 };

--- a/package-tests/component-driver-mui-v7-test/src/examples/slider/BasicSlider.suite.ts
+++ b/package-tests/component-driver-mui-v7-test/src/examples/slider/BasicSlider.suite.ts
@@ -48,10 +48,16 @@ export const basicSliderTestSuite: TestSuiteInfo<typeof basicSliderExampleSceneP
       assertTrue(await engine().parts.range.exists());
     });
 
-    test.skip('it should be able to set value on basic slider', async () => {
+    test('it should be able to set value on basic slider', async () => {
       await engine().parts.basic.setValue(50);
       const value = await engine().parts.basic.getValue();
       assertEqual(value, 50);
+    });
+
+    test('it should set every thumb of a range slider in order', async () => {
+      await engine().parts.range.setRangeValues([20, 70]);
+      const values = await engine().parts.range.getRangeValues();
+      assertEqual(values, [20, 70]);
     });
   },
 };

--- a/packages/component-driver-html/src/components/HTMLRangeInputDriver.ts
+++ b/packages/component-driver-html/src/components/HTMLRangeInputDriver.ts
@@ -1,0 +1,57 @@
+import { ComponentDriver, IComponentDriverOption, IInputDriver, Interactor, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for a range input (`<input type="range">`), the native control behind a
+ * slider. The value is read from the input's `value` property (the browser-stable
+ * source for the *current* value — unlike the `value` attribute, which keeps the
+ * initial value after a programmatic change) and written through the dedicated
+ * {@link Interactor.setRangeValue} primitive, since a range input accepts no typed
+ * text and a positional click yields only a coordinate-derived value.
+ */
+export class HTMLRangeInputDriver extends ComponentDriver<{}> implements IInputDriver<number> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts: {},
+    });
+  }
+
+  /**
+   * Read the current value of the range input.
+   */
+  async getValue(): Promise<number> {
+    const value = await this.interactor.getInputValue(this.locator);
+    return Number.parseFloat(value ?? '');
+  }
+
+  /**
+   * Set the value of the range input. The browser snaps an off-step target to the
+   * nearest valid step; jsdom stores it verbatim. Pass a step-aligned value for
+   * assertions that must hold in both environments.
+   */
+  async setValue(value: number): Promise<boolean> {
+    await this.interactor.setRangeValue(this.locator, value);
+    return true;
+  }
+
+  /**
+   * Check whether the range input is disabled.
+   */
+  isDisabled(): Promise<boolean> {
+    return this.interactor.isDisabled(this.locator);
+  }
+
+  /**
+   * Check whether the range input is read only.
+   */
+  isReadonly(): Promise<boolean> {
+    return this.interactor.isReadonly(this.locator);
+  }
+
+  /**
+   * Identifier for this driver.
+   */
+  get driverName(): string {
+    return 'HTMLRangeInput';
+  }
+}

--- a/packages/component-driver-html/src/index.ts
+++ b/packages/component-driver-html/src/index.ts
@@ -7,6 +7,7 @@ export { HTMLFileInputDriver } from './components/HTMLFileInputDriver';
 export { HTMLHiddenInputDriver } from './components/HTMLHiddenInputDriver';
 export { HTMLOptionDriver } from './components/HTMLOptionDriver';
 export { HTMLRadioButtonGroupDriver } from './components/HTMLRadioButtonGroupDriver';
+export { HTMLRangeInputDriver } from './components/HTMLRangeInputDriver';
 export { HTMLSelectDriver } from './components/HTMLSelectDriver';
 export { HTMLTextAreaDriver } from './components/HTMLTextAreaDriver';
 export { HTMLTextInputDriver } from './components/HTMLTextInputDriver';

--- a/packages/component-driver-mui-v6/src/components/SliderDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/SliderDriver.ts
@@ -40,13 +40,18 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
   }
 
   /**
-   * Set slider's range value.  Do not use as it will throw an error
-   * @param values
-   * @see https://github.com/atomic-testing/atomic-testing/issues/73
+   * Set the slider's value by driving its range input to the target.
+   *
+   * The value is applied through the {@link Interactor.setRangeValue} primitive,
+   * so the browser snaps an off-step target to the slider's nearest step. On a
+   * multi-thumb (range) slider this sets the first thumb only; use
+   * {@link setRangeValues} to set every thumb.
+   *
+   * @param value The target value; snapped to the slider's step in-browser
+   * @returns Whether the slider's input was found and set
    */
   async setValue(value: number): Promise<boolean> {
-    const success = await this.setRangeValues([value]);
-    return success;
+    return this.setRangeValues([value]);
   }
 
   async getRangeValues(count?: number): Promise<readonly number[]> {
@@ -61,7 +66,9 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
       if (exists) {
         index++;
         done = count != null && index >= count;
-        const value = await this.interactor.getAttribute(locator, 'value');
+        // Read the value *property* (not the `value` attribute, which keeps the
+        // initial value after a programmatic change in real browsers).
+        const value = await this.interactor.getInputValue(locator);
         result.push(parseFloat(value!));
       } else {
         done = true;
@@ -75,27 +82,28 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
   }
 
   /**
-   * Set slider's range values.  Do not use as it will throw an error
-   * @param values
-   * @see https://github.com/atomic-testing/atomic-testing/issues/73
+   * Set every thumb of the slider, one `value` per thumb in document order.
+   *
+   * Each thumb's range input is driven through the {@link Interactor.setRangeValue}
+   * primitive, so the browser snaps an off-step target to the slider's nearest
+   * step. Thumbs are set in index order and MUI clamps a thumb at its neighbor, so
+   * pass already-ordered, non-crossing values (e.g. `[20, 70]`, not `[70, 20]`).
+   *
+   * @param values One target per thumb, lowest thumb first
+   * @returns `true` once every thumb was set; `false` if more values than thumbs
+   *   were supplied (a missing thumb input stops the run)
    */
-  async setRangeValues(_values: readonly number[]): Promise<boolean> {
+  async setRangeValues(values: readonly number[]): Promise<boolean> {
     await this.enforcePartExistence('input');
-    throw new Error('setRangeValue is not supported.');
-    // for (let index = 0; index < values.length; index++) {
-    //   const locator = locatorUtil.append(this.locator, this.getInputLocator(index));
-    //   const exists = await this.interactor.exists(locator);
-    //   if (exists) {
-    //     // @ts-ignore
-    //     await this.interactor.changeValue(locator, values[index].toString());
-    //     // const driver = new HTMLTextInputDriver(locator, this.interactor);
-    //     // await driver.setValue(values[index].toString());
-    //   } else {
-    //     return false;
-    //   }
-    // }
-
-    // return true;
+    for (let index = 0; index < values.length; index++) {
+      const locator = locatorUtil.append(this.locator, this.getInputLocator(index));
+      const exists = await this.interactor.exists(locator);
+      if (!exists) {
+        return false;
+      }
+      await this.interactor.setRangeValue(locator, values[index]!);
+    }
+    return true;
   }
 
   async isDisabled(): Promise<boolean> {

--- a/packages/component-driver-mui-v7/src/components/SliderDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/SliderDriver.ts
@@ -40,13 +40,18 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
   }
 
   /**
-   * Set slider's range value.  Do not use as it will throw an error
-   * @param values
-   * @see https://github.com/atomic-testing/atomic-testing/issues/73
+   * Set the slider's value by driving its range input to the target.
+   *
+   * The value is applied through the {@link Interactor.setRangeValue} primitive,
+   * so the browser snaps an off-step target to the slider's nearest step. On a
+   * multi-thumb (range) slider this sets the first thumb only; use
+   * {@link setRangeValues} to set every thumb.
+   *
+   * @param value The target value; snapped to the slider's step in-browser
+   * @returns Whether the slider's input was found and set
    */
   async setValue(value: number): Promise<boolean> {
-    const success = await this.setRangeValues([value]);
-    return success;
+    return this.setRangeValues([value]);
   }
 
   async getRangeValues(count?: number): Promise<readonly number[]> {
@@ -61,7 +66,9 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
       if (exists) {
         index++;
         done = count != null && index >= count;
-        const value = await this.interactor.getAttribute(locator, 'value');
+        // Read the value *property* (not the `value` attribute, which keeps the
+        // initial value after a programmatic change in real browsers).
+        const value = await this.interactor.getInputValue(locator);
         result.push(parseFloat(value!));
       } else {
         done = true;
@@ -75,27 +82,28 @@ export class SliderDriver extends ComponentDriver<SelectScenePart> implements II
   }
 
   /**
-   * Set slider's range values.  Do not use as it will throw an error
-   * @param values
-   * @see https://github.com/atomic-testing/atomic-testing/issues/73
+   * Set every thumb of the slider, one `value` per thumb in document order.
+   *
+   * Each thumb's range input is driven through the {@link Interactor.setRangeValue}
+   * primitive, so the browser snaps an off-step target to the slider's nearest
+   * step. Thumbs are set in index order and MUI clamps a thumb at its neighbor, so
+   * pass already-ordered, non-crossing values (e.g. `[20, 70]`, not `[70, 20]`).
+   *
+   * @param values One target per thumb, lowest thumb first
+   * @returns `true` once every thumb was set; `false` if more values than thumbs
+   *   were supplied (a missing thumb input stops the run)
    */
-  async setRangeValues(_values: readonly number[]): Promise<boolean> {
+  async setRangeValues(values: readonly number[]): Promise<boolean> {
     await this.enforcePartExistence('input');
-    throw new Error('setRangeValue is not supported.');
-    // for (let index = 0; index < values.length; index++) {
-    //   const locator = locatorUtil.append(this.locator, this.getInputLocator(index));
-    //   const exists = await this.interactor.exists(locator);
-    //   if (exists) {
-    //     // @ts-ignore
-    //     await this.interactor.changeValue(locator, values[index].toString());
-    //     // const driver = new HTMLTextInputDriver(locator, this.interactor);
-    //     // await driver.setValue(values[index].toString());
-    //   } else {
-    //     return false;
-    //   }
-    // }
-
-    // return true;
+    for (let index = 0; index < values.length; index++) {
+      const locator = locatorUtil.append(this.locator, this.getInputLocator(index));
+      const exists = await this.interactor.exists(locator);
+      if (!exists) {
+        return false;
+      }
+      await this.interactor.setRangeValue(locator, values[index]!);
+    }
+    return true;
   }
 
   async isDisabled(): Promise<boolean> {

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -123,6 +123,27 @@ export interface Interactor {
   enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void>;
 
   /**
+   * Set the value of a range input (`<input type="range">`, the element behind a
+   * slider) and fire its change so the host framework reacts.
+   *
+   * A dedicated primitive exists because a range input cannot be driven through
+   * {@link enterText} (it accepts no typed text) nor reliably through {@link click}
+   * (a positional click on the track sets a coordinate-derived, not an exact,
+   * value). The value is assigned through the element's native value setter — so
+   * the browser sanitizes it to the input's `min`/`max`/`step`, snapping an
+   * off-step target to the nearest valid step — and an `input`/`change` event is
+   * dispatched so controlled components (e.g. MUI Slider) update their state.
+   *
+   * jsdom has no range sanitization, so it stores an off-step value verbatim
+   * whereas a real browser snaps it; pass a step-aligned `value` for assertions
+   * that must hold in both environments. See #73.
+   *
+   * @param locator Locator of the `<input type="range">` element
+   * @param value The numeric value to set; sanitized to the input's step in-browser
+   */
+  setRangeValue(locator: PartLocator, value: number): Promise<void>;
+
+  /**
    * Select option by value from a select element
    * @param locator
    * @param values

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -426,6 +426,27 @@ export class DOMInteractor implements Interactor {
   }
 
   /**
+   * Set the value of a range input and fire its change event.
+   *
+   * `fireEvent.change` assigns the value through the element's native value
+   * setter (which both sanitizes it to the input's step and lets React's value
+   * tracker observe the change) and dispatches the event so a controlled
+   * component re-renders. Typing (`enterText`) does not apply to a range input.
+   *
+   * @param locator - Locator used to find the range input element
+   * @param value - The numeric value to set
+   * @returns Promise resolved once the change event has fired
+   * @throws {ElementNotFoundError} If the element is not found
+   */
+  async setRangeValue(locator: PartLocator, value: number): Promise<void> {
+    const el = await this.getElement(locator);
+    if (el == null) {
+      throw new ElementNotFoundError(locator, 'setRangeValue');
+    }
+    fireEvent.change(el, { target: { value: String(value) } });
+  }
+
+  /**
    * Select one or more option values in a `<select>` element.
    *
    * @param locator - Locator used to find the select element

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -220,6 +220,23 @@ export class PlaywrightInteractor implements Interactor {
     await this.page.locator(cssLocator).fill(text);
   }
 
+  async setRangeValue(locator: PartLocator, value: number): Promise<void> {
+    const cssLocator = await locatorUtil.toCssSelector(locator, this);
+    // Playwright's `fill` rejects `<input type="range">` (it is not a fillable
+    // text control), so set the value in-page through the native value setter.
+    // Calling the prototype setter both sanitizes the value to the input's step
+    // (the browser snaps an off-step target to the nearest valid step) and lets
+    // React's value tracker observe the change; the dispatched input/change
+    // events then drive a controlled component (e.g. MUI Slider) to re-render.
+    await this.page.locator(cssLocator).evaluate((el, nextValue) => {
+      const input = el as HTMLInputElement;
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(input, nextValue);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }, String(value));
+  }
+
   async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
     await this.page.locator(cssLocator).click({ position: option?.position });

--- a/packages/react-core/src/ReactInteractor.ts
+++ b/packages/react-core/src/ReactInteractor.ts
@@ -28,6 +28,12 @@ export class ReactInteractor extends DOMInteractor {
     });
   }
 
+  override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
+    await act(async () => {
+      await super.setRangeValue(locator, value);
+    });
+  }
+
   override async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
     await act(async () => {
       await super.click(locator, option);

--- a/packages/vue-3/src/VueInteractor.ts
+++ b/packages/vue-3/src/VueInteractor.ts
@@ -31,6 +31,11 @@ export class VueInteractor extends DOMInteractor {
     await this.flush();
   }
 
+  override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
+    await super.setRangeValue(locator, value);
+    await this.flush();
+  }
+
   override async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
     await super.click(locator, option);
     await this.flush();


### PR DESCRIPTION

MUI v6/v7 SliderDriver.setValue and setRangeValues threw — a slider had no portable
way to be set, since a range input rejects typed text and a positional click yields
only a coordinate-derived value. Add a coordinate-free setRangeValue Interactor
primitive (native value set + change event, in DOM/React/Vue/Playwright) and route the
Slider drivers through it: thumbs are set in order and the browser snaps an off-step
target to the nearest step. Proven in jsdom and all three browsers via a new
HTMLRangeInputDriver and the MUI Slider suites.

## Key Changes

- Add Interactor.setRangeValue across core + all four interactors; export a new
  HTMLRangeInputDriver and prove it at the HTML-driver layer (dom + e2e).
- Implement MUI v6/v7 SliderDriver.setValue/setRangeValues; read the current value
  from the input's value property (browser-stable) instead of the value attribute.
- Un-skip the Slider suites and add single- and range-thumb set coverage.

Closes #73

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
