### PR TITLE
feat(astryx): add nav, display, chat & overlay component drivers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,26 @@ cd docs && pnpm build           # Build documentation (test before doc PRs)
 
 > **Toolchain note:** Type-_checking_ uses `tsgo` (TypeScript 7 beta / native port, `@typescript/native-preview`). Builds, `.d.ts` emit (tsdown), and TypeDoc still use the classic TypeScript compiler (`typescript@^6.0`) because the native preview has no programmatic API yet. Linting is oxlint (replaced ESLint); formatting is oxfmt (replaced Prettier + `@trivago/prettier-plugin-sort-imports`).
 
+**Build before you test (stale-`dist` trap):** every test runner resolves
+`@atomic-testing/*` imports to that package's built **`dist`**, never its `src` —
+jest via `moduleNameMapper` (see [`jest.config.base.js`](jest.config.base.js)),
+Vite/Playwright via the package's `exports`. So a source edit is invisible both to
+the package's own `test:dom`/`test:e2e` **and** to any other package's tests that
+import it, until you `pnpm run build` that package **and every changed dependency**
+(most often `core`). A stale `dist` silently runs the _old_ code with no error — a
+real trap when verifying a fix: e.g. an out-of-date `core` kept a `childListHelper`
+enumeration that stopped at the first non-matching child, truncating list counts so
+a green test was meaningless. Rebuild the touched packages (and `core`) before
+trusting any dom/e2e result. (`tsgo` also reads the stale `.d.ts`, so cross-package
+typecheck errors that name newly-added exports usually just mean "rebuild," not a
+real bug.)
+
 ### Running E2E Tests
 
-E2E tests require the dev server to be running first:
+E2E tests require the dev server (rebuild the driver packages first — see the
+stale-`dist` trap above; the served examples come from `src`, but the drivers they
+import come from `dist`). The `component-driver-astryx-test` Playwright config
+auto-starts/stops the server itself; other packages start it manually:
 
 ```bash
 cd package-tests/component-driver-html-test

--- a/docs/docs/guides/astryx-driver-coverage.md
+++ b/docs/docs/guides/astryx-driver-coverage.md
@@ -1,0 +1,118 @@
+---
+id: astryx-driver-coverage
+sidebar_label: Astryx driver coverage
+sidebar_position: 2
+---
+
+# Astryx driver coverage matrix
+
+[`@atomic-testing/component-driver-astryx`](https://www.npmjs.com/package/@atomic-testing/component-driver-astryx)
+provides component drivers for [Astryx](https://github.com/facebook/astryx)
+(`@astryxdesign/core`). Astryx styles with **StyleX**, whose class names are
+build-time hashed and therefore _not_ stable anchors — so every driver locates by
+**role / accessible name / `data-*` / `data-testid`**, never by a StyleX class.
+
+## How to read coverage
+
+Each driver is exercised by one shared suite that runs in **two worlds**:
+
+- **DOM (jsdom)** — fast, structural. Faithful for anything expressed as markup or
+  attributes: `data-*`, `aria-*`, text, `[open]`/`aria-expanded`/`aria-current`,
+  typed entry.
+- **E2E (Playwright)** — Chromium, Firefox, WebKit. Required for behavior jsdom
+  cannot model: the **native Popover API** (`showPopover`), layout/geometry,
+  scroll/virtualization, the clipboard, file pickers, and image loading.
+
+A behavior tagged **E2E-only** below is real but only _observable_ in a browser;
+the jsdom suite asserts the structural/closed-state facts that hold in both worlds,
+and the driver's JSDoc names the gap. **Best-effort v1** marks a driver whose
+anchor is structurally fragile (documented inline) pending an upstream change.
+
+## Coverage — display, typography & feedback
+
+All DOM + E2E (Chromium/Firefox/WebKit).
+
+| Component   | Driver              | E2E-only behavior                                                                                 |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------- |
+| Badge       | `BadgeDriver`       | —                                                                                                 |
+| Text        | `TextDriver`        | truncation tooltip                                                                                |
+| Heading     | `HeadingDriver`     | truncation tooltip                                                                                |
+| Code        | `CodeDriver`        | —                                                                                                 |
+| Blockquote  | `BlockquoteDriver`  | —                                                                                                 |
+| Timestamp   | `TimestampDriver`   | relative-time tooltip & live updates; `data-format` lives on the wrapper, read via a sibling part |
+| Divider     | `DividerDriver`     | —                                                                                                 |
+| EmptyState  | `EmptyStateDriver`  | —                                                                                                 |
+| ProgressBar | `ProgressBarDriver` | — (role switches `meter`↔`progressbar` with determinacy)                                          |
+| Spinner     | `SpinnerDriver`     | — (testid placement is conditional on a label)                                                    |
+| NavIcon     | `NavIconDriver`     | —                                                                                                 |
+| Item        | `ItemDriver`        | —                                                                                                 |
+| Markdown    | `MarkdownDriver`    | copy-code (clipboard)                                                                             |
+| CodeBlock   | `CodeBlockDriver`   | copy-code button `aria-label` flip (clipboard)                                                    |
+
+## Coverage — media & status
+
+| Component   | Driver              | E2E-only behavior                                                    |
+| ----------- | ------------------- | -------------------------------------------------------------------- |
+| StatusDot   | `StatusDotDriver`   | hover tooltip                                                        |
+| Citation    | `CitationDriver`    | —                                                                    |
+| Token       | `TokenDriver`       | disabled state (class-only — not exposed)                            |
+| Avatar      | `AvatarDriver`      | image load-failure → initials fallback (jsdom never fires `onError`) |
+| AvatarGroup | `AvatarGroupDriver` | —                                                                    |
+| Thumbnail   | `ThumbnailDriver`   | hover tooltip & lightbox preview                                     |
+
+## Coverage — nav chrome
+
+| Component      | Driver                 | E2E-only behavior                                                           |
+| -------------- | ---------------------- | --------------------------------------------------------------------------- |
+| TopNav         | `TopNavDriver`         | —                                                                           |
+| TopNavItem     | `TopNavItemDriver`     | —                                                                           |
+| TopNavMenu     | `TopNavMenuDriver`     | menu **open** (native popover); items read while closed via `aria-controls` |
+| TopNavMegaMenu | `TopNavMegaMenuDriver` | panel **open** (native popover); best-effort single-instance scope          |
+| Breadcrumbs    | `BreadcrumbsDriver`    | —                                                                           |
+| SideNav        | `SideNavDriver`        | collapsed visual state                                                      |
+| SideNavItem    | `SideNavItemDriver`    | flyout (collapsed mode)                                                     |
+| MobileNav      | `MobileNavDriver`      | `dialog[open]` (set by `showModal`)                                         |
+
+## Coverage — chat suite
+
+| Component           | Driver                      | E2E-only behavior                                                                  |
+| ------------------- | --------------------------- | ---------------------------------------------------------------------------------- |
+| ChatMessage         | `ChatMessageDriver`         | — (`getName` omitted: the name has only a generated-`id` `aria-labelledby` anchor) |
+| ChatMessageBubble   | `ChatMessageBubbleDriver`   | —                                                                                  |
+| ChatMessageList     | `ChatMessageListDriver`     | auto-scroll                                                                        |
+| ChatSystemMessage   | `ChatSystemMessageDriver`   | —                                                                                  |
+| ChatToolCalls       | `ChatToolCallsDriver`       | —                                                                                  |
+| ChatLayout          | `ChatLayoutDriver`          | scroll-to-bottom button                                                            |
+| ChatSendButton      | `ChatSendButtonDriver`      | —                                                                                  |
+| ChatDictationButton | `ChatDictationButtonDriver` | live dictation (Web Speech API; mock the `dictation` prop)                         |
+
+## Coverage — hard set (best-effort v1)
+
+These shipped against the now-landed Wave 0 primitives (`contextMenu`,
+`setInputFiles`) or via structural workarounds; each names its blocking dependency
+inline.
+
+| Component         | Driver                    | v1 scope & blocking dependency                                                                                                                                                                                           |
+| ----------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FileInput         | `FileInputDriver`         | read-side state + `uploadFiles` (via `setInputFiles`). File-chip readback and dropzone drag-and-drop are E2E-only/consumer-`value`-controlled.                                                                           |
+| ContextMenu       | `ContextMenuDriver`       | opens via the right-click primitive; items read at the document root. **`isOpen` is E2E-only** — the trigger exposes no open-state ARIA. Single-instance per scene.                                                      |
+| AppShell          | `AppShellDriver`          | confirms landmark regions + variant, delegates to child drivers. Responsive collapse / mobile drawer are E2E-only.                                                                                                       |
+| ChatComposerInput | `ChatComposerInputDriver` | `contenteditable`: value via `textContent`, **append-only typing** (`userEvent.clear` throws; `getInputValue` returns `null`). Suggestion menu open is E2E-only.                                                         |
+| ChatComposer      | `ChatComposerDriver`      | wraps the composer input + send/stop button + status. Enter-to-send is E2E-only.                                                                                                                                         |
+| HoverCard         | `HoverCardDriver`         | content via the trigger's `aria-describedby` → layer `id`. **Open state is E2E-only** (no role/testid/open attr on the layer). Tracked upstream: [facebook/astryx#3240](https://github.com/facebook/astryx/issues/3240). |
+| Tooltip           | `TooltipDriver`           | same anchor/limitation as HoverCard. Tracked upstream: [facebook/astryx#3240](https://github.com/facebook/astryx/issues/3240).                                                                                           |
+
+## Earlier waves
+
+Buttons, inputs, toggles, selection controls, overlays/menus, selectors,
+date/time pickers, lists, tables and trees (Waves 1–3) are fully covered with
+DOM + E2E. See the package's `src/index.ts` for the complete export list; overlay
+open/close behavior follows the [Portals & overlays](./portal-and-overlays.md) recipe.
+
+## Out of scope (no driver)
+
+Astryx context providers, style-only modules, and pure layout boxes
+(`FormLayout`, `Layer`, `Stack`/`HStack`/`VStack`, `Grid`, `Center`, `Section`,
+`Card`, `Skeleton`, `Kbd`, `Icon`, `OverflowList`, …) expose no testable widget
+surface and intentionally get **no** driver — assert them incidentally through the
+existing `HTMLElement` driver on a `byDataTestId`/`byCssClass` anchor.

--- a/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { appShellExample, appShellExampleTestSuite } from '../src/examples';
+
+testRunner(appShellExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof appShellExample.scene) => {
+    return createTestEngine(appShellExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { appShellExampleTestSuite } from '../src/examples';
+
+testRunner(appShellExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { avatarExample, avatarExampleTestSuite } from '../src/examples';
+
+testRunner(avatarExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof avatarExample.scene) => {
+    return createTestEngine(avatarExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { avatarExampleTestSuite } from '../src/examples';
+
+testRunner(avatarExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { avatarGroupExample, avatarGroupExampleTestSuite } from '../src/examples';
+
+testRunner(avatarGroupExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof avatarGroupExample.scene) => {
+    return createTestEngine(avatarGroupExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { avatarGroupExampleTestSuite } from '../src/examples';
+
+testRunner(avatarGroupExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { badgeExample, badgeExampleTestSuite } from '../src/examples';
+
+testRunner(badgeExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof badgeExample.scene) => {
+    return createTestEngine(badgeExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { badgeExampleTestSuite } from '../src/examples';
+
+testRunner(badgeExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { blockquoteExample, blockquoteExampleTestSuite } from '../src/examples';
+
+testRunner(blockquoteExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof blockquoteExample.scene) => {
+    return createTestEngine(blockquoteExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { blockquoteExampleTestSuite } from '../src/examples';
+
+testRunner(blockquoteExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { breadcrumbsExample, breadcrumbsExampleTestSuite } from '../src/examples';
+
+testRunner(breadcrumbsExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof breadcrumbsExample.scene) => {
+    return createTestEngine(breadcrumbsExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { breadcrumbsExampleTestSuite } from '../src/examples';
+
+testRunner(breadcrumbsExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatComposerExample, chatComposerExampleTestSuite } from '../src/examples';
+
+testRunner(chatComposerExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatComposerExample.scene) => {
+    return createTestEngine(chatComposerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatComposerExampleTestSuite } from '../src/examples';
+
+testRunner(chatComposerExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatComposerInputExample, chatComposerInputExampleTestSuite } from '../src/examples';
+
+testRunner(chatComposerInputExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatComposerInputExample.scene) => {
+    return createTestEngine(chatComposerInputExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatComposerInputExampleTestSuite } from '../src/examples';
+
+testRunner(chatComposerInputExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatDictationButtonExample, chatDictationButtonExampleTestSuite } from '../src/examples';
+
+testRunner(chatDictationButtonExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatDictationButtonExample.scene) => {
+    return createTestEngine(chatDictationButtonExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatDictationButtonExampleTestSuite } from '../src/examples';
+
+testRunner(chatDictationButtonExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatLayoutExample, chatLayoutExampleTestSuite } from '../src/examples';
+
+testRunner(chatLayoutExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatLayoutExample.scene) => {
+    return createTestEngine(chatLayoutExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatLayoutExampleTestSuite } from '../src/examples';
+
+testRunner(chatLayoutExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatMessageBubbleExample, chatMessageBubbleExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageBubbleExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatMessageBubbleExample.scene) => {
+    return createTestEngine(chatMessageBubbleExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatMessageBubbleExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageBubbleExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatMessageExample, chatMessageExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatMessageExample.scene) => {
+    return createTestEngine(chatMessageExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatMessageExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatMessageListExample, chatMessageListExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageListExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatMessageListExample.scene) => {
+    return createTestEngine(chatMessageListExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatMessageListExampleTestSuite } from '../src/examples';
+
+testRunner(chatMessageListExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatSendButtonExample, chatSendButtonExampleTestSuite } from '../src/examples';
+
+testRunner(chatSendButtonExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatSendButtonExample.scene) => {
+    return createTestEngine(chatSendButtonExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatSendButtonExampleTestSuite } from '../src/examples';
+
+testRunner(chatSendButtonExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatSystemMessageExample, chatSystemMessageExampleTestSuite } from '../src/examples';
+
+testRunner(chatSystemMessageExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatSystemMessageExample.scene) => {
+    return createTestEngine(chatSystemMessageExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatSystemMessageExampleTestSuite } from '../src/examples';
+
+testRunner(chatSystemMessageExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chatToolCallsExample, chatToolCallsExampleTestSuite } from '../src/examples';
+
+testRunner(chatToolCallsExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chatToolCallsExample.scene) => {
+    return createTestEngine(chatToolCallsExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { chatToolCallsExampleTestSuite } from '../src/examples';
+
+testRunner(chatToolCallsExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/CitationDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CitationDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { citationExample, citationExampleTestSuite } from '../src/examples';
+
+testRunner(citationExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof citationExample.scene) => {
+    return createTestEngine(citationExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/CitationDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CitationDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { citationExampleTestSuite } from '../src/examples';
+
+testRunner(citationExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { codeBlockExample, codeBlockExampleTestSuite } from '../src/examples';
+
+testRunner(codeBlockExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof codeBlockExample.scene) => {
+    return createTestEngine(codeBlockExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { codeBlockExampleTestSuite } from '../src/examples';
+
+testRunner(codeBlockExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/CodeDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { codeExample, codeExampleTestSuite } from '../src/examples';
+
+testRunner(codeExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof codeExample.scene) => {
+    return createTestEngine(codeExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/CodeDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { codeExampleTestSuite } from '../src/examples';
+
+testRunner(codeExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { contextMenuExample, contextMenuExampleTestSuite } from '../src/examples';
+
+testRunner(contextMenuExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof contextMenuExample.scene) => {
+    return createTestEngine(contextMenuExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { contextMenuExampleTestSuite } from '../src/examples';
+
+testRunner(contextMenuExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/DividerDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/DividerDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { dividerExample, dividerExampleTestSuite } from '../src/examples';
+
+testRunner(dividerExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof dividerExample.scene) => {
+    return createTestEngine(dividerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/DividerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/DividerDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { dividerExampleTestSuite } from '../src/examples';
+
+testRunner(dividerExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { emptyStateExample, emptyStateExampleTestSuite } from '../src/examples';
+
+testRunner(emptyStateExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof emptyStateExample.scene) => {
+    return createTestEngine(emptyStateExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { emptyStateExampleTestSuite } from '../src/examples';
+
+testRunner(emptyStateExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { fileInputExample, fileInputExampleTestSuite } from '../src/examples';
+
+testRunner(fileInputExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof fileInputExample.scene) => {
+    return createTestEngine(fileInputExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { fileInputExampleTestSuite } from '../src/examples';
+
+testRunner(fileInputExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { headingExample, headingExampleTestSuite } from '../src/examples';
+
+testRunner(headingExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof headingExample.scene) => {
+    return createTestEngine(headingExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { headingExampleTestSuite } from '../src/examples';
+
+testRunner(headingExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { hoverCardExample, hoverCardExampleTestSuite } from '../src/examples';
+
+testRunner(hoverCardExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof hoverCardExample.scene) => {
+    return createTestEngine(hoverCardExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { hoverCardExampleTestSuite } from '../src/examples';
+
+testRunner(hoverCardExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ItemDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ItemDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { itemExample, itemExampleTestSuite } from '../src/examples';
+
+testRunner(itemExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof itemExample.scene) => {
+    return createTestEngine(itemExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ItemDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { itemExampleTestSuite } from '../src/examples';
+
+testRunner(itemExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { markdownExample, markdownExampleTestSuite } from '../src/examples';
+
+testRunner(markdownExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof markdownExample.scene) => {
+    return createTestEngine(markdownExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { markdownExampleTestSuite } from '../src/examples';
+
+testRunner(markdownExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { mobileNavExample, mobileNavExampleTestSuite } from '../src/examples';
+
+testRunner(mobileNavExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof mobileNavExample.scene) => {
+    return createTestEngine(mobileNavExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { mobileNavExampleTestSuite } from '../src/examples';
+
+testRunner(mobileNavExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { navIconExample, navIconExampleTestSuite } from '../src/examples';
+
+testRunner(navIconExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof navIconExample.scene) => {
+    return createTestEngine(navIconExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { navIconExampleTestSuite } from '../src/examples';
+
+testRunner(navIconExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { progressBarExample, progressBarExampleTestSuite } from '../src/examples';
+
+testRunner(progressBarExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof progressBarExample.scene) => {
+    return createTestEngine(progressBarExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { progressBarExampleTestSuite } from '../src/examples';
+
+testRunner(progressBarExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { sideNavExample, sideNavExampleTestSuite } from '../src/examples';
+
+testRunner(sideNavExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof sideNavExample.scene) => {
+    return createTestEngine(sideNavExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { sideNavExampleTestSuite } from '../src/examples';
+
+testRunner(sideNavExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { sideNavItemExample, sideNavItemExampleTestSuite } from '../src/examples';
+
+testRunner(sideNavItemExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof sideNavItemExample.scene) => {
+    return createTestEngine(sideNavItemExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { sideNavItemExampleTestSuite } from '../src/examples';
+
+testRunner(sideNavItemExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { spinnerExample, spinnerExampleTestSuite } from '../src/examples';
+
+testRunner(spinnerExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof spinnerExample.scene) => {
+    return createTestEngine(spinnerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { spinnerExampleTestSuite } from '../src/examples';
+
+testRunner(spinnerExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { statusDotExample, statusDotExampleTestSuite } from '../src/examples';
+
+testRunner(statusDotExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof statusDotExample.scene) => {
+    return createTestEngine(statusDotExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { statusDotExampleTestSuite } from '../src/examples';
+
+testRunner(statusDotExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TextDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TextDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { textExample, textExampleTestSuite } from '../src/examples';
+
+testRunner(textExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof textExample.scene) => {
+    return createTestEngine(textExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TextDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TextDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { textExampleTestSuite } from '../src/examples';
+
+testRunner(textExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { thumbnailExample, thumbnailExampleTestSuite } from '../src/examples';
+
+testRunner(thumbnailExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof thumbnailExample.scene) => {
+    return createTestEngine(thumbnailExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { thumbnailExampleTestSuite } from '../src/examples';
+
+testRunner(thumbnailExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { timestampExample, timestampExampleTestSuite } from '../src/examples';
+
+testRunner(timestampExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof timestampExample.scene) => {
+    return createTestEngine(timestampExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { timestampExampleTestSuite } from '../src/examples';
+
+testRunner(timestampExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TokenDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TokenDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { tokenExample, tokenExampleTestSuite } from '../src/examples';
+
+testRunner(tokenExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof tokenExample.scene) => {
+    return createTestEngine(tokenExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TokenDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TokenDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { tokenExampleTestSuite } from '../src/examples';
+
+testRunner(tokenExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { tooltipExample, tooltipExampleTestSuite } from '../src/examples';
+
+testRunner(tooltipExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof tooltipExample.scene) => {
+    return createTestEngine(tooltipExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { tooltipExampleTestSuite } from '../src/examples';
+
+testRunner(tooltipExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { topNavExample, topNavExampleTestSuite } from '../src/examples';
+
+testRunner(topNavExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof topNavExample.scene) => {
+    return createTestEngine(topNavExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { topNavExampleTestSuite } from '../src/examples';
+
+testRunner(topNavExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { topNavItemExample, topNavItemExampleTestSuite } from '../src/examples';
+
+testRunner(topNavItemExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof topNavItemExample.scene) => {
+    return createTestEngine(topNavItemExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { topNavItemExampleTestSuite } from '../src/examples';
+
+testRunner(topNavItemExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { topNavMegaMenuExample, topNavMegaMenuExampleTestSuite } from '../src/examples';
+
+testRunner(topNavMegaMenuExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof topNavMegaMenuExample.scene) => {
+    return createTestEngine(topNavMegaMenuExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { topNavMegaMenuExampleTestSuite } from '../src/examples';
+
+testRunner(topNavMegaMenuExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { topNavMenuExample, topNavMenuExampleTestSuite } from '../src/examples';
+
+testRunner(topNavMenuExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof topNavMenuExample.scene) => {
+    return createTestEngine(topNavMenuExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.e2e.test.ts
@@ -1,0 +1,6 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+
+import { topNavMenuExampleTestSuite } from '../src/examples';
+
+testRunner(topNavMenuExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/src/directory.tsx
+++ b/package-tests/component-driver-astryx-test/src/directory.tsx
@@ -3,51 +3,100 @@ import { ExampleList, ExampleToc } from '@atomic-testing/internal-react-example'
 import { JSX } from 'react';
 
 import { alertDialogUIExample } from './examples/alert-dialog/AlertDialog.examples';
+import { appShellUIExample } from './examples/app-shell/AppShell.examples';
+import { avatarGroupUIExample } from './examples/avatar-group/AvatarGroup.examples';
+import { avatarUIExample } from './examples/avatar/Avatar.examples';
+// Wave 4 — display & typography
+import { badgeUIExample } from './examples/badge/Badge.examples';
 import { bannerUIExample } from './examples/banner/Banner.examples';
+import { blockquoteUIExample } from './examples/blockquote/Blockquote.examples';
+import { breadcrumbsUIExample } from './examples/breadcrumbs/Breadcrumbs.examples';
 import { buttonGroupUIExample } from './examples/button-group/ButtonGroup.examples';
 import { buttonUIExample } from './examples/button/Button.examples';
 import { calendarUIExample } from './examples/calendar/Calendar.examples';
 import { carouselUIExample } from './examples/carousel/Carousel.examples';
+import { chatComposerInputUIExample } from './examples/chat-composer-input/ChatComposerInput.examples';
+import { chatComposerUIExample } from './examples/chat-composer/ChatComposer.examples';
+import { chatDictationButtonUIExample } from './examples/chat-dictation-button/ChatDictationButton.examples';
+import { chatLayoutUIExample } from './examples/chat-layout/ChatLayout.examples';
+import { chatMessageBubbleUIExample } from './examples/chat-message-bubble/ChatMessageBubble.examples';
+import { chatMessageListUIExample } from './examples/chat-message-list/ChatMessageList.examples';
+// Wave 4 — chat suite
+import { chatMessageUIExample } from './examples/chat-message/ChatMessage.examples';
+import { chatSendButtonUIExample } from './examples/chat-send-button/ChatSendButton.examples';
+import { chatSystemMessageUIExample } from './examples/chat-system-message/ChatSystemMessage.examples';
+import { chatToolCallsUIExample } from './examples/chat-tool-calls/ChatToolCalls.examples';
 import { checkboxInputUIExample } from './examples/checkbox-input/CheckboxInput.examples';
 import { checkboxListUIExample } from './examples/checkbox-list/CheckboxList.examples';
+import { citationUIExample } from './examples/citation/Citation.examples';
+import { codeBlockUIExample } from './examples/code-block/CodeBlock.examples';
+import { codeUIExample } from './examples/code/Code.examples';
 import { collapsibleUIExample } from './examples/collapsible/Collapsible.examples';
 import { commandPaletteUIExample } from './examples/command-palette/CommandPalette.examples';
+import { contextMenuUIExample } from './examples/context-menu/ContextMenu.examples';
 import { dateInputUIExample } from './examples/date-input/DateInput.examples';
 import { dateRangeInputUIExample } from './examples/date-range-input/DateRangeInput.examples';
 import { dateTimeInputUIExample } from './examples/date-time-input/DateTimeInput.examples';
 import { dialogUIExample } from './examples/dialog/Dialog.examples';
+import { dividerUIExample } from './examples/divider/Divider.examples';
 import { dropdownMenuUIExample } from './examples/dropdown-menu/DropdownMenu.examples';
+// Wave 4 — feedback & misc
+import { emptyStateUIExample } from './examples/empty-state/EmptyState.examples';
 import { fieldStatusUIExample } from './examples/field-status/FieldStatus.examples';
 import { fieldUIExample } from './examples/field/Field.examples';
+// Wave 4 — hard set (best-effort v1)
+import { fileInputUIExample } from './examples/file-input/FileInput.examples';
+import { headingUIExample } from './examples/heading/Heading.examples';
+import { hoverCardUIExample } from './examples/hover-card/HoverCard.examples';
 import { iconButtonUIExample } from './examples/icon-button/IconButton.examples';
 import { inputGroupUIExample } from './examples/input-group/InputGroup.examples';
+import { itemUIExample } from './examples/item/Item.examples';
 import { linkUIExample } from './examples/link/Link.examples';
 import { listUIExample } from './examples/list/List.examples';
+import { markdownUIExample } from './examples/markdown/Markdown.examples';
 import { metadataListUIExample } from './examples/metadata-list/MetadataList.examples';
+import { mobileNavUIExample } from './examples/mobile-nav/MobileNav.examples';
 import { moreMenuUIExample } from './examples/more-menu/MoreMenu.examples';
 import { multiSelectorUIExample } from './examples/multi-selector/MultiSelector.examples';
+import { navIconUIExample } from './examples/nav-icon/NavIcon.examples';
 import { navMenuUIExample } from './examples/nav-menu/NavMenu.examples';
 import { numberInputUIExample } from './examples/number-input/NumberInput.examples';
 import { outlineUIExample } from './examples/outline/Outline.examples';
 import { paginationUIExample } from './examples/pagination/Pagination.examples';
 import { popoverUIExample } from './examples/popover/Popover.examples';
 import { powerSearchUIExample } from './examples/power-search/PowerSearch.examples';
+import { progressBarUIExample } from './examples/progress-bar/ProgressBar.examples';
 import { radioListUIExample } from './examples/radio-list/RadioList.examples';
 import { segmentedControlUIExample } from './examples/segmented-control/SegmentedControl.examples';
 import { selectableCardUIExample } from './examples/selectable-card/SelectableCard.examples';
 import { selectorUIExample } from './examples/selector/Selector.examples';
+import { sideNavItemUIExample } from './examples/side-nav-item/SideNavItem.examples';
+import { sideNavUIExample } from './examples/side-nav/SideNav.examples';
 import { sliderUIExample } from './examples/slider/Slider.examples';
+import { spinnerUIExample } from './examples/spinner/Spinner.examples';
+// Wave 4 — media & status
+import { statusDotUIExample } from './examples/status-dot/StatusDot.examples';
 import { switchControlUIExample } from './examples/switch/Switch.examples';
 import { tabListUIExample } from './examples/tab-list/TabList.examples';
 import { tableUIExample } from './examples/table/Table.examples';
 import { textAreaUIExample } from './examples/text-area/TextArea.examples';
 import { textInputUIExample } from './examples/text-input/TextInput.examples';
+import { textUIExample } from './examples/text/Text.examples';
+import { thumbnailUIExample } from './examples/thumbnail/Thumbnail.examples';
 import { timeInputUIExample } from './examples/time-input/TimeInput.examples';
+import { timestampUIExample } from './examples/timestamp/Timestamp.examples';
 import { toastUIExample } from './examples/toast/Toast.examples';
 import { toggleButtonGroupUIExample } from './examples/toggle-button-group/ToggleButtonGroup.examples';
 import { toggleButtonUIExample } from './examples/toggle-button/ToggleButton.examples';
+import { tokenUIExample } from './examples/token/Token.examples';
 import { tokenizerUIExample } from './examples/tokenizer/Tokenizer.examples';
 import { toolbarUIExample } from './examples/toolbar/Toolbar.examples';
+import { tooltipUIExample } from './examples/tooltip/Tooltip.examples';
+import { topNavItemUIExample } from './examples/top-nav-item/TopNavItem.examples';
+import { topNavMegaMenuUIExample } from './examples/top-nav-mega-menu/TopNavMegaMenu.examples';
+import { topNavMenuUIExample } from './examples/top-nav-menu/TopNavMenu.examples';
+// Wave 4 — nav chrome
+import { topNavUIExample } from './examples/top-nav/TopNav.examples';
 import { treeListUIExample } from './examples/tree-list/TreeList.examples';
 import { typeaheadUIExample } from './examples/typeahead/Typeahead.examples';
 
@@ -106,4 +155,53 @@ export const tocs: ExampleToc[] = [
   toc('DateTimeInput', '/date-time-input', dateTimeInputUIExample),
   toc('DateRangeInput', '/date-range-input', dateRangeInputUIExample),
   toc('PowerSearch', '/power-search', powerSearchUIExample),
+  // Wave 4 — display & typography
+  toc('Badge', '/badge', badgeUIExample),
+  toc('Text', '/text', textUIExample),
+  toc('Heading', '/heading', headingUIExample),
+  toc('Code', '/code', codeUIExample),
+  toc('Blockquote', '/blockquote', blockquoteUIExample),
+  toc('Timestamp', '/timestamp', timestampUIExample),
+  toc('Divider', '/divider', dividerUIExample),
+  // Wave 4 — media & status
+  toc('StatusDot', '/status-dot', statusDotUIExample),
+  toc('Citation', '/citation', citationUIExample),
+  toc('Token', '/token', tokenUIExample),
+  toc('Avatar', '/avatar', avatarUIExample),
+  toc('AvatarGroup', '/avatar-group', avatarGroupUIExample),
+  toc('Thumbnail', '/thumbnail', thumbnailUIExample),
+  // Wave 4 — feedback & misc
+  toc('EmptyState', '/empty-state', emptyStateUIExample),
+  toc('ProgressBar', '/progress-bar', progressBarUIExample),
+  toc('Spinner', '/spinner', spinnerUIExample),
+  toc('NavIcon', '/nav-icon', navIconUIExample),
+  toc('Item', '/item', itemUIExample),
+  toc('Markdown', '/markdown', markdownUIExample),
+  toc('CodeBlock', '/code-block', codeBlockUIExample),
+  // Wave 4 — nav chrome
+  toc('TopNav', '/top-nav', topNavUIExample),
+  toc('TopNavItem', '/top-nav-item', topNavItemUIExample),
+  toc('TopNavMenu', '/top-nav-menu', topNavMenuUIExample),
+  toc('TopNavMegaMenu', '/top-nav-mega-menu', topNavMegaMenuUIExample),
+  toc('Breadcrumbs', '/breadcrumbs', breadcrumbsUIExample),
+  toc('SideNav', '/side-nav', sideNavUIExample),
+  toc('SideNavItem', '/side-nav-item', sideNavItemUIExample),
+  toc('MobileNav', '/mobile-nav', mobileNavUIExample),
+  // Wave 4 — hard set (best-effort v1)
+  toc('FileInput', '/file-input', fileInputUIExample),
+  toc('ContextMenu', '/context-menu', contextMenuUIExample),
+  toc('AppShell', '/app-shell', appShellUIExample),
+  toc('ChatComposerInput', '/chat-composer-input', chatComposerInputUIExample),
+  toc('ChatComposer', '/chat-composer', chatComposerUIExample),
+  toc('HoverCard', '/hover-card', hoverCardUIExample),
+  toc('Tooltip', '/tooltip', tooltipUIExample),
+  // Wave 4 — chat suite
+  toc('ChatMessage', '/chat-message', chatMessageUIExample),
+  toc('ChatMessageBubble', '/chat-message-bubble', chatMessageBubbleUIExample),
+  toc('ChatMessageList', '/chat-message-list', chatMessageListUIExample),
+  toc('ChatSystemMessage', '/chat-system-message', chatSystemMessageUIExample),
+  toc('ChatToolCalls', '/chat-tool-calls', chatToolCallsUIExample),
+  toc('ChatLayout', '/chat-layout', chatLayoutUIExample),
+  toc('ChatSendButton', '/chat-send-button', chatSendButtonUIExample),
+  toc('ChatDictationButton', '/chat-dictation-button', chatDictationButtonUIExample),
 ];

--- a/package-tests/component-driver-astryx-test/src/examples/app-shell/AppShell.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/app-shell/AppShell.examples.tsx
@@ -1,0 +1,32 @@
+import { AppShell } from '@astryxdesign/core/AppShell';
+import { SideNav, SideNavItem } from '@astryxdesign/core/SideNav';
+import { TopNav, TopNavHeading } from '@astryxdesign/core/TopNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx AppShell scene.
+ *
+ * AppShell is a slot-based layout orchestrator: it places `topNav`, `sideNav`, and
+ * `children` into landmark regions. The driver confirms the regions are mounted and
+ * reads the `data-variant` (default `'elevated'`) and the `role="main"` text, then
+ * hands off to the child navigation drivers. The scene anchors on the root via the
+ * forwarded `data-testid`.
+ */
+export const AppShellExample = () => (
+  <AppShell
+    topNav={<TopNav label='Main' heading={<TopNavHeading heading='My App' />} />}
+    sideNav={
+      <SideNav>
+        <SideNavItem label='Home' href='/' />
+      </SideNav>
+    }
+    data-testid='app-shell'>
+    <div>Main content here</div>
+  </AppShell>
+);
+
+export const appShellUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx AppShell',
+  ui: <AppShellExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/app-shell/AppShell.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/app-shell/AppShell.suite.ts
@@ -1,0 +1,50 @@
+import { AppShellDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { appShellUIExample } from './AppShell.examples';
+
+export const appShellExampleScenePart = {
+  appShell: {
+    locator: byDataTestId('app-shell'),
+    driver: AppShellDriver,
+  },
+} satisfies ScenePart;
+
+export const appShellExample: IExampleUnit<typeof appShellExampleScenePart, JSX.Element> = {
+  ...appShellUIExample,
+  scene: appShellExampleScenePart,
+};
+
+export const appShellExampleTestSuite: TestSuiteInfo<typeof appShellExample.scene> = {
+  title: 'Astryx AppShell',
+  url: '/app-shell',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+    describe(`${appShellExample.title}`, () => {
+      const engine = useTestEngine(appShellExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The default variant reflects onto data-variant.
+      test(`getVariant reads the default variant`, async () => {
+        assertEqual(await engine().parts.appShell.getVariant(), 'elevated');
+      });
+
+      // The slotted topNav/sideNav and the role="main" content landmark are mounted.
+      test(`header, side-nav and main regions are mounted`, async () => {
+        assertTrue(await engine().parts.appShell.hasHeader());
+        assertTrue(await engine().parts.appShell.hasSideNav());
+        assertTrue(await engine().parts.appShell.hasMain());
+      });
+
+      // The main content text reads from the role="main" landmark.
+      test(`getMainText reads the main landmark text`, async () => {
+        assertTrue((await engine().parts.appShell.getMainText())?.includes('Main content here') ?? false);
+      });
+
+      // AppShell renders a built-in skip-to-content link.
+      test(`hasSkipLink reports the built-in skip link`, async () => {
+        assertTrue(await engine().parts.appShell.hasSkipLink());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/app-shell/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/app-shell/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { appShellExample, appShellExampleTestSuite } from './AppShell.suite';
+
+export { appShellUIExample } from './AppShell.examples';
+export { appShellExample, appShellExampleTestSuite };
+
+export const appShellExamples = [appShellExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/avatar-group/AvatarGroup.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar-group/AvatarGroup.examples.tsx
@@ -1,0 +1,32 @@
+import { Avatar } from '@astryxdesign/core/Avatar';
+import { AvatarGroup, AvatarGroupOverflow } from '@astryxdesign/core/AvatarGroup';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx AvatarGroup scene.
+ *
+ * AvatarGroup renders a `<div role="group" aria-label="Avatars">`; each visible
+ * avatar is a descendant `[role="img"]` carrying its own `aria-label`, and an
+ * optional `AvatarGroupOverflow` chip reports the hidden count. The scene renders
+ * one group with an overflow chip and one without, to cover overflow / no-overflow.
+ */
+export const AvatarGroupExample = () => (
+  <div>
+    <AvatarGroup size='small' data-testid='avatar-group-overflow'>
+      <Avatar name='John Doe' data-testid='ag-overflow-avatar-1' />
+      <Avatar name='Jane Smith' data-testid='ag-overflow-avatar-2' />
+      <Avatar name='Sam Lee' data-testid='ag-overflow-avatar-3' />
+      <AvatarGroupOverflow count={5} />
+    </AvatarGroup>
+    <AvatarGroup size='small' data-testid='avatar-group-plain'>
+      <Avatar name='Alice Wong' data-testid='ag-plain-avatar-1' />
+      <Avatar name='Bob Carter' data-testid='ag-plain-avatar-2' />
+    </AvatarGroup>
+  </div>
+);
+
+export const avatarGroupUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx AvatarGroup',
+  ui: <AvatarGroupExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/avatar-group/AvatarGroup.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar-group/AvatarGroup.suite.ts
@@ -1,0 +1,50 @@
+import { AvatarGroupDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { avatarGroupUIExample } from './AvatarGroup.examples';
+
+export const avatarGroupExampleScenePart = {
+  withOverflow: {
+    locator: byDataTestId('avatar-group-overflow'),
+    driver: AvatarGroupDriver,
+  },
+  withoutOverflow: {
+    locator: byDataTestId('avatar-group-plain'),
+    driver: AvatarGroupDriver,
+  },
+} satisfies ScenePart;
+
+export const avatarGroupExample: IExampleUnit<typeof avatarGroupExampleScenePart, JSX.Element> = {
+  ...avatarGroupUIExample,
+  scene: avatarGroupExampleScenePart,
+};
+
+export const avatarGroupExampleTestSuite: TestSuiteInfo<typeof avatarGroupExample.scene> = {
+  title: 'Astryx AvatarGroup',
+  url: '/avatar-group',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${avatarGroupExample.title}`, () => {
+      const engine = useTestEngine(avatarGroupExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getVisibleCount counts the [role="img"] avatars; getAvatarNames reads their labels.
+      test(`getVisibleCount and getAvatarNames read the avatars`, async () => {
+        assertEqual(await engine().parts.withOverflow.getVisibleCount(), 3);
+        assertEqual(await engine().parts.withOverflow.getAvatarNames(), ['John Doe', 'Jane Smith', 'Sam Lee']);
+      });
+
+      // The overflow chip's "{n} more" aria-label yields the hidden count.
+      test(`getOverflowCount parses the overflow chip`, async () => {
+        assertEqual(await engine().parts.withOverflow.getOverflowCount(), 5);
+      });
+
+      // A group without an overflow chip reports undefined and counts only its avatars.
+      test(`a group without overflow reports undefined`, async () => {
+        assertEqual(await engine().parts.withoutOverflow.getOverflowCount(), undefined);
+        assertEqual(await engine().parts.withoutOverflow.getVisibleCount(), 2);
+        assertEqual(await engine().parts.withoutOverflow.getAvatarNames(), ['Alice Wong', 'Bob Carter']);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/avatar-group/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar-group/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { avatarGroupExample, avatarGroupExampleTestSuite } from './AvatarGroup.suite';
+
+export { avatarGroupUIExample } from './AvatarGroup.examples';
+export { avatarGroupExample, avatarGroupExampleTestSuite };
+
+export const avatarGroupExamples = [avatarGroupExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/avatar/Avatar.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar/Avatar.examples.tsx
@@ -1,0 +1,34 @@
+import { Avatar } from '@astryxdesign/core/Avatar';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * A 1×1 transparent PNG as a data URI. Used instead of an `http(s)` URL so the
+ * image actually LOADS in a real browser — a broken URL fires Avatar's `onError`,
+ * which swaps to the initials fallback and removes the `<img>` (jsdom never fires
+ * `onError`, so that divergence only bites E2E). A data URI keeps `hasImage` true
+ * in both worlds.
+ */
+export const avatarImageSrc =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+/**
+ * Astryx Avatar scene.
+ *
+ * Avatar renders a `<div role="img">` whose accessible name is its `aria-label`
+ * (`alt || name || 'Avatar'`); its inner content is conditional — an `<img>` when
+ * `src` is set, otherwise initials (from `name`) or an icon. The scene renders an
+ * initials avatar, an image avatar, and an icon avatar to cover those branches.
+ */
+export const AvatarExample = () => (
+  <div>
+    <Avatar name='John Doe' data-testid='avatar-initials' />
+    <Avatar src={avatarImageSrc} alt='Jane Smith photo' data-testid='avatar-image' />
+    <Avatar data-testid='avatar-icon' />
+  </div>
+);
+
+export const avatarUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Avatar',
+  ui: <AvatarExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/avatar/Avatar.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar/Avatar.suite.ts
@@ -1,0 +1,58 @@
+import { AvatarDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { avatarImageSrc, avatarUIExample } from './Avatar.examples';
+
+export const avatarExampleScenePart = {
+  initials: {
+    locator: byDataTestId('avatar-initials'),
+    driver: AvatarDriver,
+  },
+  image: {
+    locator: byDataTestId('avatar-image'),
+    driver: AvatarDriver,
+  },
+  icon: {
+    locator: byDataTestId('avatar-icon'),
+    driver: AvatarDriver,
+  },
+} satisfies ScenePart;
+
+export const avatarExample: IExampleUnit<typeof avatarExampleScenePart, JSX.Element> = {
+  ...avatarUIExample,
+  scene: avatarExampleScenePart,
+};
+
+export const avatarExampleTestSuite: TestSuiteInfo<typeof avatarExample.scene> = {
+  title: 'Astryx Avatar',
+  url: '/avatar',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${avatarExample.title}`, () => {
+      const engine = useTestEngine(avatarExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getAccessibleName reads the aria-label (name when no alt, alt when imaged).
+      test(`getAccessibleName reads the aria-label`, async () => {
+        assertEqual(await engine().parts.initials.getAccessibleName(), 'John Doe');
+        assertEqual(await engine().parts.image.getAccessibleName(), 'Jane Smith photo');
+      });
+
+      // An image avatar exposes its src and reports hasImage; initials does neither.
+      // NOTE: jsdom always materialises the <img> for a src, so hasImage here means
+      // "a src was supplied" — the load-failure fallback to initials is E2E-only.
+      test(`hasImage and getImageSrc detect the image branch`, async () => {
+        assertTrue(await engine().parts.image.hasImage());
+        assertEqual(await engine().parts.image.getImageSrc(), avatarImageSrc);
+        assertFalse(await engine().parts.initials.hasImage());
+        assertEqual(await engine().parts.initials.getImageSrc(), undefined);
+      });
+
+      // The initials avatar renders its initials text; the image avatar renders none.
+      test(`getInitials reads the initials fallback`, async () => {
+        assertEqual(await engine().parts.initials.getInitials(), 'JD');
+        assertEqual(await engine().parts.image.getInitials(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/avatar/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/avatar/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { avatarExample, avatarExampleTestSuite } from './Avatar.suite';
+
+export { avatarUIExample } from './Avatar.examples';
+export { avatarExample, avatarExampleTestSuite };
+
+export const avatarExamples = [avatarExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/badge/Badge.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/badge/Badge.examples.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@astryxdesign/core/Badge';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Badge scene.
+ *
+ * Badge renders a single `<span>` (no role) whose `variant` is reflected as
+ * `data-variant` and whose `label` is the text content. Two instances with
+ * distinct variants exercise reads and disambiguation.
+ */
+export const BadgeExample = () => (
+  <div>
+    <Badge variant='success' label='Active' data-testid='badge-success' />
+    <Badge variant='purple' label='Engineering' data-testid='badge-purple' />
+  </div>
+);
+
+export const badgeUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Badge',
+  ui: <BadgeExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/badge/Badge.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/badge/Badge.suite.ts
@@ -1,0 +1,44 @@
+import { BadgeDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { badgeUIExample } from './Badge.examples';
+
+export const badgeExampleScenePart = {
+  success: {
+    locator: byDataTestId('badge-success'),
+    driver: BadgeDriver,
+  },
+  purple: {
+    locator: byDataTestId('badge-purple'),
+    driver: BadgeDriver,
+  },
+} satisfies ScenePart;
+
+export const badgeExample: IExampleUnit<typeof badgeExampleScenePart, JSX.Element> = {
+  ...badgeUIExample,
+  scene: badgeExampleScenePart,
+};
+
+export const badgeExampleTestSuite: TestSuiteInfo<typeof badgeExample.scene> = {
+  title: 'Astryx Badge',
+  url: '/badge',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${badgeExample.title}`, () => {
+      const engine = useTestEngine(badgeExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getText reads the label; getVariant the stable data-variant.
+      test(`reads label and variant`, async () => {
+        assertEqual(await engine().parts.success.getText(), 'Active');
+        assertEqual(await engine().parts.success.getVariant(), 'success');
+      });
+
+      // Two instances are disambiguated by their distinct testids/variants.
+      test(`disambiguates two instances`, async () => {
+        assertEqual(await engine().parts.purple.getText(), 'Engineering');
+        assertEqual(await engine().parts.purple.getVariant(), 'purple');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/badge/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/badge/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { badgeExample, badgeExampleTestSuite } from './Badge.suite';
+
+export { badgeUIExample } from './Badge.examples';
+export { badgeExample, badgeExampleTestSuite };
+
+export const badgeExamples = [badgeExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/blockquote/Blockquote.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/blockquote/Blockquote.examples.tsx
@@ -1,0 +1,24 @@
+import { Blockquote } from '@astryxdesign/core/Blockquote';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Blockquote scene.
+ *
+ * Blockquote renders a semantic `<blockquote>` (no role). With a `cite` it appends
+ * a `<footer><cite>…</cite></footer>`; without one no `<cite>` exists. The two
+ * instances cover the cited and uncited (citation → `undefined`) cases.
+ */
+export const BlockquoteExample = () => (
+  <div>
+    <Blockquote data-testid='blockquote-cited' cite='Steve Jobs'>
+      Design is not just what it looks like.
+    </Blockquote>
+    <Blockquote data-testid='blockquote-plain'>Stay hungry, stay foolish.</Blockquote>
+  </div>
+);
+
+export const blockquoteUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Blockquote',
+  ui: <BlockquoteExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/blockquote/Blockquote.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/blockquote/Blockquote.suite.ts
@@ -1,0 +1,43 @@
+import { BlockquoteDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { blockquoteUIExample } from './Blockquote.examples';
+
+export const blockquoteExampleScenePart = {
+  cited: {
+    locator: byDataTestId('blockquote-cited'),
+    driver: BlockquoteDriver,
+  },
+  plain: {
+    locator: byDataTestId('blockquote-plain'),
+    driver: BlockquoteDriver,
+  },
+} satisfies ScenePart;
+
+export const blockquoteExample: IExampleUnit<typeof blockquoteExampleScenePart, JSX.Element> = {
+  ...blockquoteUIExample,
+  scene: blockquoteExampleScenePart,
+};
+
+export const blockquoteExampleTestSuite: TestSuiteInfo<typeof blockquoteExample.scene> = {
+  title: 'Astryx Blockquote',
+  url: '/blockquote',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${blockquoteExample.title}`, () => {
+      const engine = useTestEngine(blockquoteExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getCitation isolates the <cite> descendant from the whole-element getText.
+      test(`reads the citation when present`, async () => {
+        assertEqual(await engine().parts.cited.getCitation(), 'Steve Jobs');
+      });
+
+      // An uncited blockquote has no <cite>, so getCitation is undefined and getText is the quote alone.
+      test(`citation is undefined when absent`, async () => {
+        assertEqual(await engine().parts.plain.getCitation(), undefined);
+        assertEqual(await engine().parts.plain.getText(), 'Stay hungry, stay foolish.');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/blockquote/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/blockquote/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { blockquoteExample, blockquoteExampleTestSuite } from './Blockquote.suite';
+
+export { blockquoteUIExample } from './Blockquote.examples';
+export { blockquoteExample, blockquoteExampleTestSuite };
+
+export const blockquoteExamples = [blockquoteExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/Breadcrumbs.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/Breadcrumbs.examples.tsx
@@ -1,0 +1,29 @@
+import { BreadcrumbItem, Breadcrumbs } from '@astryxdesign/core/Breadcrumbs';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Breadcrumbs scene.
+ *
+ * Breadcrumbs is a `<nav aria-label="Breadcrumb">` wrapping an `<ol>` of
+ * `<li class="astryx-breadcrumb-item">`. Linked crumbs hold an `<a href>`; the last
+ * crumb here is left WITHOUT `isCurrent` on purpose, so Astryx auto-detects it and
+ * puts `aria-current="page"` on the `<li>` itself (not an inner span) while its
+ * content is a bare `<span>`. That crumb has neither an `<a>` nor a descendant
+ * `[aria-current="page"]`, so a reader that probes only those would drop it from the
+ * labels and miss the current crumb — the driver reads the label from the crumb's
+ * content element and checks `aria-current` on the `<li>` too, so `getLabels`,
+ * `getCurrentLabel`, and `getHrefs` all stay correct.
+ */
+export const BreadcrumbsExample = () => (
+  <Breadcrumbs label='Breadcrumb' data-testid='breadcrumbs'>
+    <BreadcrumbItem href='/'>Home</BreadcrumbItem>
+    <BreadcrumbItem href='/projects'>Projects</BreadcrumbItem>
+    <BreadcrumbItem>My Project</BreadcrumbItem>
+  </Breadcrumbs>
+);
+
+export const breadcrumbsUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Breadcrumbs',
+  ui: <BreadcrumbsExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/Breadcrumbs.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/Breadcrumbs.suite.ts
@@ -1,0 +1,47 @@
+import { BreadcrumbsDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { breadcrumbsUIExample } from './Breadcrumbs.examples';
+
+export const breadcrumbsExampleScenePart = {
+  breadcrumbs: {
+    locator: byDataTestId('breadcrumbs'),
+    driver: BreadcrumbsDriver,
+  },
+} satisfies ScenePart;
+
+export const breadcrumbsExample: IExampleUnit<typeof breadcrumbsExampleScenePart, JSX.Element> = {
+  ...breadcrumbsUIExample,
+  scene: breadcrumbsExampleScenePart,
+};
+
+export const breadcrumbsExampleTestSuite: TestSuiteInfo<typeof breadcrumbsExample.scene> = {
+  title: 'Astryx Breadcrumbs',
+  url: '/breadcrumbs',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${breadcrumbsExample.title}`, () => {
+      const engine = useTestEngine(breadcrumbsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel and getItemCount read the trail`, async () => {
+        assertEqual(await engine().parts.breadcrumbs.getLabel(), 'Breadcrumb');
+        assertEqual(await engine().parts.breadcrumbs.getItemCount(), 3);
+      });
+
+      test(`getLabels reads every crumb in order`, async () => {
+        assertEqual(await engine().parts.breadcrumbs.getLabels(), ['Home', 'Projects', 'My Project']);
+      });
+
+      // getCurrentLabel reads the inner [aria-current="page"] span, not the <li>.
+      test(`getCurrentLabel reads the current crumb`, async () => {
+        assertEqual(await engine().parts.breadcrumbs.getCurrentLabel(), 'My Project');
+      });
+
+      // Only linked crumbs contribute an href; the current crumb (a span) is skipped.
+      test(`getHrefs reads the linked crumbs only`, async () => {
+        assertEqual(await engine().parts.breadcrumbs.getHrefs(), ['/', '/projects']);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/breadcrumbs/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { breadcrumbsExample, breadcrumbsExampleTestSuite } from './Breadcrumbs.suite';
+
+export { breadcrumbsUIExample } from './Breadcrumbs.examples';
+export { breadcrumbsExample, breadcrumbsExampleTestSuite };
+
+export const breadcrumbsExamples = [breadcrumbsExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/ChatComposerInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/ChatComposerInput.examples.tsx
@@ -1,0 +1,21 @@
+import { ChatComposerInput } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatComposerInput scene.
+ *
+ * The editor is a `contenteditable` `div[role="textbox"]`, not an `<input>`. The
+ * driver reads the accessible name (`aria-label` from `label`), the placeholder
+ * (an `aria-hidden` sibling, not the native attribute), and the suggestion menu's
+ * closed `aria-expanded`. `data-testid` is forwarded onto the root (a `data-*`
+ * attribute allowed by Astryx's BaseProps), so the scene anchors there.
+ */
+export const ChatComposerInputExample = () => (
+  <ChatComposerInput label='Message input' placeholder='Type a message…' data-testid='cci' />
+);
+
+export const chatComposerInputUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatComposerInput',
+  ui: <ChatComposerInputExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/ChatComposerInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/ChatComposerInput.suite.ts
@@ -1,0 +1,43 @@
+import { ChatComposerInputDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatComposerInputUIExample } from './ChatComposerInput.examples';
+
+export const chatComposerInputExampleScenePart = {
+  cci: {
+    locator: byDataTestId('cci'),
+    driver: ChatComposerInputDriver,
+  },
+} satisfies ScenePart;
+
+export const chatComposerInputExample: IExampleUnit<typeof chatComposerInputExampleScenePart, JSX.Element> = {
+  ...chatComposerInputUIExample,
+  scene: chatComposerInputExampleScenePart,
+};
+
+export const chatComposerInputExampleTestSuite: TestSuiteInfo<typeof chatComposerInputExample.scene> = {
+  title: 'Astryx ChatComposerInput',
+  url: '/chat-composer-input',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertFalse }) => {
+    describe(`${chatComposerInputExample.title}`, () => {
+      const engine = useTestEngine(chatComposerInputExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The accessible name reads off the contenteditable's aria-label.
+      test(`getLabel reads the accessible name`, async () => {
+        assertEqual(await engine().parts.cci.getLabel(), 'Message input');
+      });
+
+      // The placeholder is an aria-hidden sibling, read in jsdom.
+      test(`getPlaceholder reads the placeholder sibling`, async () => {
+        assertEqual(await engine().parts.cci.getPlaceholder(), 'Type a message…');
+      });
+
+      // The trigger/suggestion menu starts closed; the open transition is E2E-only.
+      test(`isSuggestionsOpen is false at rest`, async () => {
+        assertFalse(await engine().parts.cci.isSuggestionsOpen());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer-input/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatComposerInputExample, chatComposerInputExampleTestSuite } from './ChatComposerInput.suite';
+
+export { chatComposerInputUIExample } from './ChatComposerInput.examples';
+export { chatComposerInputExample, chatComposerInputExampleTestSuite };
+
+export const chatComposerInputExamples = [chatComposerInputExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer/ChatComposer.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer/ChatComposer.examples.tsx
@@ -1,0 +1,32 @@
+import { ChatComposer } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatComposer scene.
+ *
+ * ChatComposer wraps a contenteditable editor, a send/stop button, and an optional
+ * status message. The driver reads the root's `data-density` (default `'balanced'`),
+ * the send button's `disabled`/`aria-label` (Send↔Stop), and the `role="alert"`
+ * status text — all jsdom-faithful. `onSubmit` is required; `data-testid` is
+ * forwarded onto the root, so the scene anchors there.
+ *
+ * Two instances: an idle composer (empty → send disabled) and one showing the stop
+ * button alongside an error status.
+ */
+export const ChatComposerExample = () => (
+  <div>
+    <ChatComposer placeholder='Message…' onSubmit={() => {}} data-testid='cc-idle' />
+    <ChatComposer
+      isStopShown
+      status={{ type: 'error', message: 'Connection lost' }}
+      onSubmit={() => {}}
+      data-testid='cc-stop'
+    />
+  </div>
+);
+
+export const chatComposerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatComposer',
+  ui: <ChatComposerExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer/ChatComposer.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer/ChatComposer.suite.ts
@@ -1,0 +1,54 @@
+import { ChatComposerDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatComposerUIExample } from './ChatComposer.examples';
+
+export const chatComposerExampleScenePart = {
+  ccIdle: {
+    locator: byDataTestId('cc-idle'),
+    driver: ChatComposerDriver,
+  },
+  ccStop: {
+    locator: byDataTestId('cc-stop'),
+    driver: ChatComposerDriver,
+  },
+} satisfies ScenePart;
+
+export const chatComposerExample: IExampleUnit<typeof chatComposerExampleScenePart, JSX.Element> = {
+  ...chatComposerUIExample,
+  scene: chatComposerExampleScenePart,
+};
+
+export const chatComposerExampleTestSuite: TestSuiteInfo<typeof chatComposerExample.scene> = {
+  title: 'Astryx ChatComposer',
+  url: '/chat-composer',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${chatComposerExample.title}`, () => {
+      const engine = useTestEngine(chatComposerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // Density reflects onto data-density (default 'balanced').
+      test(`getDensity reads the default density`, async () => {
+        assertEqual(await engine().parts.ccIdle.getDensity(), 'balanced');
+      });
+
+      // The send button is disabled while the editor is empty.
+      test(`canSend is false for the empty idle composer`, async () => {
+        assertFalse(await engine().parts.ccIdle.canSend());
+      });
+
+      // The stop variant flips the button's aria-label to "Stop".
+      test(`isStopShown reads the stop-button state`, async () => {
+        assertTrue(await engine().parts.ccStop.isStopShown());
+        assertFalse(await engine().parts.ccIdle.isStopShown());
+      });
+
+      // The status message reads off the role="alert" element when present.
+      test(`getStatusMessage reads the status, undefined when absent`, async () => {
+        assertEqual(await engine().parts.ccStop.getStatusMessage(), 'Connection lost');
+        assertEqual(await engine().parts.ccIdle.getStatusMessage(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-composer/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-composer/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatComposerExample, chatComposerExampleTestSuite } from './ChatComposer.suite';
+
+export { chatComposerUIExample } from './ChatComposer.examples';
+export { chatComposerExample, chatComposerExampleTestSuite };
+
+export const chatComposerExamples = [chatComposerExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/ChatDictationButton.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/ChatDictationButton.examples.tsx
@@ -1,0 +1,44 @@
+import { ChatDictationButton, UseSpeechRecognitionReturn } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatDictationButton scene.
+ *
+ * The button renders `null` when speech recognition is unsupported and
+ * `isHiddenWhenUnsupported` is left at its default, and it forwards no
+ * `data-testid`. So each instance is given a mock `dictation` (a stand-in for
+ * `useSpeechRecognition`'s return) reporting `isSupported: true`, plus
+ * `isHiddenWhenUnsupported={false}`, to force a render. The state shows as the
+ * inner button's verbatim `aria-label`: `"Start dictation"` (idle) vs
+ * `"Stop dictation"` (listening), so the scene anchors each instance on that label.
+ */
+
+// The full UseSpeechRecognitionReturn surface. The button only reads isSupported,
+// isListening, bands, and volume; the no-op handlers and empty buffers stand in for
+// the AudioContext-bound internals that have no meaning under jsdom.
+const makeDictation = (isListening: boolean): UseSpeechRecognitionReturn => ({
+  isSupported: true,
+  isListening,
+  isSpeaking: false,
+  volume: 0,
+  bands: [],
+  rawBands: [],
+  interimTranscript: '',
+  start: () => {},
+  stop: () => {},
+  abort: () => {},
+  toggle: () => {},
+});
+
+export const ChatDictationButtonExample = () => (
+  <div>
+    <ChatDictationButton dictation={makeDictation(false)} isHiddenWhenUnsupported={false} />
+    <ChatDictationButton dictation={makeDictation(true)} isHiddenWhenUnsupported={false} />
+  </div>
+);
+
+export const chatDictationButtonUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatDictationButton',
+  ui: <ChatDictationButtonExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/ChatDictationButton.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/ChatDictationButton.suite.ts
@@ -1,0 +1,44 @@
+import { ChatDictationButtonDriver } from '@atomic-testing/component-driver-astryx';
+import { byCssSelector, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatDictationButtonUIExample } from './ChatDictationButton.examples';
+
+export const chatDictationButtonExampleScenePart = {
+  idle: {
+    locator: byCssSelector('button[aria-label="Start dictation"]'),
+    driver: ChatDictationButtonDriver,
+  },
+  listening: {
+    locator: byCssSelector('button[aria-label="Stop dictation"]'),
+    driver: ChatDictationButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const chatDictationButtonExample: IExampleUnit<typeof chatDictationButtonExampleScenePart, JSX.Element> = {
+  ...chatDictationButtonUIExample,
+  scene: chatDictationButtonExampleScenePart,
+};
+
+export const chatDictationButtonExampleTestSuite: TestSuiteInfo<typeof chatDictationButtonExample.scene> = {
+  title: 'Astryx ChatDictationButton',
+  url: '/chat-dictation-button',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${chatDictationButtonExample.title}`, () => {
+      const engine = useTestEngine(chatDictationButtonExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getAccessibleName reads the verbatim aria-label for each state.
+      test(`reads the accessible name`, async () => {
+        assertEqual(await engine().parts.idle.getAccessibleName(), 'Start dictation');
+        assertEqual(await engine().parts.listening.getAccessibleName(), 'Stop dictation');
+      });
+
+      // isListening is true only for the "Stop dictation" state.
+      test(`reports the listening state`, async () => {
+        assertFalse(await engine().parts.idle.isListening());
+        assertTrue(await engine().parts.listening.isListening());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-dictation-button/index.ts
@@ -1,0 +1,12 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatDictationButtonExample, chatDictationButtonExampleTestSuite } from './ChatDictationButton.suite';
+
+export { chatDictationButtonUIExample } from './ChatDictationButton.examples';
+export { chatDictationButtonExample, chatDictationButtonExampleTestSuite };
+
+export const chatDictationButtonExamples = [chatDictationButtonExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-layout/ChatLayout.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-layout/ChatLayout.examples.tsx
@@ -1,0 +1,37 @@
+import { ChatLayout, ChatMessage, ChatMessageBubble, ChatMessageList } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatLayout scene.
+ *
+ * The root `<div class="astryx-chat-layout">` forwards `data-testid` and carries
+ * `data-density`. When `children` is empty the message area renders the caller's
+ * `emptyState` node. Both layouts pass `scrollButton={null}` to suppress the
+ * default scroll button (it drives `useChatStreamScroll`, a browser-only concern).
+ * Two layouts — a populated one (compact density) and an empty one whose
+ * `emptyState` node carries its own testid — verify density and the empty-state read.
+ */
+export const ChatLayoutExample = () => (
+  <div>
+    <ChatLayout density='compact' scrollButton={null} composer={<div>composer</div>} data-testid='layout-compact'>
+      <ChatMessageList>
+        <ChatMessage sender='user' name='Alice'>
+          <ChatMessageBubble>Hey there!</ChatMessageBubble>
+        </ChatMessage>
+      </ChatMessageList>
+    </ChatLayout>
+    <ChatLayout
+      scrollButton={null}
+      composer={<div>composer</div>}
+      emptyState={<span data-testid='layout-empty-state'>No messages</span>}
+      data-testid='layout-empty'>
+      {null}
+    </ChatLayout>
+  </div>
+);
+
+export const chatLayoutUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatLayout',
+  ui: <ChatLayoutExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-layout/ChatLayout.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-layout/ChatLayout.suite.ts
@@ -1,0 +1,49 @@
+import { ChatLayoutDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatLayoutUIExample } from './ChatLayout.examples';
+
+export const chatLayoutExampleScenePart = {
+  compactLayout: {
+    locator: byDataTestId('layout-compact'),
+    driver: ChatLayoutDriver,
+  },
+  emptyLayout: {
+    locator: byDataTestId('layout-empty'),
+    driver: ChatLayoutDriver,
+  },
+} satisfies ScenePart;
+
+export const chatLayoutExample: IExampleUnit<typeof chatLayoutExampleScenePart, JSX.Element> = {
+  ...chatLayoutUIExample,
+  scene: chatLayoutExampleScenePart,
+};
+
+export const chatLayoutExampleTestSuite: TestSuiteInfo<typeof chatLayoutExample.scene> = {
+  title: 'Astryx ChatLayout',
+  url: '/chat-layout',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${chatLayoutExample.title}`, () => {
+      const engine = useTestEngine(chatLayoutExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getDensity reads the stable data-density on the layout root.
+      test(`reads density`, async () => {
+        assertEqual(await engine().parts.compactLayout.getDensity(), 'compact');
+      });
+
+      // getEmptyStateText reads the empty layout's content, undefined when populated.
+      test(`reads the empty state`, async () => {
+        assertEqual(
+          await engine().parts.emptyLayout.getEmptyStateText('[data-testid="layout-empty-state"]'),
+          'No messages'
+        );
+        assertEqual(
+          await engine().parts.compactLayout.getEmptyStateText('[data-testid="layout-empty-state"]'),
+          undefined
+        );
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-layout/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-layout/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatLayoutExample, chatLayoutExampleTestSuite } from './ChatLayout.suite';
+
+export { chatLayoutUIExample } from './ChatLayout.examples';
+export { chatLayoutExample, chatLayoutExampleTestSuite };
+
+export const chatLayoutExamples = [chatLayoutExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/ChatMessageBubble.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/ChatMessageBubble.examples.tsx
@@ -1,0 +1,30 @@
+import { ChatMessage, ChatMessageBubble } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatMessageBubble scene.
+ *
+ * Each bubble renders a `<div class="astryx-chat-message-bubble">` that forwards
+ * `data-testid` and reflects its props as `data-sender` (inherited from the
+ * enclosing `ChatMessage`, or `assistant` when standalone), `data-variant`
+ * (`filled` | `ghost`), and `data-density`. Three bubbles — a filled user bubble,
+ * a standalone (default assistant) filled bubble, and a ghost bubble — verify
+ * sender and variant disambiguation.
+ */
+export const ChatMessageBubbleExample = () => (
+  <div>
+    <ChatMessage sender='user' density='compact'>
+      <ChatMessageBubble data-testid='bubble-user'>Hey there!</ChatMessageBubble>
+    </ChatMessage>
+    <ChatMessageBubble data-testid='bubble-standalone'>Standalone reply</ChatMessageBubble>
+    <ChatMessageBubble variant='ghost' data-testid='bubble-ghost'>
+      Ghost content
+    </ChatMessageBubble>
+  </div>
+);
+
+export const chatMessageBubbleUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatMessageBubble',
+  ui: <ChatMessageBubbleExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/ChatMessageBubble.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/ChatMessageBubble.suite.ts
@@ -1,0 +1,54 @@
+import { ChatMessageBubbleDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatMessageBubbleUIExample } from './ChatMessageBubble.examples';
+
+export const chatMessageBubbleExampleScenePart = {
+  userBubble: {
+    locator: byDataTestId('bubble-user'),
+    driver: ChatMessageBubbleDriver,
+  },
+  standaloneBubble: {
+    locator: byDataTestId('bubble-standalone'),
+    driver: ChatMessageBubbleDriver,
+  },
+  ghostBubble: {
+    locator: byDataTestId('bubble-ghost'),
+    driver: ChatMessageBubbleDriver,
+  },
+} satisfies ScenePart;
+
+export const chatMessageBubbleExample: IExampleUnit<typeof chatMessageBubbleExampleScenePart, JSX.Element> = {
+  ...chatMessageBubbleUIExample,
+  scene: chatMessageBubbleExampleScenePart,
+};
+
+export const chatMessageBubbleExampleTestSuite: TestSuiteInfo<typeof chatMessageBubbleExample.scene> = {
+  title: 'Astryx ChatMessageBubble',
+  url: '/chat-message-bubble',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${chatMessageBubbleExample.title}`, () => {
+      const engine = useTestEngine(chatMessageBubbleExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getText reads the bubble's content.
+      test(`reads bubble text`, async () => {
+        assertEqual(await engine().parts.userBubble.getText(), 'Hey there!');
+        assertEqual(await engine().parts.standaloneBubble.getText(), 'Standalone reply');
+      });
+
+      // getSender reflects the enclosing message context, defaulting to assistant standalone.
+      test(`reads sender from context`, async () => {
+        assertEqual(await engine().parts.userBubble.getSender(), 'user');
+        assertEqual(await engine().parts.standaloneBubble.getSender(), 'assistant');
+      });
+
+      // getVariant distinguishes the filled default from the ghost variant.
+      test(`reads variant`, async () => {
+        assertEqual(await engine().parts.standaloneBubble.getVariant(), 'filled');
+        assertEqual(await engine().parts.ghostBubble.getVariant(), 'ghost');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-bubble/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatMessageBubbleExample, chatMessageBubbleExampleTestSuite } from './ChatMessageBubble.suite';
+
+export { chatMessageBubbleUIExample } from './ChatMessageBubble.examples';
+export { chatMessageBubbleExample, chatMessageBubbleExampleTestSuite };
+
+export const chatMessageBubbleExamples = [chatMessageBubbleExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-list/ChatMessageList.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-list/ChatMessageList.examples.tsx
@@ -1,0 +1,34 @@
+import { ChatMessage, ChatMessageBubble, ChatMessageList } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatMessageList scene.
+ *
+ * The list root is a `<div role="log" class="astryx-chat-message-list">` that
+ * forwards `data-testid` and carries `data-density`. Messages are
+ * `<article class="astryx-chat-message">` descendants the driver enumerates. Two
+ * lists — a populated one (compact density, two messages) and an empty one whose
+ * `emptyState` node carries its own testid — verify counting, density, and the
+ * empty-state read.
+ */
+export const ChatMessageListExample = () => (
+  <div>
+    <ChatMessageList density='compact' data-testid='list-full'>
+      <ChatMessage sender='user' name='Alice'>
+        <ChatMessageBubble>Hey there!</ChatMessageBubble>
+      </ChatMessage>
+      <ChatMessage sender='assistant' name='Navi'>
+        <ChatMessageBubble>How can I help?</ChatMessageBubble>
+      </ChatMessage>
+    </ChatMessageList>
+    <ChatMessageList data-testid='list-empty' emptyState={<span data-testid='list-empty-state'>Start chatting!</span>}>
+      {null}
+    </ChatMessageList>
+  </div>
+);
+
+export const chatMessageListUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatMessageList',
+  ui: <ChatMessageListExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-list/ChatMessageList.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-list/ChatMessageList.suite.ts
@@ -1,0 +1,60 @@
+import { ChatMessageListDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatMessageListUIExample } from './ChatMessageList.examples';
+
+export const chatMessageListExampleScenePart = {
+  fullList: {
+    locator: byDataTestId('list-full'),
+    driver: ChatMessageListDriver,
+  },
+  emptyList: {
+    locator: byDataTestId('list-empty'),
+    driver: ChatMessageListDriver,
+  },
+} satisfies ScenePart;
+
+export const chatMessageListExample: IExampleUnit<typeof chatMessageListExampleScenePart, JSX.Element> = {
+  ...chatMessageListUIExample,
+  scene: chatMessageListExampleScenePart,
+};
+
+export const chatMessageListExampleTestSuite: TestSuiteInfo<typeof chatMessageListExample.scene> = {
+  title: 'Astryx ChatMessageList',
+  url: '/chat-message-list',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${chatMessageListExample.title}`, () => {
+      const engine = useTestEngine(chatMessageListExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getMessageCount counts the article rows; the empty list has none.
+      test(`counts messages`, async () => {
+        assertEqual(await engine().parts.fullList.getMessageCount(), 2);
+        assertEqual(await engine().parts.emptyList.getMessageCount(), 0);
+      });
+
+      // The list items are ChatMessageDriver instances the driver can drive.
+      test(`exposes message rows`, async () => {
+        const first = await engine().parts.fullList.getItemByIndex(0);
+        assertEqual(first != null ? await first.getSender() : undefined, 'user');
+        const second = await engine().parts.fullList.getItemByIndex(1);
+        assertEqual(second != null ? await second.getSender() : undefined, 'assistant');
+      });
+
+      // getDensity reads the stable data-density on the log root.
+      test(`reads density`, async () => {
+        assertEqual(await engine().parts.fullList.getDensity(), 'compact');
+      });
+
+      // getEmptyStateText reads the empty list's content, undefined when populated.
+      test(`reads the empty state`, async () => {
+        assertEqual(
+          await engine().parts.emptyList.getEmptyStateText('[data-testid="list-empty-state"]'),
+          'Start chatting!'
+        );
+        assertEqual(await engine().parts.fullList.getEmptyStateText('[data-testid="list-empty-state"]'), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message-list/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message-list/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatMessageListExample, chatMessageListExampleTestSuite } from './ChatMessageList.suite';
+
+export { chatMessageListUIExample } from './ChatMessageList.examples';
+export { chatMessageListExample, chatMessageListExampleTestSuite };
+
+export const chatMessageListExamples = [chatMessageListExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message/ChatMessage.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message/ChatMessage.examples.tsx
@@ -1,0 +1,30 @@
+import { ChatMessage, ChatMessageBubble, ChatMessageMetadata } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatMessage scene.
+ *
+ * Each message is an `<article class="astryx-chat-message">` carrying `data-sender`
+ * and `data-density`, forwarding `data-testid` onto the root. The bubble
+ * (`.astryx-chat-message-bubble`) and metadata (`.astryx-chat-message-metadata`)
+ * are descendants the driver reads by their stable semantic classes. Two messages
+ * — user (compact density, with metadata) and assistant — verify sender/density
+ * disambiguation and the absent-metadata case.
+ */
+export const ChatMessageExample = () => (
+  <div>
+    <ChatMessage sender='user' name='Alice' density='compact' data-testid='msg-user'>
+      <ChatMessageBubble>Hey there!</ChatMessageBubble>
+      <ChatMessageMetadata timestamp='2:30 PM' />
+    </ChatMessage>
+    <ChatMessage sender='assistant' name='Navi' data-testid='msg-assistant'>
+      <ChatMessageBubble>How can I help?</ChatMessageBubble>
+    </ChatMessage>
+  </div>
+);
+
+export const chatMessageUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatMessage',
+  ui: <ChatMessageExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message/ChatMessage.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message/ChatMessage.suite.ts
@@ -1,0 +1,51 @@
+import { ChatMessageDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatMessageUIExample } from './ChatMessage.examples';
+
+export const chatMessageExampleScenePart = {
+  userMessage: {
+    locator: byDataTestId('msg-user'),
+    driver: ChatMessageDriver,
+  },
+  assistantMessage: {
+    locator: byDataTestId('msg-assistant'),
+    driver: ChatMessageDriver,
+  },
+} satisfies ScenePart;
+
+export const chatMessageExample: IExampleUnit<typeof chatMessageExampleScenePart, JSX.Element> = {
+  ...chatMessageUIExample,
+  scene: chatMessageExampleScenePart,
+};
+
+export const chatMessageExampleTestSuite: TestSuiteInfo<typeof chatMessageExample.scene> = {
+  title: 'Astryx ChatMessage',
+  url: '/chat-message',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${chatMessageExample.title}`, () => {
+      const engine = useTestEngine(chatMessageExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getSender / getDensity read the stable data-* attributes on the article.
+      test(`reads sender and density per message`, async () => {
+        assertEqual(await engine().parts.userMessage.getSender(), 'user');
+        assertEqual(await engine().parts.userMessage.getDensity(), 'compact');
+        assertEqual(await engine().parts.assistantMessage.getSender(), 'assistant');
+      });
+
+      // getBubbleText returns just the bubble's text, isolated from name/metadata.
+      test(`reads the bubble text`, async () => {
+        assertEqual(await engine().parts.userMessage.getBubbleText(), 'Hey there!');
+        assertEqual(await engine().parts.assistantMessage.getBubbleText(), 'How can I help?');
+      });
+
+      // getMetadataText reads the metadata block, and is undefined when absent.
+      test(`reads metadata when present, undefined otherwise`, async () => {
+        assertEqual(await engine().parts.userMessage.getMetadataText(), '2:30 PM');
+        assertEqual(await engine().parts.assistantMessage.getMetadataText(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-message/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-message/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatMessageExample, chatMessageExampleTestSuite } from './ChatMessage.suite';
+
+export { chatMessageUIExample } from './ChatMessage.examples';
+export { chatMessageExample, chatMessageExampleTestSuite };
+
+export const chatMessageExamples = [chatMessageExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-send-button/ChatSendButton.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-send-button/ChatSendButton.examples.tsx
@@ -1,0 +1,34 @@
+import { ChatSendButton } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatSendButton scene.
+ *
+ * ChatSendButton renders an icon-only `<button class="astryx-chat-send-button">`
+ * but does NOT forward `data-testid` (it spreads props onto an inner `Button`), so
+ * each instance is wrapped in a `data-testid` `<div>` the scene scopes through. The
+ * button's state shows as the verbatim `aria-label` (`"Send"` vs `"Stop"`) and, for
+ * the send state, the native `disabled` attribute. Three instances — an enabled
+ * send, a disabled send, and a stop — provide that disambiguation.
+ */
+export const ChatSendButtonExample = () => (
+  <div>
+    <div data-testid='send-enabled'>
+      {/* isDisabled defaults to !canSend from composer context; standalone that is
+          `true`, so an enabled send button must opt out explicitly. */}
+      <ChatSendButton onSend={() => {}} isDisabled={false} />
+    </div>
+    <div data-testid='send-disabled'>
+      <ChatSendButton onSend={() => {}} isDisabled />
+    </div>
+    <div data-testid='send-stop'>
+      <ChatSendButton isStopShown onStop={() => {}} />
+    </div>
+  </div>
+);
+
+export const chatSendButtonUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatSendButton',
+  ui: <ChatSendButtonExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-send-button/ChatSendButton.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-send-button/ChatSendButton.suite.ts
@@ -1,0 +1,55 @@
+import { ChatSendButtonDriver } from '@atomic-testing/component-driver-astryx';
+import { byCssSelector, byDataTestId, IExampleUnit, locatorUtil, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatSendButtonUIExample } from './ChatSendButton.examples';
+
+// ChatSendButton forwards no testid, so each button is reached as the
+// `astryx-chat-send-button` descendant of its testid'd wrapper.
+const sendButtonIn = (wrapperTestId: string) =>
+  locatorUtil.append(byDataTestId(wrapperTestId), byCssSelector('.astryx-chat-send-button'));
+
+export const chatSendButtonExampleScenePart = {
+  enabledSend: {
+    locator: sendButtonIn('send-enabled'),
+    driver: ChatSendButtonDriver,
+  },
+  disabledSend: {
+    locator: sendButtonIn('send-disabled'),
+    driver: ChatSendButtonDriver,
+  },
+  stop: {
+    locator: sendButtonIn('send-stop'),
+    driver: ChatSendButtonDriver,
+  },
+} satisfies ScenePart;
+
+export const chatSendButtonExample: IExampleUnit<typeof chatSendButtonExampleScenePart, JSX.Element> = {
+  ...chatSendButtonUIExample,
+  scene: chatSendButtonExampleScenePart,
+};
+
+export const chatSendButtonExampleTestSuite: TestSuiteInfo<typeof chatSendButtonExample.scene> = {
+  title: 'Astryx ChatSendButton',
+  url: '/chat-send-button',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertTrue, assertFalse }) => {
+    describe(`${chatSendButtonExample.title}`, () => {
+      const engine = useTestEngine(chatSendButtonExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // isSend / isStop distinguish the two states via the verbatim aria-label.
+      test(`distinguishes send from stop`, async () => {
+        assertTrue(await engine().parts.enabledSend.isSend());
+        assertFalse(await engine().parts.enabledSend.isStop());
+        assertTrue(await engine().parts.stop.isStop());
+        assertFalse(await engine().parts.stop.isSend());
+      });
+
+      // isDisabled reads the native disabled attribute on the send state.
+      test(`reads the disabled state`, async () => {
+        assertFalse(await engine().parts.enabledSend.isDisabled());
+        assertTrue(await engine().parts.disabledSend.isDisabled());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-send-button/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-send-button/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatSendButtonExample, chatSendButtonExampleTestSuite } from './ChatSendButton.suite';
+
+export { chatSendButtonUIExample } from './ChatSendButton.examples';
+export { chatSendButtonExample, chatSendButtonExampleTestSuite };
+
+export const chatSendButtonExamples = [chatSendButtonExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-system-message/ChatSystemMessage.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-system-message/ChatSystemMessage.examples.tsx
@@ -1,0 +1,25 @@
+import { ChatSystemMessage } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatSystemMessage scene.
+ *
+ * Both variants render a `<div role="status" class="astryx-chat-system-message">`
+ * that forwards `data-testid` and carries the stable `data-variant`. Two messages —
+ * the plain default and the divider (date-separator) variant — verify text reads
+ * and variant disambiguation.
+ */
+export const ChatSystemMessageExample = () => (
+  <div>
+    <ChatSystemMessage data-testid='sys-default'>Conversation started</ChatSystemMessage>
+    <ChatSystemMessage variant='divider' data-testid='sys-divider'>
+      Today
+    </ChatSystemMessage>
+  </div>
+);
+
+export const chatSystemMessageUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatSystemMessage',
+  ui: <ChatSystemMessageExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-system-message/ChatSystemMessage.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-system-message/ChatSystemMessage.suite.ts
@@ -1,0 +1,44 @@
+import { ChatSystemMessageDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatSystemMessageUIExample } from './ChatSystemMessage.examples';
+
+export const chatSystemMessageExampleScenePart = {
+  defaultMessage: {
+    locator: byDataTestId('sys-default'),
+    driver: ChatSystemMessageDriver,
+  },
+  dividerMessage: {
+    locator: byDataTestId('sys-divider'),
+    driver: ChatSystemMessageDriver,
+  },
+} satisfies ScenePart;
+
+export const chatSystemMessageExample: IExampleUnit<typeof chatSystemMessageExampleScenePart, JSX.Element> = {
+  ...chatSystemMessageUIExample,
+  scene: chatSystemMessageExampleScenePart,
+};
+
+export const chatSystemMessageExampleTestSuite: TestSuiteInfo<typeof chatSystemMessageExample.scene> = {
+  title: 'Astryx ChatSystemMessage',
+  url: '/chat-system-message',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${chatSystemMessageExample.title}`, () => {
+      const engine = useTestEngine(chatSystemMessageExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getText reads the system notice's content.
+      test(`reads message text`, async () => {
+        assertEqual(await engine().parts.defaultMessage.getText(), 'Conversation started');
+        assertEqual(await engine().parts.dividerMessage.getText(), 'Today');
+      });
+
+      // getVariant distinguishes the default from the divider variant.
+      test(`reads variant`, async () => {
+        assertEqual(await engine().parts.defaultMessage.getVariant(), 'default');
+        assertEqual(await engine().parts.dividerMessage.getVariant(), 'divider');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-system-message/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-system-message/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatSystemMessageExample, chatSystemMessageExampleTestSuite } from './ChatSystemMessage.suite';
+
+export { chatSystemMessageUIExample } from './ChatSystemMessage.examples';
+export { chatSystemMessageExample, chatSystemMessageExampleTestSuite };
+
+export const chatSystemMessageExamples = [chatSystemMessageExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/ChatToolCalls.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/ChatToolCalls.examples.tsx
@@ -1,0 +1,36 @@
+import { ChatToolCalls } from '@astryxdesign/core/Chat';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ChatToolCalls scene.
+ *
+ * The root `<div class="astryx-chat-tool-calls">` forwards `data-testid`. A single
+ * call renders one inline row with no group chrome; multiple calls render a
+ * collapsible `<div role="button" aria-expanded>` header over a body that always
+ * keeps every row in the DOM. Two blocks — a single call and a four-call group
+ * (collapsed by default, since `defaultIsExpanded` is false for >3) — verify
+ * counting, the single-vs-group distinction, and the expand toggle.
+ */
+export const ChatToolCallsExample = () => (
+  <div>
+    <ChatToolCalls
+      data-testid='tool-single'
+      calls={[{ name: 'read_file', target: 'Button.tsx', status: 'complete', duration: '1.2s' }]}
+    />
+    <ChatToolCalls
+      data-testid='tool-multi'
+      calls={[
+        { name: 'read_file', target: 'Button.tsx', status: 'complete', duration: '1.2s' },
+        { name: 'edit_file', target: 'Button.tsx', status: 'complete', duration: '0.8s' },
+        { name: 'run_tests', target: 'yarn test', status: 'complete', duration: '4.1s' },
+        { name: 'commit', target: 'main', status: 'complete', duration: '0.3s' },
+      ]}
+    />
+  </div>
+);
+
+export const chatToolCallsUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ChatToolCalls',
+  ui: <ChatToolCallsExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/ChatToolCalls.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/ChatToolCalls.suite.ts
@@ -1,0 +1,58 @@
+import { ChatToolCallsDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { chatToolCallsUIExample } from './ChatToolCalls.examples';
+
+export const chatToolCallsExampleScenePart = {
+  single: {
+    locator: byDataTestId('tool-single'),
+    driver: ChatToolCallsDriver,
+  },
+  multi: {
+    locator: byDataTestId('tool-multi'),
+    driver: ChatToolCallsDriver,
+  },
+} satisfies ScenePart;
+
+export const chatToolCallsExample: IExampleUnit<typeof chatToolCallsExampleScenePart, JSX.Element> = {
+  ...chatToolCallsUIExample,
+  scene: chatToolCallsExampleScenePart,
+};
+
+export const chatToolCallsExampleTestSuite: TestSuiteInfo<typeof chatToolCallsExample.scene> = {
+  title: 'Astryx ChatToolCalls',
+  url: '/chat-tool-calls',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${chatToolCallsExample.title}`, () => {
+      const engine = useTestEngine(chatToolCallsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // isGrouped distinguishes a single inline call from a multi-call group.
+      test(`distinguishes single from group`, async () => {
+        assertFalse(await engine().parts.single.isGrouped());
+        assertTrue(await engine().parts.multi.isGrouped());
+      });
+
+      // getCallCount counts rows in both shapes; the group's rows stay in the DOM.
+      test(`counts calls`, async () => {
+        assertEqual(await engine().parts.single.getCallCount(), 1);
+        assertEqual(await engine().parts.multi.getCallCount(), 4);
+      });
+
+      // isExpanded is undefined for a single call; a >3 group defaults to collapsed.
+      test(`reports expanded state`, async () => {
+        assertEqual(await engine().parts.single.isExpanded(), undefined);
+        assertEqual(await engine().parts.multi.isExpanded(), false);
+      });
+
+      // toggleGroup flips the group header's aria-expanded.
+      test(`toggles the group`, async () => {
+        await engine().parts.multi.toggleGroup();
+        assertTrue(await engine().parts.multi.isExpanded());
+        await engine().parts.multi.toggleGroup();
+        assertFalse(await engine().parts.multi.isExpanded());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/chat-tool-calls/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chatToolCallsExample, chatToolCallsExampleTestSuite } from './ChatToolCalls.suite';
+
+export { chatToolCallsUIExample } from './ChatToolCalls.examples';
+export { chatToolCallsExample, chatToolCallsExampleTestSuite };
+
+export const chatToolCallsExamples = [chatToolCallsExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/citation/Citation.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/citation/Citation.examples.tsx
@@ -1,0 +1,34 @@
+import { Citation } from '@astryxdesign/core/Citation';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Citation scene.
+ *
+ * Citation's root tag is conditional — an `<a>` when its source has a `url`, else
+ * a `<span>` — but always carries `role="doc-noteref"`, `aria-label`, `title`, and
+ * `data-variant`. The scene renders a linked `label` citation, an unlinked one
+ * (source without `url`), and a `number` variant to cover link / no-link / variant.
+ */
+export const CitationExample = () => (
+  <div>
+    <Citation
+      source={{ title: 'Example Source', url: 'https://example.com' }}
+      number={1}
+      variant='label'
+      data-testid='citation-link'
+    />
+    <Citation source={{ title: 'Offline Source' }} number={2} variant='label' data-testid='citation-plain' />
+    <Citation
+      source={{ title: 'Referenced Work', url: 'https://example.org' }}
+      number={3}
+      variant='number'
+      data-testid='citation-number'
+    />
+  </div>
+);
+
+export const citationUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Citation',
+  ui: <CitationExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/citation/Citation.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/citation/Citation.suite.ts
@@ -1,0 +1,62 @@
+import { CitationDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { citationUIExample } from './Citation.examples';
+
+export const citationExampleScenePart = {
+  link: {
+    locator: byDataTestId('citation-link'),
+    driver: CitationDriver,
+  },
+  plain: {
+    locator: byDataTestId('citation-plain'),
+    driver: CitationDriver,
+  },
+  number: {
+    locator: byDataTestId('citation-number'),
+    driver: CitationDriver,
+  },
+} satisfies ScenePart;
+
+export const citationExample: IExampleUnit<typeof citationExampleScenePart, JSX.Element> = {
+  ...citationUIExample,
+  scene: citationExampleScenePart,
+};
+
+export const citationExampleTestSuite: TestSuiteInfo<typeof citationExample.scene> = {
+  title: 'Astryx Citation',
+  url: '/citation',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${citationExample.title}`, () => {
+      const engine = useTestEngine(citationExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getTitle reads the title attribute; getNumber parses the aria-label.
+      test(`getTitle and getNumber read the citation`, async () => {
+        assertEqual(await engine().parts.link.getTitle(), 'Example Source');
+        assertEqual(await engine().parts.link.getNumber(), 1);
+        assertEqual(await engine().parts.link.getVariant(), 'label');
+      });
+
+      // A source with a url renders an <a href>: getHref returns it and isLink is true.
+      test(`getHref and isLink detect the link case`, async () => {
+        assertEqual(await engine().parts.link.getHref(), 'https://example.com');
+        assertTrue(await engine().parts.link.isLink());
+      });
+
+      // A source without a url renders a <span>: no href, isLink is false.
+      test(`an unlinked citation has no href`, async () => {
+        assertEqual(await engine().parts.plain.getHref(), undefined);
+        assertFalse(await engine().parts.plain.isLink());
+        assertEqual(await engine().parts.plain.getNumber(), 2);
+      });
+
+      // The number variant exposes the same parsed number and its data-variant.
+      test(`reads the number variant`, async () => {
+        assertEqual(await engine().parts.number.getNumber(), 3);
+        assertEqual(await engine().parts.number.getVariant(), 'number');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/citation/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/citation/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { citationExample, citationExampleTestSuite } from './Citation.suite';
+
+export { citationUIExample } from './Citation.examples';
+export { citationExample, citationExampleTestSuite };
+
+export const citationExamples = [citationExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/code-block/CodeBlock.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/code-block/CodeBlock.examples.tsx
@@ -1,0 +1,44 @@
+import { CodeBlock } from '@astryxdesign/core/CodeBlock';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx CodeBlock scene.
+ *
+ * CodeBlock renders a `<pre data-language>` root (with `data-testid`) around a
+ * `<code>` whose lines are `<div data-line>`. The `basic` instance shows a
+ * language label and copy button; the `collapsible` instance sets a low threshold
+ * so it renders the `role="button"` collapse header (starting collapsed).
+ *
+ * The `large` instance has 150 lines — above Astryx's `LINE_CHUNK_THRESHOLD` (100),
+ * where the `<div data-line>` markers are wrapped in 20-line chunk `<div>`s instead
+ * of being flat children of `<code>`. A tag-based `nth-of-type` walk stops at the
+ * first chunk boundary (reporting 20); the driver descends through the chunk
+ * wrappers, so `getLineCount` is the full `150`.
+ */
+const largeCode = Array.from({ length: 150 }, (_, i) => `const v${i} = ${i};`).join('\n');
+
+export const CodeBlockExample = () => (
+  <div>
+    <CodeBlock
+      code={'const x = 1;\nconst y = 2;'}
+      language='javascript'
+      hasCopyButton
+      hasLanguageLabel
+      data-testid='codeblock-basic'
+    />
+    <CodeBlock
+      code={'line1\nline2\nline3'}
+      language='text'
+      isCollapsible
+      collapsibleThreshold={1}
+      data-testid='codeblock-collapsible'
+    />
+    <CodeBlock code={largeCode} language='javascript' data-testid='codeblock-large' />
+  </div>
+);
+
+export const codeBlockUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx CodeBlock',
+  ui: <CodeBlockExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/code-block/CodeBlock.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/code-block/CodeBlock.suite.ts
@@ -1,0 +1,64 @@
+import { CodeBlockDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { codeBlockUIExample } from './CodeBlock.examples';
+
+export const codeBlockExampleScenePart = {
+  basic: {
+    locator: byDataTestId('codeblock-basic'),
+    driver: CodeBlockDriver,
+  },
+  collapsible: {
+    locator: byDataTestId('codeblock-collapsible'),
+    driver: CodeBlockDriver,
+  },
+  large: {
+    locator: byDataTestId('codeblock-large'),
+    driver: CodeBlockDriver,
+  },
+} satisfies ScenePart;
+
+export const codeBlockExample: IExampleUnit<typeof codeBlockExampleScenePart, JSX.Element> = {
+  ...codeBlockUIExample,
+  scene: codeBlockExampleScenePart,
+};
+
+export const codeBlockExampleTestSuite: TestSuiteInfo<typeof codeBlockExample.scene> = {
+  title: 'Astryx CodeBlock',
+  url: '/code-block',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${codeBlockExample.title}`, () => {
+      const engine = useTestEngine(codeBlockExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getLanguage reads data-language; getCode reads the <code> text; lines are data-line markers.
+      test(`reads the language, code, and line count`, async () => {
+        assertEqual(await engine().parts.basic.getLanguage(), 'javascript');
+        assertTrue((await engine().parts.basic.getCode())?.includes('const x = 1;') ?? false);
+        assertEqual(await engine().parts.basic.getLineCount(), 2);
+      });
+
+      // A non-collapsible block has no collapse toggle, so it is never collapsed.
+      test(`a plain block is never collapsed`, async () => {
+        assertFalse(await engine().parts.basic.isCollapsed());
+      });
+
+      // Above 100 lines Astryx wraps the data-line markers in chunk <div>s; the
+      // line count must descend through those wrappers rather than count flat children.
+      test(`counts every line in a chunked (>100-line) block`, async () => {
+        assertEqual(await engine().parts.large.getLineCount(), 150);
+      });
+
+      // The collapsible block exposes a toggle; toggleCollapse flips its state.
+      // Astryx renders it expanded by default, so this goes expanded -> collapsed.
+      test(`toggleCollapse flips the collapsible block's state`, async () => {
+        assertEqual(await engine().parts.collapsible.getLanguage(), 'text');
+
+        const before = await engine().parts.collapsible.isCollapsed();
+        await engine().parts.collapsible.toggleCollapse();
+        assertEqual(await engine().parts.collapsible.isCollapsed(), !before);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/code-block/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/code-block/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { codeBlockExample, codeBlockExampleTestSuite } from './CodeBlock.suite';
+
+export { codeBlockUIExample } from './CodeBlock.examples';
+export { codeBlockExample, codeBlockExampleTestSuite };
+
+export const codeBlockExamples = [codeBlockExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/code/Code.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/code/Code.examples.tsx
@@ -1,0 +1,21 @@
+import { Code } from '@astryxdesign/core/Code';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Code scene.
+ *
+ * Code renders an inline `<code class="astryx-code">` (no role, no theme `data-*`).
+ * Two instances exercise the text read and disambiguation.
+ */
+export const CodeExample = () => (
+  <div>
+    <Code data-testid='code-1'>const x = 1</Code>
+    <Code data-testid='code-2'>npm install</Code>
+  </div>
+);
+
+export const codeUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Code',
+  ui: <CodeExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/code/Code.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/code/Code.suite.ts
@@ -1,0 +1,42 @@
+import { CodeDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { codeUIExample } from './Code.examples';
+
+export const codeExampleScenePart = {
+  first: {
+    locator: byDataTestId('code-1'),
+    driver: CodeDriver,
+  },
+  second: {
+    locator: byDataTestId('code-2'),
+    driver: CodeDriver,
+  },
+} satisfies ScenePart;
+
+export const codeExample: IExampleUnit<typeof codeExampleScenePart, JSX.Element> = {
+  ...codeUIExample,
+  scene: codeExampleScenePart,
+};
+
+export const codeExampleTestSuite: TestSuiteInfo<typeof codeExample.scene> = {
+  title: 'Astryx Code',
+  url: '/code',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${codeExample.title}`, () => {
+      const engine = useTestEngine(codeExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getText reads the inline code content.
+      test(`reads code text`, async () => {
+        assertEqual(await engine().parts.first.getText(), 'const x = 1');
+      });
+
+      // Two instances are disambiguated by their distinct testids.
+      test(`disambiguates two instances`, async () => {
+        assertEqual(await engine().parts.second.getText(), 'npm install');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/code/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/code/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { codeExample, codeExampleTestSuite } from './Code.suite';
+
+export { codeUIExample } from './Code.examples';
+export { codeExample, codeExampleTestSuite };
+
+export const codeExamples = [codeExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.examples.tsx
@@ -1,0 +1,38 @@
+import { ContextMenu } from '@astryxdesign/core/ContextMenu';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ContextMenu scene.
+ *
+ * A SINGLE instance is rendered on purpose: the driver reads the `role="menu"`
+ * items at the document root (the menu is a body-level popover with no id link back
+ * to its trigger), so two ContextMenus on one page would be ambiguous — a documented
+ * v1 limitation.
+ *
+ * A `divider` is placed between Copy and Paste deliberately: it renders as a
+ * `<div role="separator">`, a same-tag sibling of the `<div role="menuitem">`s, so
+ * it is exactly the case a tag-based `nth-of-type` walk drops the trailing item on.
+ * The driver enumerates by `:nth-child` + a `role="menuitem"` filter, so the three
+ * real items still read as `['Cut', 'Copy', 'Paste']` / count `3`.
+ *
+ * The scene anchors on the trigger `<div>`, which carries `aria-haspopup="menu"` and
+ * the forwarded `data-testid`.
+ */
+export const ContextMenuExample = () => (
+  <ContextMenu
+    items={[
+      { label: 'Cut', onClick: () => {} },
+      { label: 'Copy', onClick: () => {} },
+      { type: 'divider' },
+      { label: 'Paste', onClick: () => {} },
+    ]}
+    data-testid='ctx-menu'>
+    <div>Right-click here</div>
+  </ContextMenu>
+);
+
+export const contextMenuUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ContextMenu',
+  ui: <ContextMenuExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.suite.ts
@@ -1,0 +1,43 @@
+import { ContextMenuDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { contextMenuUIExample } from './ContextMenu.examples';
+
+export const contextMenuExampleScenePart = {
+  ctxMenu: {
+    locator: byDataTestId('ctx-menu'),
+    driver: ContextMenuDriver,
+  },
+} satisfies ScenePart;
+
+export const contextMenuExample: IExampleUnit<typeof contextMenuExampleScenePart, JSX.Element> = {
+  ...contextMenuUIExample,
+  scene: contextMenuExampleScenePart,
+};
+
+export const contextMenuExampleTestSuite: TestSuiteInfo<typeof contextMenuExample.scene> = {
+  title: 'Astryx ContextMenu',
+  url: '/context-menu',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${contextMenuExample.title}`, () => {
+      const engine = useTestEngine(contextMenuExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The trigger advertises a menu popup via aria-haspopup.
+      test(`getHasPopup reads the trigger's popup type`, async () => {
+        assertEqual(await engine().parts.ctxMenu.getHasPopup(), 'menu');
+      });
+
+      // Items stay mounted in the DOM while closed, so labels/count read in jsdom.
+      // Open-state is intentionally NOT asserted — it is E2E-only (native popover).
+      test(`getItemLabels reads every menu item in order`, async () => {
+        assertEqual(await engine().parts.ctxMenu.getItemLabels(), ['Cut', 'Copy', 'Paste']);
+      });
+
+      test(`getItemCount counts the menu items`, async () => {
+        assertEqual(await engine().parts.ctxMenu.getItemCount(), 3);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/context-menu/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/context-menu/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { contextMenuExample, contextMenuExampleTestSuite } from './ContextMenu.suite';
+
+export { contextMenuUIExample } from './ContextMenu.examples';
+export { contextMenuExample, contextMenuExampleTestSuite };
+
+export const contextMenuExamples = [contextMenuExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/divider/Divider.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/divider/Divider.examples.tsx
@@ -1,0 +1,23 @@
+import { Divider } from '@astryxdesign/core/Divider';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Divider scene.
+ *
+ * Divider renders a `<div role="separator">` carrying `data-variant` and
+ * `data-orientation`. A labeled divider renders three inner `<div>`s
+ * (line | label | line); an unlabeled one renders a single inner `<div>`. The two
+ * instances cover the labeled and unlabeled (label → `undefined`) cases.
+ */
+export const DividerExample = () => (
+  <div>
+    <Divider variant='subtle' label='or' data-testid='divider-labeled' />
+    <Divider variant='strong' data-testid='divider-plain' />
+  </div>
+);
+
+export const dividerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Divider',
+  ui: <DividerExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/divider/Divider.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/divider/Divider.suite.ts
@@ -1,0 +1,45 @@
+import { DividerDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { dividerUIExample } from './Divider.examples';
+
+export const dividerExampleScenePart = {
+  labeled: {
+    locator: byDataTestId('divider-labeled'),
+    driver: DividerDriver,
+  },
+  plain: {
+    locator: byDataTestId('divider-plain'),
+    driver: DividerDriver,
+  },
+} satisfies ScenePart;
+
+export const dividerExample: IExampleUnit<typeof dividerExampleScenePart, JSX.Element> = {
+  ...dividerUIExample,
+  scene: dividerExampleScenePart,
+};
+
+export const dividerExampleTestSuite: TestSuiteInfo<typeof dividerExample.scene> = {
+  title: 'Astryx Divider',
+  url: '/divider',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${dividerExample.title}`, () => {
+      const engine = useTestEngine(dividerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getVariant/getOrientation read the stable data-* attributes; getLabel the middle child.
+      test(`reads variant, orientation, and label`, async () => {
+        assertEqual(await engine().parts.labeled.getVariant(), 'subtle');
+        assertEqual(await engine().parts.labeled.getOrientation(), 'horizontal');
+        assertEqual(await engine().parts.labeled.getLabel(), 'or');
+      });
+
+      // An unlabeled divider has a single inner div, so getLabel is undefined.
+      test(`label is undefined when unlabeled`, async () => {
+        assertEqual(await engine().parts.plain.getVariant(), 'strong');
+        assertEqual(await engine().parts.plain.getLabel(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/divider/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/divider/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { dividerExample, dividerExampleTestSuite } from './Divider.suite';
+
+export { dividerUIExample } from './Divider.examples';
+export { dividerExample, dividerExampleTestSuite };
+
+export const dividerExamples = [dividerExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/empty-state/EmptyState.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/empty-state/EmptyState.examples.tsx
@@ -1,0 +1,33 @@
+import { EmptyState } from '@astryxdesign/core/EmptyState';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx EmptyState scene.
+ *
+ * EmptyState renders a `<div role="status">` (where `data-testid` is forwarded)
+ * around a heading, a `<p>` description, and — when `actions` are given — a
+ * trailing button. The `basic` instance omits actions and uses the default `<h3>`;
+ * the `withAction` instance sets `headingLevel={2}` and supplies an action button.
+ */
+export const EmptyStateExample = () => (
+  <div>
+    <EmptyState
+      title='No results found'
+      description='Try adjusting your search or filters.'
+      data-testid='empty-basic'
+    />
+    <EmptyState
+      title='Your inbox is empty'
+      description='Start a conversation to see it here.'
+      headingLevel={2}
+      actions={<button>Compose</button>}
+      data-testid='empty-with-action'
+    />
+  </div>
+);
+
+export const emptyStateUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx EmptyState',
+  ui: <EmptyStateExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/empty-state/EmptyState.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/empty-state/EmptyState.suite.ts
@@ -1,0 +1,55 @@
+import { EmptyStateDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { emptyStateUIExample } from './EmptyState.examples';
+
+export const emptyStateExampleScenePart = {
+  basic: {
+    locator: byDataTestId('empty-basic'),
+    driver: EmptyStateDriver,
+  },
+  withAction: {
+    locator: byDataTestId('empty-with-action'),
+    driver: EmptyStateDriver,
+  },
+} satisfies ScenePart;
+
+export const emptyStateExample: IExampleUnit<typeof emptyStateExampleScenePart, JSX.Element> = {
+  ...emptyStateUIExample,
+  scene: emptyStateExampleScenePart,
+};
+
+export const emptyStateExampleTestSuite: TestSuiteInfo<typeof emptyStateExample.scene> = {
+  title: 'Astryx EmptyState',
+  url: '/empty-state',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${emptyStateExample.title}`, () => {
+      const engine = useTestEngine(emptyStateExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getTitle / getDescription read the heading and paragraph text.
+      test(`reads the title and description`, async () => {
+        assertEqual(await engine().parts.basic.getTitle(), 'No results found');
+        assertEqual(await engine().parts.basic.getDescription(), 'Try adjusting your search or filters.');
+      });
+
+      // The default heading level is 3; headingLevel={2} renders an <h2>.
+      test(`getHeadingLevel reflects the rendered heading tag`, async () => {
+        assertEqual(await engine().parts.basic.getHeadingLevel(), 3);
+        assertEqual(await engine().parts.withAction.getHeadingLevel(), 2);
+      });
+
+      // hasAction is true only for the instance given an actions button.
+      test(`hasAction distinguishes the actioned instance`, async () => {
+        assertFalse(await engine().parts.basic.hasAction());
+        assertTrue(await engine().parts.withAction.hasAction());
+      });
+
+      // isPresent mirrors exists for a rendered empty state.
+      test(`isPresent is true when rendered`, async () => {
+        assertTrue(await engine().parts.basic.isPresent());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/empty-state/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/empty-state/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { emptyStateExample, emptyStateExampleTestSuite } from './EmptyState.suite';
+
+export { emptyStateUIExample } from './EmptyState.examples';
+export { emptyStateExample, emptyStateExampleTestSuite };
+
+export const emptyStateExamples = [emptyStateExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.examples.tsx
@@ -1,0 +1,43 @@
+import { FileInput } from '@astryxdesign/core/FileInput';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx FileInput scene.
+ *
+ * FileInput is a controlled component (`value` + `onChange` are required), so each
+ * instance gets `value={null}` and a no-op `onChange`. Astryx forwards `data-testid`
+ * onto the **hidden native `<input type="file">`** — where `accept`, `multiple`,
+ * `aria-required`, `aria-invalid`, `disabled`, and the `aria-describedby` status link
+ * all live — so the scene anchors there.
+ *
+ * Three instances cover the readable surface: a basic single-file input, a required
+ * multi-file dropzone, and a disabled input carrying an error `status`.
+ */
+export const FileInputExample = () => (
+  <div>
+    <FileInput label='Resume' accept='.pdf,.doc' value={null} onChange={() => {}} data-testid='fi-basic' />
+    <FileInput
+      label='Attachments'
+      mode='dropzone'
+      isMultiple
+      isRequired
+      value={null}
+      onChange={() => {}}
+      data-testid='fi-multi'
+    />
+    <FileInput
+      label='Document'
+      isDisabled
+      status={{ type: 'error', message: 'File too large' }}
+      value={null}
+      onChange={() => {}}
+      data-testid='fi-error'
+    />
+  </div>
+);
+
+export const fileInputUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx FileInput',
+  ui: <FileInputExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.suite.ts
@@ -1,0 +1,67 @@
+import { FileInputDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { fileInputUIExample } from './FileInput.examples';
+
+export const fileInputExampleScenePart = {
+  fiBasic: {
+    locator: byDataTestId('fi-basic'),
+    driver: FileInputDriver,
+  },
+  fiMulti: {
+    locator: byDataTestId('fi-multi'),
+    driver: FileInputDriver,
+  },
+  fiError: {
+    locator: byDataTestId('fi-error'),
+    driver: FileInputDriver,
+  },
+} satisfies ScenePart;
+
+export const fileInputExample: IExampleUnit<typeof fileInputExampleScenePart, JSX.Element> = {
+  ...fileInputUIExample,
+  scene: fileInputExampleScenePart,
+};
+
+export const fileInputExampleTestSuite: TestSuiteInfo<typeof fileInputExample.scene> = {
+  title: 'Astryx FileInput',
+  url: '/file-input',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${fileInputExample.title}`, () => {
+      const engine = useTestEngine(fileInputExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // accept + label read off the native input and its for/id-linked <label>.
+      test(`getAccept and getLabel read the basic field`, async () => {
+        assertEqual(await engine().parts.fiBasic.getAccept(), '.pdf,.doc');
+        assertEqual(await engine().parts.fiBasic.getLabel(), 'Resume');
+      });
+
+      // isMultiple/isRequired reflect the multi-file dropzone's input attributes.
+      test(`isMultiple and isRequired read the multi field`, async () => {
+        assertTrue(await engine().parts.fiMulti.isMultiple());
+        assertTrue(await engine().parts.fiMulti.isRequired());
+      });
+
+      // isDisabled/isInvalid + the aria-describedby status link read the error field.
+      test(`isDisabled, isInvalid and getStatusMessage read the error field`, async () => {
+        assertTrue(await engine().parts.fiError.isDisabled());
+        assertTrue(await engine().parts.fiError.isInvalid());
+        assertEqual(await engine().parts.fiError.getStatusMessage(), 'File too large');
+      });
+
+      // A field with no status carries no aria-describedby → undefined.
+      test(`getStatusMessage is undefined without a status`, async () => {
+        assertEqual(await engine().parts.fiBasic.getStatusMessage(), undefined);
+      });
+
+      // The basic field is neither multiple nor required nor disabled.
+      test(`basic field is single, optional and enabled`, async () => {
+        assertFalse(await engine().parts.fiBasic.isMultiple());
+        assertFalse(await engine().parts.fiBasic.isRequired());
+        assertFalse(await engine().parts.fiBasic.isDisabled());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/file-input/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/file-input/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { fileInputExample, fileInputExampleTestSuite } from './FileInput.suite';
+
+export { fileInputUIExample } from './FileInput.examples';
+export { fileInputExample, fileInputExampleTestSuite };
+
+export const fileInputExamples = [fileInputExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/heading/Heading.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/heading/Heading.examples.tsx
@@ -1,0 +1,28 @@
+import { Heading } from '@astryxdesign/core/Heading';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Heading scene.
+ *
+ * Heading renders a native `<h1>`–`<h6>` (role `heading`) reflecting the level as
+ * `data-level`. The first instance leaves `accessibilityLevel` at its default
+ * (no `aria-level` emitted, so accessibility level falls back to `data-level`);
+ * the second sets `accessibilityLevel={3}` on a level-2 heading, emitting
+ * `aria-level="3"` distinct from the visual level.
+ */
+export const HeadingExample = () => (
+  <div>
+    <Heading level={1} data-testid='heading-plain'>
+      Page Title
+    </Heading>
+    <Heading level={2} accessibilityLevel={3} data-testid='heading-aria'>
+      Section
+    </Heading>
+  </div>
+);
+
+export const headingUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Heading',
+  ui: <HeadingExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/heading/Heading.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/heading/Heading.suite.ts
@@ -1,0 +1,49 @@
+import { HeadingDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { headingUIExample } from './Heading.examples';
+
+export const headingExampleScenePart = {
+  plain: {
+    locator: byDataTestId('heading-plain'),
+    driver: HeadingDriver,
+  },
+  aria: {
+    locator: byDataTestId('heading-aria'),
+    driver: HeadingDriver,
+  },
+} satisfies ScenePart;
+
+export const headingExample: IExampleUnit<typeof headingExampleScenePart, JSX.Element> = {
+  ...headingUIExample,
+  scene: headingExampleScenePart,
+};
+
+export const headingExampleTestSuite: TestSuiteInfo<typeof headingExample.scene> = {
+  title: 'Astryx Heading',
+  url: '/heading',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${headingExample.title}`, () => {
+      const engine = useTestEngine(headingExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getLevel reads the always-present data-level as a number; getText the content.
+      test(`reads level and text`, async () => {
+        assertEqual(await engine().parts.plain.getLevel(), 1);
+        assertEqual(await engine().parts.plain.getText(), 'Page Title');
+      });
+
+      // With no accessibilityLevel override, aria-level is absent, so it falls back to level.
+      test(`accessibility level falls back to level when not overridden`, async () => {
+        assertEqual(await engine().parts.plain.getAccessibilityLevel(), 1);
+      });
+
+      // A level-2 heading with accessibilityLevel={3} keeps data-level=2 but aria-level=3.
+      test(`accessibility level reflects the override`, async () => {
+        assertEqual(await engine().parts.aria.getLevel(), 2);
+        assertEqual(await engine().parts.aria.getAccessibilityLevel(), 3);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/heading/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/heading/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { headingExample, headingExampleTestSuite } from './Heading.suite';
+
+export { headingUIExample } from './Heading.examples';
+export { headingExample, headingExampleTestSuite };
+
+export const headingExamples = [headingExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/hover-card/HoverCard.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/hover-card/HoverCard.examples.tsx
@@ -1,0 +1,23 @@
+import { HoverCard } from '@astryxdesign/core/HoverCard';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx HoverCard scene.
+ *
+ * The floating layer is a body-level popover with no role/testid/open-state; the
+ * only stable link is the trigger's injected `aria-describedby` → the layer's `id`.
+ * The scene anchors on the trigger (`data-testid`); the driver follows that link to
+ * read the layer's content. The layer stays mounted in jsdom (no native Popover API),
+ * so content reads in both states — but open/visibility is E2E-only and not asserted.
+ */
+export const HoverCardExample = () => (
+  <HoverCard content={<div>Hover card content</div>}>
+    <button data-testid='hc-trigger'>Hover me</button>
+  </HoverCard>
+);
+
+export const hoverCardUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx HoverCard',
+  ui: <HoverCardExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/hover-card/HoverCard.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/hover-card/HoverCard.suite.ts
@@ -1,0 +1,39 @@
+import { HoverCardDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { hoverCardUIExample } from './HoverCard.examples';
+
+export const hoverCardExampleScenePart = {
+  hc: {
+    locator: byDataTestId('hc-trigger'),
+    driver: HoverCardDriver,
+  },
+} satisfies ScenePart;
+
+export const hoverCardExample: IExampleUnit<typeof hoverCardExampleScenePart, JSX.Element> = {
+  ...hoverCardUIExample,
+  scene: hoverCardExampleScenePart,
+};
+
+export const hoverCardExampleTestSuite: TestSuiteInfo<typeof hoverCardExample.scene> = {
+  title: 'Astryx HoverCard',
+  url: '/hover-card',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${hoverCardExample.title}`, () => {
+      const engine = useTestEngine(hoverCardExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The trigger's own text reads directly.
+      test(`getTriggerText reads the trigger label`, async () => {
+        assertEqual(await engine().parts.hc.getTriggerText(), 'Hover me');
+      });
+
+      // The layer stays mounted in jsdom, so getContent reads through aria-describedby.
+      // Open/visibility is E2E-only and NOT asserted here.
+      test(`getContent reads the layer content via aria-describedby`, async () => {
+        assertEqual(await engine().parts.hc.getContent(), 'Hover card content');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/hover-card/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/hover-card/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { hoverCardExample, hoverCardExampleTestSuite } from './HoverCard.suite';
+
+export { hoverCardUIExample } from './HoverCard.examples';
+export { hoverCardExample, hoverCardExampleTestSuite };
+
+export const hoverCardExamples = [hoverCardExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/index.ts
@@ -46,3 +46,58 @@ export * from './date-input';
 export * from './date-time-input';
 export * from './date-range-input';
 export * from './power-search';
+
+// Display & typography (Wave 4)
+export * from './badge';
+export * from './text';
+export * from './heading';
+export * from './code';
+export * from './blockquote';
+export * from './timestamp';
+export * from './divider';
+
+// Media & status (Wave 4)
+export * from './status-dot';
+export * from './citation';
+export * from './token';
+export * from './avatar';
+export * from './avatar-group';
+export * from './thumbnail';
+
+// Feedback & misc (Wave 4)
+export * from './empty-state';
+export * from './progress-bar';
+export * from './spinner';
+export * from './nav-icon';
+export * from './item';
+export * from './markdown';
+export * from './code-block';
+
+// Nav chrome (Wave 4)
+export * from './top-nav';
+export * from './top-nav-item';
+export * from './top-nav-menu';
+export * from './top-nav-mega-menu';
+export * from './breadcrumbs';
+export * from './side-nav';
+export * from './side-nav-item';
+export * from './mobile-nav';
+
+// Hard set, best-effort v1 (Wave 4)
+export * from './file-input';
+export * from './context-menu';
+export * from './app-shell';
+export * from './chat-composer-input';
+export * from './chat-composer';
+export * from './hover-card';
+export * from './tooltip';
+
+// Chat suite (Wave 4)
+export * from './chat-message';
+export * from './chat-message-bubble';
+export * from './chat-message-list';
+export * from './chat-system-message';
+export * from './chat-tool-calls';
+export * from './chat-layout';
+export * from './chat-send-button';
+export * from './chat-dictation-button';

--- a/package-tests/component-driver-astryx-test/src/examples/item/Item.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/item/Item.examples.tsx
@@ -1,0 +1,26 @@
+import { Item } from '@astryxdesign/core/Item';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Item scene.
+ *
+ * Item renders the tag chosen by `as` (default `<div>`, also `<li>`), carrying
+ * `data-density`/`data-align` and `data-testid` on the root. `aria-selected` is
+ * emitted only on an `<li>` root. The `basic` instance is a plain `<div>`; the
+ * `selected` instance is an `<li>` marked selected so the driver can read
+ * `aria-selected`.
+ */
+export const ItemExample = () => (
+  <div>
+    <Item label='John Doe' description='Software Engineer' data-testid='item-basic' />
+    <ul>
+      <Item as='li' label='Jane Smith' isSelected data-testid='item-li' />
+    </ul>
+  </div>
+);
+
+export const itemUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Item',
+  ui: <ItemExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/item/Item.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/item/Item.suite.ts
@@ -1,0 +1,50 @@
+import { ItemDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { itemUIExample } from './Item.examples';
+
+export const itemExampleScenePart = {
+  basic: {
+    locator: byDataTestId('item-basic'),
+    driver: ItemDriver,
+  },
+  selected: {
+    locator: byDataTestId('item-li'),
+    driver: ItemDriver,
+  },
+} satisfies ScenePart;
+
+export const itemExample: IExampleUnit<typeof itemExampleScenePart, JSX.Element> = {
+  ...itemUIExample,
+  scene: itemExampleScenePart,
+};
+
+export const itemExampleTestSuite: TestSuiteInfo<typeof itemExample.scene> = {
+  title: 'Astryx Item',
+  url: '/item',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${itemExample.title}`, () => {
+      const engine = useTestEngine(itemExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // density/align come from the root data-* attributes; the label is the text content.
+      test(`reads the density, align, and label`, async () => {
+        assertTrue((await engine().parts.basic.getLabel())?.includes('John Doe') ?? false);
+        assertEqual(await engine().parts.basic.getDensity(), 'balanced');
+        assertEqual(await engine().parts.basic.getAlign(), 'center');
+      });
+
+      // aria-selected is emitted only on an <li> root, so the <div> item is never selected.
+      test(`isSelected is true only for the selected <li> item`, async () => {
+        assertFalse(await engine().parts.basic.isSelected());
+        assertTrue(await engine().parts.selected.isSelected());
+      });
+
+      // Neither item is a link, so getHref is undefined.
+      test(`getHref is undefined for non-link items`, async () => {
+        assertEqual(await engine().parts.basic.getHref(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/item/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/item/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { itemExample, itemExampleTestSuite } from './Item.suite';
+
+export { itemUIExample } from './Item.examples';
+export { itemExample, itemExampleTestSuite };
+
+export const itemExamples = [itemExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/markdown/Markdown.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/markdown/Markdown.examples.tsx
@@ -1,0 +1,43 @@
+import { Markdown } from '@astryxdesign/core/Markdown';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+const blockSource = `# Hello World
+
+This is a [link](https://example.com) and text.
+
+## Resources
+
+See the [API docs](https://example.com/api) for details.
+
+\`\`\`javascript
+const x = 1;
+\`\`\`
+
+And \`inline code\` here.`;
+
+/**
+ * Astryx Markdown scene.
+ *
+ * Markdown renders its source to native HTML under a root whose shape depends on
+ * `display`: a block `<div role="document">` or an inline `<span>` (no role). The
+ * `block` instance contains two headings and two links — each link in its own
+ * `<p>`, so the two `<a>`s have different parents. That is the case a tag-based
+ * `nth-of-type` walk undercounts (every link is the sole `<a>` of its paragraph);
+ * the driver counts links/headings by descending through the block wrappers, so
+ * `getLinkCount` and `getHeadingCount` are both `2`. The `inline` instance is a
+ * single inline span with no heading or link.
+ */
+export const MarkdownExample = () => (
+  <div>
+    <Markdown data-testid='markdown-block'>{blockSource}</Markdown>
+    <Markdown display='inline' data-testid='markdown-inline'>
+      Inline **bold** and `code`.
+    </Markdown>
+  </div>
+);
+
+export const markdownUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Markdown',
+  ui: <MarkdownExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/markdown/Markdown.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/markdown/Markdown.suite.ts
@@ -1,0 +1,50 @@
+import { MarkdownDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { markdownUIExample } from './Markdown.examples';
+
+export const markdownExampleScenePart = {
+  block: {
+    locator: byDataTestId('markdown-block'),
+    driver: MarkdownDriver,
+  },
+  inline: {
+    locator: byDataTestId('markdown-inline'),
+    driver: MarkdownDriver,
+  },
+} satisfies ScenePart;
+
+export const markdownExample: IExampleUnit<typeof markdownExampleScenePart, JSX.Element> = {
+  ...markdownUIExample,
+  scene: markdownExampleScenePart,
+};
+
+export const markdownExampleTestSuite: TestSuiteInfo<typeof markdownExample.scene> = {
+  title: 'Astryx Markdown',
+  url: '/markdown',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${markdownExample.title}`, () => {
+      const engine = useTestEngine(markdownExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The block root is role="document"; the inline root is a roleless span.
+      test(`isInline distinguishes block from inline rendering`, async () => {
+        assertFalse(await engine().parts.block.isInline());
+        assertTrue(await engine().parts.inline.isInline());
+      });
+
+      // The block source has two headings and two links (each link in its own
+      // paragraph, so they have different parents); the inline source has neither.
+      test(`counts headings and links in the block`, async () => {
+        assertEqual(await engine().parts.block.getHeadingCount(), 2);
+        assertEqual(await engine().parts.block.getLinkCount(), 2);
+      });
+
+      test(`inline markdown has no headings or links`, async () => {
+        assertEqual(await engine().parts.inline.getHeadingCount(), 0);
+        assertEqual(await engine().parts.inline.getLinkCount(), 0);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/markdown/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/markdown/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { markdownExample, markdownExampleTestSuite } from './Markdown.suite';
+
+export { markdownUIExample } from './Markdown.examples';
+export { markdownExample, markdownExampleTestSuite };
+
+export const markdownExamples = [markdownExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/mobile-nav/MobileNav.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/mobile-nav/MobileNav.examples.tsx
@@ -1,0 +1,25 @@
+import { MobileNav } from '@astryxdesign/core/MobileNav';
+import { SideNavItem } from '@astryxdesign/core/SideNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx MobileNav scene.
+ *
+ * MobileNav is an inline native `<dialog class="astryx-mobile-nav">` drawer that
+ * forwards `data-testid`, names itself via `aria-label`, records its slide edge in
+ * `data-side`, and renders a `<button aria-label="Close navigation">` plus its
+ * children. It is rendered CLOSED (`isOpen={false}`): the structure is present and
+ * readable in jsdom, but the open transition (`showModal()`) is a no-op there and is
+ * exercised only by the E2E run. An explicit `side` makes `data-side` deterministic.
+ */
+export const MobileNavExample = () => (
+  <MobileNav isOpen={false} header='Navigation' label='Mobile navigation' side='start' data-testid='mobile-nav'>
+    <SideNavItem label='Home' href='/' />
+  </MobileNav>
+);
+
+export const mobileNavUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx MobileNav',
+  ui: <MobileNavExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/mobile-nav/MobileNav.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/mobile-nav/MobileNav.suite.ts
@@ -1,0 +1,43 @@
+import { MobileNavDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { mobileNavUIExample } from './MobileNav.examples';
+
+export const mobileNavExampleScenePart = {
+  mobileNav: {
+    locator: byDataTestId('mobile-nav'),
+    driver: MobileNavDriver,
+  },
+} satisfies ScenePart;
+
+export const mobileNavExample: IExampleUnit<typeof mobileNavExampleScenePart, JSX.Element> = {
+  ...mobileNavUIExample,
+  scene: mobileNavExampleScenePart,
+};
+
+export const mobileNavExampleTestSuite: TestSuiteInfo<typeof mobileNavExample.scene> = {
+  title: 'Astryx MobileNav',
+  url: '/mobile-nav',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${mobileNavExample.title}`, () => {
+      const engine = useTestEngine(mobileNavExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel and getSide read the drawer chrome`, async () => {
+        assertEqual(await engine().parts.mobileNav.getLabel(), 'Mobile navigation');
+        assertEqual(await engine().parts.mobileNav.getSide(), 'start');
+      });
+
+      test(`hasCloseButton detects the close affordance`, async () => {
+        assertTrue(await engine().parts.mobileNav.hasCloseButton());
+      });
+
+      // Closed-state read only: showModal() is a no-op in jsdom, so isOpen() is false
+      // regardless of the isOpen prop (its true case is E2E-only — never asserted here).
+      test(`isOpen reports the closed state`, async () => {
+        assertFalse(await engine().parts.mobileNav.isOpen());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/mobile-nav/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/mobile-nav/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { mobileNavExample, mobileNavExampleTestSuite } from './MobileNav.suite';
+
+export { mobileNavUIExample } from './MobileNav.examples';
+export { mobileNavExample, mobileNavExampleTestSuite };
+
+export const mobileNavExamples = [mobileNavExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.examples.tsx
@@ -1,0 +1,21 @@
+import { NavIcon } from '@astryxdesign/core/NavIcon';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx NavIcon scene.
+ *
+ * NavIcon is a display-only `<span class="astryx-navicon">` (with `data-testid`
+ * forwarded) wrapping the supplied `icon` node. The scene renders a single
+ * instance with a star glyph so the driver can read its markup.
+ */
+export const NavIconExample = () => (
+  <div>
+    <NavIcon icon={<span>★</span>} data-testid='navicon-basic' />
+  </div>
+);
+
+export const navIconUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx NavIcon',
+  ui: <NavIconExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.suite.ts
@@ -1,0 +1,34 @@
+import { NavIconDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { navIconUIExample } from './NavIcon.examples';
+
+export const navIconExampleScenePart = {
+  basic: {
+    locator: byDataTestId('navicon-basic'),
+    driver: NavIconDriver,
+  },
+} satisfies ScenePart;
+
+export const navIconExample: IExampleUnit<typeof navIconExampleScenePart, JSX.Element> = {
+  ...navIconUIExample,
+  scene: navIconExampleScenePart,
+};
+
+export const navIconExampleTestSuite: TestSuiteInfo<typeof navIconExample.scene> = {
+  title: 'Astryx NavIcon',
+  url: '/nav-icon',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertTrue }) => {
+    describe(`${navIconExample.title}`, () => {
+      const engine = useTestEngine(navIconExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // NavIcon is display-only: it exists and renders the supplied icon markup.
+      test(`renders the icon and is present`, async () => {
+        assertTrue(await engine().parts.basic.exists());
+        assertTrue((await engine().parts.basic.innerHTML()).includes('★'));
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/nav-icon/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/nav-icon/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { navIconExample, navIconExampleTestSuite } from './NavIcon.suite';
+
+export { navIconUIExample } from './NavIcon.examples';
+export { navIconExample, navIconExampleTestSuite };
+
+export const navIconExamples = [navIconExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/progress-bar/ProgressBar.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/progress-bar/ProgressBar.examples.tsx
@@ -1,0 +1,30 @@
+import { ProgressBar } from '@astryxdesign/core/ProgressBar';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx ProgressBar scene.
+ *
+ * The root `<div>` is roleless (it carries `data-testid`/`data-variant`); the ARIA
+ * role lives on an inner track that switches between `role="meter"` (determinate,
+ * with `aria-value*`) and `role="progressbar"` (indeterminate, no `aria-value*`).
+ * The `determinate` instance pins a value; the `indeterminate` instance omits one.
+ */
+export const ProgressBarExample = () => (
+  <div>
+    <ProgressBar
+      label='Upload progress'
+      value={75}
+      max={100}
+      hasValueLabel
+      variant='accent'
+      data-testid='progress-determinate'
+    />
+    <ProgressBar label='Loading...' isIndeterminate data-testid='progress-indeterminate' />
+  </div>
+);
+
+export const progressBarUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx ProgressBar',
+  ui: <ProgressBarExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/progress-bar/ProgressBar.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/progress-bar/ProgressBar.suite.ts
@@ -1,0 +1,55 @@
+import { ProgressBarDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { progressBarUIExample } from './ProgressBar.examples';
+
+export const progressBarExampleScenePart = {
+  determinate: {
+    locator: byDataTestId('progress-determinate'),
+    driver: ProgressBarDriver,
+  },
+  indeterminate: {
+    locator: byDataTestId('progress-indeterminate'),
+    driver: ProgressBarDriver,
+  },
+} satisfies ScenePart;
+
+export const progressBarExample: IExampleUnit<typeof progressBarExampleScenePart, JSX.Element> = {
+  ...progressBarUIExample,
+  scene: progressBarExampleScenePart,
+};
+
+export const progressBarExampleTestSuite: TestSuiteInfo<typeof progressBarExample.scene> = {
+  title: 'Astryx ProgressBar',
+  url: '/progress-bar',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${progressBarExample.title}`, () => {
+      const engine = useTestEngine(progressBarExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // A determinate bar exposes aria-value* off its role="meter" track.
+      test(`reads the determinate value range`, async () => {
+        assertEqual(await engine().parts.determinate.getValueNow(), '75');
+        assertEqual(await engine().parts.determinate.getValueMin(), '0');
+        assertEqual(await engine().parts.determinate.getValueMax(), '100');
+        assertEqual(await engine().parts.determinate.getValueText(), '75%');
+        assertFalse(await engine().parts.determinate.isIndeterminate());
+      });
+
+      // The label and variant come from the header span and the root respectively.
+      test(`reads the label and variant`, async () => {
+        assertEqual(await engine().parts.determinate.getLabel(), 'Upload progress');
+        assertEqual(await engine().parts.determinate.getVariant(), 'accent');
+      });
+
+      // An indeterminate bar uses role="progressbar" and emits no aria-value*.
+      test(`indeterminate bar has no value and is flagged`, async () => {
+        assertTrue(await engine().parts.indeterminate.isIndeterminate());
+        assertEqual(await engine().parts.indeterminate.getValueNow(), undefined);
+        assertEqual(await engine().parts.indeterminate.getValueText(), undefined);
+        assertEqual(await engine().parts.indeterminate.getLabel(), 'Loading...');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/progress-bar/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/progress-bar/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { progressBarExample, progressBarExampleTestSuite } from './ProgressBar.suite';
+
+export { progressBarUIExample } from './ProgressBar.examples';
+export { progressBarExample, progressBarExampleTestSuite };
+
+export const progressBarExamples = [progressBarExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav-item/SideNavItem.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav-item/SideNavItem.examples.tsx
@@ -1,0 +1,29 @@
+import { SideNav, SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx SideNavItem scene.
+ *
+ * A SideNavItem renders one of two shapes: a leaf is an
+ * `<a class="astryx-side-nav-item">` (the root is the anchor), while a
+ * collapsible-with-children item is a `<div>` wrapping an `<a href>` and a
+ * `<button aria-expanded>` toggle. Rendering a selected leaf and a collapsible item
+ * (each with its own `data-testid`, inside their SideNav host) lets the driver verify
+ * selection, href, label, and expansion across both shapes.
+ */
+export const SideNavItemExample = () => (
+  <SideNav data-testid='side-nav'>
+    <SideNavSection title='Main'>
+      <SideNavItem label='Dashboard' href='/dashboard' isSelected data-testid='sni-leaf' />
+      <SideNavItem label='Settings' href='/settings' collapsible data-testid='sni-collapsible'>
+        <SideNavItem label='Profile' href='/settings/profile' />
+      </SideNavItem>
+    </SideNavSection>
+  </SideNav>
+);
+
+export const sideNavItemUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx SideNavItem',
+  ui: <SideNavItemExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav-item/SideNavItem.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav-item/SideNavItem.suite.ts
@@ -1,0 +1,53 @@
+import { SideNavItemDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { sideNavItemUIExample } from './SideNavItem.examples';
+
+export const sideNavItemExampleScenePart = {
+  leaf: {
+    locator: byDataTestId('sni-leaf'),
+    driver: SideNavItemDriver,
+  },
+  collapsible: {
+    locator: byDataTestId('sni-collapsible'),
+    driver: SideNavItemDriver,
+  },
+} satisfies ScenePart;
+
+export const sideNavItemExample: IExampleUnit<typeof sideNavItemExampleScenePart, JSX.Element> = {
+  ...sideNavItemUIExample,
+  scene: sideNavItemExampleScenePart,
+};
+
+export const sideNavItemExampleTestSuite: TestSuiteInfo<typeof sideNavItemExample.scene> = {
+  title: 'Astryx SideNavItem',
+  url: '/side-nav-item',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${sideNavItemExample.title}`, () => {
+      const engine = useTestEngine(sideNavItemExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The leaf root is the anchor; the collapsible root is a <div> wrapping an <a>.
+      test(`getLabel and getHref read both item shapes`, async () => {
+        assertEqual(await engine().parts.leaf.getLabel(), 'Dashboard');
+        assertEqual(await engine().parts.leaf.getHref(), '/dashboard');
+        assertEqual(await engine().parts.collapsible.getLabel(), 'Settings');
+        assertEqual(await engine().parts.collapsible.getHref(), '/settings');
+      });
+
+      // isSelected reads aria-current="page" off the root or its anchor.
+      test(`isSelected distinguishes the current leaf`, async () => {
+        assertTrue(await engine().parts.leaf.isSelected());
+        assertFalse(await engine().parts.collapsible.isSelected());
+      });
+
+      // isExpanded reads the toggle's aria-expanded; a leaf has no toggle (undefined).
+      // A collapsible item starts expanded by default.
+      test(`isExpanded reflects the toggle, undefined for a leaf`, async () => {
+        assertEqual(await engine().parts.leaf.isExpanded(), undefined);
+        assertTrue(await engine().parts.collapsible.isExpanded());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav-item/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav-item/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { sideNavItemExample, sideNavItemExampleTestSuite } from './SideNavItem.suite';
+
+export { sideNavItemUIExample } from './SideNavItem.examples';
+export { sideNavItemExample, sideNavItemExampleTestSuite };
+
+export const sideNavItemExamples = [sideNavItemExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav/SideNav.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav/SideNav.examples.tsx
@@ -1,0 +1,37 @@
+import { SideNav, SideNavHeading, SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx SideNav scene.
+ *
+ * SideNav is a `<nav aria-label="Side navigation">` (the label is hardcoded — there
+ * is no `label` prop) that forwards `data-testid` onto its root. Its `children`
+ * render as `[role="group"]` sections, and `collapsible` adds a footer
+ * `<button aria-label="Collapse …">`. Two sections plus a collapsible toggle let the
+ * driver verify the section count and collapse-button presence.
+ *
+ * A standalone top-level `SideNavItem` ("Home") is placed BEFORE the sections on
+ * purpose: it renders a roleless `<div>` sibling of the `<div role="group">`
+ * sections, so it is exactly the case a tag-based `nth-of-type` walk mis-indexes
+ * (`[role="group"]:nth-of-type(1)` would require the first `<div>` to be a group).
+ * The driver counts by `:nth-child` + a `role="group"` filter, so `getSectionCount`
+ * is still `2`.
+ */
+export const SideNavExample = () => (
+  <SideNav data-testid='side-nav' header={<SideNavHeading heading='My App' headingHref='/' />} collapsible>
+    <SideNavItem label='Home' href='/' />
+    <SideNavSection title='Main'>
+      <SideNavItem label='Dashboard' href='/dashboard' isSelected />
+      <SideNavItem label='Reports' href='/reports' />
+    </SideNavSection>
+    <SideNavSection title='Settings'>
+      <SideNavItem label='Profile' href='/profile' />
+    </SideNavSection>
+  </SideNav>
+);
+
+export const sideNavUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx SideNav',
+  ui: <SideNavExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav/SideNav.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav/SideNav.suite.ts
@@ -1,0 +1,42 @@
+import { SideNavDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { sideNavUIExample } from './SideNav.examples';
+
+export const sideNavExampleScenePart = {
+  sideNav: {
+    locator: byDataTestId('side-nav'),
+    driver: SideNavDriver,
+  },
+} satisfies ScenePart;
+
+export const sideNavExample: IExampleUnit<typeof sideNavExampleScenePart, JSX.Element> = {
+  ...sideNavUIExample,
+  scene: sideNavExampleScenePart,
+};
+
+export const sideNavExampleTestSuite: TestSuiteInfo<typeof sideNavExample.scene> = {
+  title: 'Astryx SideNav',
+  url: '/side-nav',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+    describe(`${sideNavExample.title}`, () => {
+      const engine = useTestEngine(sideNavExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getLabel reads the hardcoded aria-label (there is no label prop).
+      test(`getLabel reads the hardcoded landmark name`, async () => {
+        assertEqual(await engine().parts.sideNav.getLabel(), 'Side navigation');
+      });
+
+      test(`getSectionCount counts the SideNavSection groups`, async () => {
+        assertEqual(await engine().parts.sideNav.getSectionCount(), 2);
+      });
+
+      // The example is collapsible, so a collapse toggle is rendered.
+      test(`hasCollapseButton detects the collapse toggle`, async () => {
+        assertTrue(await engine().parts.sideNav.hasCollapseButton());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/side-nav/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/side-nav/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { sideNavExample, sideNavExampleTestSuite } from './SideNav.suite';
+
+export { sideNavUIExample } from './SideNav.examples';
+export { sideNavExample, sideNavExampleTestSuite };
+
+export const sideNavExamples = [sideNavExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/spinner/Spinner.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/spinner/Spinner.examples.tsx
@@ -1,0 +1,23 @@
+import { Spinner } from '@astryxdesign/core/Spinner';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Spinner scene.
+ *
+ * Spinner's structure is conditional: unlabeled, the root IS the
+ * `<span role="status" aria-label>` (default name `"Loading"`); labeled, the root
+ * is a roleless `<div>` wrapping the status span plus a visible `astryx-text`
+ * label. The two instances cover both shapes.
+ */
+export const SpinnerExample = () => (
+  <div>
+    <Spinner data-testid='spinner-unlabeled' />
+    <Spinner label='Loading...' data-testid='spinner-labeled' />
+  </div>
+);
+
+export const spinnerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Spinner',
+  ui: <SpinnerExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/spinner/Spinner.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/spinner/Spinner.suite.ts
@@ -1,0 +1,45 @@
+import { SpinnerDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { spinnerUIExample } from './Spinner.examples';
+
+export const spinnerExampleScenePart = {
+  unlabeled: {
+    locator: byDataTestId('spinner-unlabeled'),
+    driver: SpinnerDriver,
+  },
+  labeled: {
+    locator: byDataTestId('spinner-labeled'),
+    driver: SpinnerDriver,
+  },
+} satisfies ScenePart;
+
+export const spinnerExample: IExampleUnit<typeof spinnerExampleScenePart, JSX.Element> = {
+  ...spinnerUIExample,
+  scene: spinnerExampleScenePart,
+};
+
+export const spinnerExampleTestSuite: TestSuiteInfo<typeof spinnerExample.scene> = {
+  title: 'Astryx Spinner',
+  url: '/spinner',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertNotEqual }) => {
+    describe(`${spinnerExample.title}`, () => {
+      const engine = useTestEngine(spinnerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // Unlabeled: the root itself is the role="status" region with the default name.
+      test(`unlabeled spinner exposes the default accessible name and no visible label`, async () => {
+        assertEqual(await engine().parts.unlabeled.getAccessibleName(), 'Loading');
+        assertEqual(await engine().parts.unlabeled.getLabelText(), undefined);
+      });
+
+      // Labeled: the visible astryx-text label is present and the descendant status
+      // span still provides an accessible name.
+      test(`labeled spinner exposes the visible label`, async () => {
+        assertEqual(await engine().parts.labeled.getLabelText(), 'Loading...');
+        assertNotEqual(await engine().parts.labeled.getAccessibleName(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/spinner/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/spinner/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { spinnerExample, spinnerExampleTestSuite } from './Spinner.suite';
+
+export { spinnerUIExample } from './Spinner.examples';
+export { spinnerExample, spinnerExampleTestSuite };
+
+export const spinnerExamples = [spinnerExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/status-dot/StatusDot.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/status-dot/StatusDot.examples.tsx
@@ -1,0 +1,22 @@
+import { StatusDot } from '@astryxdesign/core/StatusDot';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx StatusDot scene.
+ *
+ * StatusDot renders a single `<span role="img">` whose accessible name is the
+ * verbatim `aria-label` (from `label`) and whose severity lives in `data-variant`.
+ * Two instances disambiguate the by-testid anchoring.
+ */
+export const StatusDotExample = () => (
+  <div>
+    <StatusDot variant='success' label='Online' data-testid='status-dot-1' />
+    <StatusDot variant='error' label='Offline' data-testid='status-dot-2' />
+  </div>
+);
+
+export const statusDotUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx StatusDot',
+  ui: <StatusDotExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/status-dot/StatusDot.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/status-dot/StatusDot.suite.ts
@@ -1,0 +1,49 @@
+import { StatusDotDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { statusDotUIExample } from './StatusDot.examples';
+
+export const statusDotExampleScenePart = {
+  online: {
+    locator: byDataTestId('status-dot-1'),
+    driver: StatusDotDriver,
+  },
+  offline: {
+    locator: byDataTestId('status-dot-2'),
+    driver: StatusDotDriver,
+  },
+} satisfies ScenePart;
+
+export const statusDotExample: IExampleUnit<typeof statusDotExampleScenePart, JSX.Element> = {
+  ...statusDotUIExample,
+  scene: statusDotExampleScenePart,
+};
+
+export const statusDotExampleTestSuite: TestSuiteInfo<typeof statusDotExample.scene> = {
+  title: 'Astryx StatusDot',
+  url: '/status-dot',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+    describe(`${statusDotExample.title}`, () => {
+      const engine = useTestEngine(statusDotExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getLabel reads the aria-label; getVariant the data-variant.
+      test(`getLabel and getVariant read the dot`, async () => {
+        assertEqual(await engine().parts.online.getLabel(), 'Online');
+        assertEqual(await engine().parts.online.getVariant(), 'success');
+      });
+
+      // Two instances disambiguate by testid.
+      test(`reads each dot independently`, async () => {
+        assertEqual(await engine().parts.offline.getLabel(), 'Offline');
+        assertEqual(await engine().parts.offline.getVariant(), 'error');
+      });
+
+      // isPresent is true for a rendered dot.
+      test(`isPresent reports a rendered dot`, async () => {
+        assertTrue(await engine().parts.online.isPresent());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/status-dot/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/status-dot/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { statusDotExample, statusDotExampleTestSuite } from './StatusDot.suite';
+
+export { statusDotUIExample } from './StatusDot.examples';
+export { statusDotExample, statusDotExampleTestSuite };
+
+export const statusDotExamples = [statusDotExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/text/Text.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/text/Text.examples.tsx
@@ -1,0 +1,27 @@
+import { Text } from '@astryxdesign/core/Text';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Text scene.
+ *
+ * Text renders a single element (no role) reflecting the semantic `type` as
+ * `data-type` and the RESOLVED color as `data-color`. The `supporting` instance
+ * resolves to `data-color="secondary"` with no explicit `color` prop, exercising
+ * the resolved-color read alongside the `body`/`primary` default.
+ */
+export const TextExample = () => (
+  <div>
+    <Text type='body' data-testid='text-body'>
+      Body text
+    </Text>
+    <Text type='supporting' data-testid='text-supporting'>
+      Supporting text
+    </Text>
+  </div>
+);
+
+export const textUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Text',
+  ui: <TextExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/text/Text.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/text/Text.suite.ts
@@ -1,0 +1,45 @@
+import { TextDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { textUIExample } from './Text.examples';
+
+export const textExampleScenePart = {
+  body: {
+    locator: byDataTestId('text-body'),
+    driver: TextDriver,
+  },
+  supporting: {
+    locator: byDataTestId('text-supporting'),
+    driver: TextDriver,
+  },
+} satisfies ScenePart;
+
+export const textExample: IExampleUnit<typeof textExampleScenePart, JSX.Element> = {
+  ...textUIExample,
+  scene: textExampleScenePart,
+};
+
+export const textExampleTestSuite: TestSuiteInfo<typeof textExample.scene> = {
+  title: 'Astryx Text',
+  url: '/text',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${textExample.title}`, () => {
+      const engine = useTestEngine(textExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getText reads content; getType the data-type; getColor the RESOLVED data-color.
+      test(`reads text, type, and resolved color`, async () => {
+        assertEqual(await engine().parts.body.getText(), 'Body text');
+        assertEqual(await engine().parts.body.getType(), 'body');
+        assertEqual(await engine().parts.body.getColor(), 'primary');
+      });
+
+      // 'supporting' resolves to data-color="secondary" without an explicit color prop.
+      test(`resolves supporting color to secondary`, async () => {
+        assertEqual(await engine().parts.supporting.getType(), 'supporting');
+        assertEqual(await engine().parts.supporting.getColor(), 'secondary');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/text/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/text/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { textExample, textExampleTestSuite } from './Text.suite';
+
+export { textUIExample } from './Text.examples';
+export { textExample, textExampleTestSuite };
+
+export const textExamples = [textExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/thumbnail/Thumbnail.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/thumbnail/Thumbnail.examples.tsx
@@ -1,0 +1,32 @@
+import { Thumbnail } from '@astryxdesign/core/Thumbnail';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Thumbnail scene.
+ *
+ * Thumbnail renders a `<div class="astryx-thumbnail">` (no role) whose `aria-label`
+ * is a composite accessible name; its inner content is conditional — an `<img>`
+ * when `src` is set, a `.astryx-skeleton` while loading, or an icon placeholder
+ * otherwise — and a removable thumbnail adds a `Remove …` button. The scene covers
+ * placeholder / image / removable / loading.
+ */
+export const ThumbnailExample = () => (
+  <div>
+    <Thumbnail label='file.jpg' data-testid='thumbnail-placeholder' />
+    <Thumbnail label='photo.jpg' alt='Vacation photo' src='https://example.com/p.jpg' data-testid='thumbnail-image' />
+    <Thumbnail
+      label='removable.jpg'
+      alt='Removable photo'
+      src='https://example.com/r.jpg'
+      onRemove={() => {}}
+      data-testid='thumbnail-removable'
+    />
+    <Thumbnail label='loading.jpg' isLoading data-testid='thumbnail-loading' />
+  </div>
+);
+
+export const thumbnailUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Thumbnail',
+  ui: <ThumbnailExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/thumbnail/Thumbnail.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/thumbnail/Thumbnail.suite.ts
@@ -1,0 +1,66 @@
+import { ThumbnailDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { thumbnailUIExample } from './Thumbnail.examples';
+
+export const thumbnailExampleScenePart = {
+  placeholder: {
+    locator: byDataTestId('thumbnail-placeholder'),
+    driver: ThumbnailDriver,
+  },
+  image: {
+    locator: byDataTestId('thumbnail-image'),
+    driver: ThumbnailDriver,
+  },
+  removable: {
+    locator: byDataTestId('thumbnail-removable'),
+    driver: ThumbnailDriver,
+  },
+  loading: {
+    locator: byDataTestId('thumbnail-loading'),
+    driver: ThumbnailDriver,
+  },
+} satisfies ScenePart;
+
+export const thumbnailExample: IExampleUnit<typeof thumbnailExampleScenePart, JSX.Element> = {
+  ...thumbnailUIExample,
+  scene: thumbnailExampleScenePart,
+};
+
+export const thumbnailExampleTestSuite: TestSuiteInfo<typeof thumbnailExample.scene> = {
+  title: 'Astryx Thumbnail',
+  url: '/thumbnail',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${thumbnailExample.title}`, () => {
+      const engine = useTestEngine(thumbnailExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // An image thumbnail exposes its src; getAccessibleName reads the composite aria-label.
+      test(`getImageSrc and getAccessibleName read the image thumbnail`, async () => {
+        assertEqual(await engine().parts.image.getImageSrc(), 'https://example.com/p.jpg');
+        assertEqual(await engine().parts.image.getAccessibleName(), 'photo.jpg — Vacation photo');
+      });
+
+      // isLoading is true only for the loading thumbnail (renders a skeleton, no img).
+      test(`isLoading detects the loading state`, async () => {
+        assertTrue(await engine().parts.loading.isLoading());
+        assertEqual(await engine().parts.loading.getImageSrc(), undefined);
+        assertFalse(await engine().parts.image.isLoading());
+      });
+
+      // isPlaceholder is true only when there is neither an image nor a skeleton.
+      test(`isPlaceholder detects the placeholder state`, async () => {
+        assertTrue(await engine().parts.placeholder.isPlaceholder());
+        assertFalse(await engine().parts.image.isPlaceholder());
+        assertFalse(await engine().parts.loading.isPlaceholder());
+      });
+
+      // canRemove is true only for the thumbnail with a Remove button.
+      test(`canRemove detects the remove control`, async () => {
+        assertTrue(await engine().parts.removable.canRemove());
+        assertFalse(await engine().parts.image.canRemove());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/thumbnail/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/thumbnail/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { thumbnailExample, thumbnailExampleTestSuite } from './Thumbnail.suite';
+
+export { thumbnailUIExample } from './Thumbnail.examples';
+export { thumbnailExample, thumbnailExampleTestSuite };
+
+export const thumbnailExamples = [thumbnailExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/timestamp/Timestamp.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/timestamp/Timestamp.examples.tsx
@@ -1,0 +1,23 @@
+import { Timestamp } from '@astryxdesign/core/Timestamp';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Timestamp scene.
+ *
+ * Timestamp wraps an inner `<time datetime>` (which receives the forwarded
+ * `data-testid`) in an outer `<span>` carrying `data-format`. The two instances
+ * use distinct `format` values so the format-bearing wrapper of each is uniquely
+ * addressable via `data-format`, while the `<time>` is reached by `data-testid`.
+ */
+export const TimestampExample = () => (
+  <div>
+    <Timestamp value='2026-02-19T17:00:00.000Z' format='date' data-testid='timestamp-date' />
+    <Timestamp value='2026-02-19T17:00:00.000Z' format='system_date' data-testid='timestamp-system' />
+  </div>
+);
+
+export const timestampUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Timestamp',
+  ui: <TimestampExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/timestamp/Timestamp.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/timestamp/Timestamp.suite.ts
@@ -1,0 +1,59 @@
+import { TimestampDriver } from '@atomic-testing/component-driver-astryx';
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { byAttribute, byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { timestampUIExample } from './Timestamp.examples';
+
+export const timestampExampleScenePart = {
+  // The forwarded data-testid lands on the inner <time>, which the driver anchors on.
+  date: {
+    locator: byDataTestId('timestamp-date'),
+    driver: TimestampDriver,
+  },
+  system: {
+    locator: byDataTestId('timestamp-system'),
+    driver: TimestampDriver,
+  },
+  // data-format lives on the OUTER wrapper span; a generic element driver reads it there.
+  dateWrapper: {
+    locator: byAttribute('data-format', 'date'),
+    driver: HTMLElementDriver,
+  },
+  systemWrapper: {
+    locator: byAttribute('data-format', 'system_date'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const timestampExample: IExampleUnit<typeof timestampExampleScenePart, JSX.Element> = {
+  ...timestampUIExample,
+  scene: timestampExampleScenePart,
+};
+
+export const timestampExampleTestSuite: TestSuiteInfo<typeof timestampExample.scene> = {
+  title: 'Astryx Timestamp',
+  url: '/timestamp',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${timestampExample.title}`, () => {
+      const engine = useTestEngine(timestampExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getDateTime reads the machine-readable ISO 8601 datetime on <time>.
+      test(`reads the ISO datetime`, async () => {
+        assertEqual(await engine().parts.date.getDateTime(), '2026-02-19T17:00:00.000Z');
+      });
+
+      // The format is read from the parent wrapper's data-format, distinct per instance.
+      test(`reads the format from the wrapper`, async () => {
+        assertEqual(await engine().parts.dateWrapper.getAttribute('data-format'), 'date');
+        assertEqual(await engine().parts.systemWrapper.getAttribute('data-format'), 'system_date');
+      });
+
+      // Both <time> instances share the same instant but are disambiguated by testid.
+      test(`disambiguates two instances`, async () => {
+        assertEqual(await engine().parts.system.getDateTime(), '2026-02-19T17:00:00.000Z');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/timestamp/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/timestamp/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { timestampExample, timestampExampleTestSuite } from './Timestamp.suite';
+
+export { timestampUIExample } from './Timestamp.examples';
+export { timestampExample, timestampExampleTestSuite };
+
+export const timestampExamples = [timestampExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/token/Token.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/token/Token.examples.tsx
@@ -1,0 +1,24 @@
+import { Token } from '@astryxdesign/core/Token';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Token scene.
+ *
+ * Token's root tag is conditional — a `<span>` by default, an `<a href>` when an
+ * `href` is supplied — with the label nested in an inner `<span>` and the color in
+ * `data-color`. The scene renders a basic chip, a removable one (renders a
+ * `Remove …` button), and a link to cover label / removable / link.
+ */
+export const TokenExample = () => (
+  <div>
+    <Token label='Tag' data-testid='token-basic' />
+    <Token label='Removable' onRemove={() => {}} data-testid='token-removable' />
+    <Token label='Link' href='/destination' data-testid='token-link' />
+  </div>
+);
+
+export const tokenUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Token',
+  ui: <TokenExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/token/Token.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/token/Token.suite.ts
@@ -1,0 +1,61 @@
+import { TokenDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { tokenUIExample } from './Token.examples';
+
+export const tokenExampleScenePart = {
+  basic: {
+    locator: byDataTestId('token-basic'),
+    driver: TokenDriver,
+  },
+  removable: {
+    locator: byDataTestId('token-removable'),
+    driver: TokenDriver,
+  },
+  link: {
+    locator: byDataTestId('token-link'),
+    driver: TokenDriver,
+  },
+} satisfies ScenePart;
+
+export const tokenExample: IExampleUnit<typeof tokenExampleScenePart, JSX.Element> = {
+  ...tokenUIExample,
+  scene: tokenExampleScenePart,
+};
+
+export const tokenExampleTestSuite: TestSuiteInfo<typeof tokenExample.scene> = {
+  title: 'Astryx Token',
+  url: '/token',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${tokenExample.title}`, () => {
+      const engine = useTestEngine(tokenExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // getLabel reads the nested label text.
+      test(`getLabel reads each token's label`, async () => {
+        assertEqual(await engine().parts.basic.getLabel(), 'Tag');
+        assertEqual(await engine().parts.removable.getLabel(), 'Removable');
+        assertEqual(await engine().parts.link.getLabel(), 'Link');
+      });
+
+      // isRemovable is true only for the token with a Remove button.
+      test(`isRemovable detects the remove control`, async () => {
+        assertTrue(await engine().parts.removable.isRemovable());
+        assertFalse(await engine().parts.basic.isRemovable());
+      });
+
+      // remove() clicks the Remove button when present, and reports false otherwise.
+      test(`remove returns false when not removable`, async () => {
+        assertFalse(await engine().parts.basic.remove());
+        assertTrue(await engine().parts.removable.remove());
+      });
+
+      // A token with href renders an <a>: getHref returns it; the basic token has none.
+      test(`getHref detects the link case`, async () => {
+        assertEqual(await engine().parts.link.getHref(), '/destination');
+        assertEqual(await engine().parts.basic.getHref(), undefined);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/token/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/token/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { tokenExample, tokenExampleTestSuite } from './Token.suite';
+
+export { tokenUIExample } from './Token.examples';
+export { tokenExample, tokenExampleTestSuite };
+
+export const tokenExamples = [tokenExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/tooltip/Tooltip.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/tooltip/Tooltip.examples.tsx
@@ -1,0 +1,23 @@
+import { Tooltip } from '@astryxdesign/core/Tooltip';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx Tooltip scene.
+ *
+ * Like HoverCard, the tooltip layer is a body-level popover with no role/testid/
+ * open-state; the trigger's injected `aria-describedby` → the layer's `id` is the
+ * only stable link. The scene anchors on the trigger (`data-testid`); the driver
+ * follows that link to read the tooltip text. The layer stays mounted in jsdom, so
+ * content reads in both states — open/visibility is E2E-only and not asserted.
+ */
+export const TooltipExample = () => (
+  <Tooltip content='Helpful tooltip text'>
+    <button data-testid='tt-trigger'>Hover me</button>
+  </Tooltip>
+);
+
+export const tooltipUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Tooltip',
+  ui: <TooltipExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/tooltip/Tooltip.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/tooltip/Tooltip.suite.ts
@@ -1,0 +1,39 @@
+import { TooltipDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { tooltipUIExample } from './Tooltip.examples';
+
+export const tooltipExampleScenePart = {
+  tt: {
+    locator: byDataTestId('tt-trigger'),
+    driver: TooltipDriver,
+  },
+} satisfies ScenePart;
+
+export const tooltipExample: IExampleUnit<typeof tooltipExampleScenePart, JSX.Element> = {
+  ...tooltipUIExample,
+  scene: tooltipExampleScenePart,
+};
+
+export const tooltipExampleTestSuite: TestSuiteInfo<typeof tooltipExample.scene> = {
+  title: 'Astryx Tooltip',
+  url: '/tooltip',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${tooltipExample.title}`, () => {
+      const engine = useTestEngine(tooltipExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      // The trigger's own text reads directly.
+      test(`getTriggerText reads the trigger label`, async () => {
+        assertEqual(await engine().parts.tt.getTriggerText(), 'Hover me');
+      });
+
+      // The layer stays mounted in jsdom, so getContent reads through aria-describedby.
+      // Open/visibility is E2E-only and NOT asserted here.
+      test(`getContent reads the tooltip text via aria-describedby`, async () => {
+        assertEqual(await engine().parts.tt.getContent(), 'Helpful tooltip text');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/tooltip/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/tooltip/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { tooltipExample, tooltipExampleTestSuite } from './Tooltip.suite';
+
+export { tooltipUIExample } from './Tooltip.examples';
+export { tooltipExample, tooltipExampleTestSuite };
+
+export const tooltipExamples = [tooltipExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-item/TopNavItem.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-item/TopNavItem.examples.tsx
@@ -1,0 +1,27 @@
+import { TopNav, TopNavItem } from '@astryxdesign/core/TopNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx TopNavItem scene.
+ *
+ * Each TopNavItem renders an `<a class="astryx-top-nav-item">` and forwards
+ * `data-testid` onto it. Rendering a selected, a normal, and a disabled item (all
+ * inside a TopNav, their natural host) lets the driver verify `aria-current`,
+ * `aria-disabled`, label, and href reads against distinct instances.
+ */
+export const TopNavItemExample = () => (
+  <TopNav
+    label='Main navigation'
+    startContent={[
+      <TopNavItem key='selected' label='Home' href='/' isSelected data-testid='tni-selected' />,
+      <TopNavItem key='normal' label='Products' href='/products' data-testid='tni-normal' />,
+      <TopNavItem key='disabled' label='Settings' href='/settings' isDisabled data-testid='tni-disabled' />,
+    ]}
+  />
+);
+
+export const topNavItemUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx TopNavItem',
+  ui: <TopNavItemExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-item/TopNavItem.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-item/TopNavItem.suite.ts
@@ -1,0 +1,53 @@
+import { TopNavItemDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { topNavItemUIExample } from './TopNavItem.examples';
+
+export const topNavItemExampleScenePart = {
+  selected: {
+    locator: byDataTestId('tni-selected'),
+    driver: TopNavItemDriver,
+  },
+  normal: {
+    locator: byDataTestId('tni-normal'),
+    driver: TopNavItemDriver,
+  },
+  disabled: {
+    locator: byDataTestId('tni-disabled'),
+    driver: TopNavItemDriver,
+  },
+} satisfies ScenePart;
+
+export const topNavItemExample: IExampleUnit<typeof topNavItemExampleScenePart, JSX.Element> = {
+  ...topNavItemUIExample,
+  scene: topNavItemExampleScenePart,
+};
+
+export const topNavItemExampleTestSuite: TestSuiteInfo<typeof topNavItemExample.scene> = {
+  title: 'Astryx TopNavItem',
+  url: '/top-nav-item',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${topNavItemExample.title}`, () => {
+      const engine = useTestEngine(topNavItemExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel and getHref read the item`, async () => {
+        assertEqual(await engine().parts.normal.getLabel(), 'Products');
+        assertEqual(await engine().parts.normal.getHref(), '/products');
+      });
+
+      // isSelected reads aria-current="page"; only the selected item carries it.
+      test(`isSelected distinguishes the current page`, async () => {
+        assertTrue(await engine().parts.selected.isSelected());
+        assertFalse(await engine().parts.normal.isSelected());
+      });
+
+      // isDisabled reads aria-disabled (the item stays an <a>, never native disabled).
+      test(`isDisabled distinguishes the disabled item`, async () => {
+        assertTrue(await engine().parts.disabled.isDisabled());
+        assertFalse(await engine().parts.normal.isDisabled());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-item/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-item/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { topNavItemExample, topNavItemExampleTestSuite } from './TopNavItem.suite';
+
+export { topNavItemUIExample } from './TopNavItem.examples';
+export { topNavItemExample, topNavItemExampleTestSuite };
+
+export const topNavItemExamples = [topNavItemExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/TopNavMegaMenu.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/TopNavMegaMenu.examples.tsx
@@ -1,0 +1,42 @@
+import { TopNav, TopNavItem, TopNavMegaMenu, TopNavMegaMenuItem } from '@astryxdesign/core/TopNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx TopNavMegaMenu scene.
+ *
+ * TopNavMegaMenu renders a trigger `<button class="astryx-top-nav-mega-menu">` plus
+ * an inline full-width panel of `astryx-top-nav-mega-menu-item` entries. The trigger
+ * forwards no `data-testid` (scene anchors on the semantic class) and carries
+ * `aria-haspopup="true"` (not `"dialog"`). Entry markup is always mounted, so titles
+ * read in jsdom; the open transition is native-Popover-API-driven and only exercised
+ * by the E2E run.
+ *
+ * The two entries mix shapes on purpose: Analytics has an `href` (renders `<a>`)
+ * while Messaging has only an `onClick` (renders `<div>`). That heterogeneity is
+ * exactly what a tag-based `nth-of-type` walk mis-indexes; the driver enumerates by
+ * `:nth-child` so both titles read in order.
+ */
+export const TopNavMegaMenuExample = () => (
+  <TopNav
+    label='Main navigation'
+    startContent={[
+      <TopNavItem key='home' label='Home' href='/' />,
+      <TopNavMegaMenu
+        key='products'
+        label='Products'
+        items={
+          <>
+            <TopNavMegaMenuItem title='Analytics' description='Track behavior' href='/analytics' />
+            <TopNavMegaMenuItem title='Messaging' description='Real-time comms' onClick={() => {}} />
+          </>
+        }
+      />,
+    ]}
+  />
+);
+
+export const topNavMegaMenuUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx TopNavMegaMenu',
+  ui: <TopNavMegaMenuExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/TopNavMegaMenu.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/TopNavMegaMenu.suite.ts
@@ -1,0 +1,49 @@
+import { TopNavMegaMenuDriver } from '@atomic-testing/component-driver-astryx';
+import { byCssSelector, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { topNavMegaMenuUIExample } from './TopNavMegaMenu.examples';
+
+export const topNavMegaMenuExampleScenePart = {
+  // TopNavMegaMenu does not forward data-testid onto its trigger button, so the
+  // scene anchors on the semantic class (the only stable handle for the trigger).
+  megaMenu: {
+    locator: byCssSelector('button.astryx-top-nav-mega-menu'),
+    driver: TopNavMegaMenuDriver,
+  },
+} satisfies ScenePart;
+
+export const topNavMegaMenuExample: IExampleUnit<typeof topNavMegaMenuExampleScenePart, JSX.Element> = {
+  ...topNavMegaMenuUIExample,
+  scene: topNavMegaMenuExampleScenePart,
+};
+
+export const topNavMegaMenuExampleTestSuite: TestSuiteInfo<typeof topNavMegaMenuExample.scene> = {
+  title: 'Astryx TopNavMegaMenu',
+  url: '/top-nav-mega-menu',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${topNavMegaMenuExample.title}`, () => {
+      const engine = useTestEngine(topNavMegaMenuExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel reads the trigger label`, async () => {
+        assertEqual(await engine().parts.megaMenu.getLabel(), 'Products');
+      });
+
+      // The panel is always mounted, so its entries read even while the menu is closed.
+      // Entry text bundles title + description, so assert count and per-entry title (substring).
+      test(`getItemTitles reads the panel entries while closed`, async () => {
+        const titles = await engine().parts.megaMenu.getItemTitles();
+        assertEqual(titles.length, 2);
+        assertTrue(titles[0].includes('Analytics'));
+        assertTrue(titles[1].includes('Messaging'));
+      });
+
+      // Closed-state read only: expansion uses the native Popover API (no-op in jsdom),
+      // so isExpanded() is false here (its true case is E2E-only — never asserted in the shared suite).
+      test(`isExpanded reports the closed state`, async () => {
+        assertFalse(await engine().parts.megaMenu.isExpanded());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-mega-menu/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { topNavMegaMenuExample, topNavMegaMenuExampleTestSuite } from './TopNavMegaMenu.suite';
+
+export { topNavMegaMenuUIExample } from './TopNavMegaMenu.examples';
+export { topNavMegaMenuExample, topNavMegaMenuExampleTestSuite };
+
+export const topNavMegaMenuExamples = [topNavMegaMenuExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/TopNavMenu.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/TopNavMenu.examples.tsx
@@ -1,0 +1,40 @@
+import { TopNav, TopNavItem, TopNavMenu } from '@astryxdesign/core/TopNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx TopNavMenu scene.
+ *
+ * TopNavMenu renders a trigger `<button class="astryx-top-nav-menu">` plus an inline
+ * (always-mounted) panel of `role="menuitem"` entries. The trigger does NOT forward
+ * `data-testid`, so the scene anchors on the semantic class. The panel markup is
+ * present while closed, so item titles are readable in jsdom; the open transition is
+ * native-popover-driven and only exercised by the E2E run.
+ *
+ * The two items mix shapes on purpose: Analytics has an `href` (renders `<a
+ * role="menuitem">`) while Messaging has only an `onClick` (renders `<div
+ * role="menuitem">`). That heterogeneity is exactly what a tag-based `nth-of-type`
+ * walk mis-indexes; the driver enumerates by `:nth-child` so both titles read in
+ * order.
+ */
+export const TopNavMenuExample = () => (
+  <TopNav
+    label='Main navigation'
+    startContent={[
+      <TopNavItem key='home' label='Home' href='/' />,
+      <TopNavMenu
+        key='products'
+        label='Products'
+        items={[
+          { title: 'Analytics', description: 'Track user behavior', href: '/products/analytics' },
+          { title: 'Messaging', description: 'Real-time communication', onClick: () => {} },
+        ]}
+      />,
+    ]}
+  />
+);
+
+export const topNavMenuUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx TopNavMenu',
+  ui: <TopNavMenuExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/TopNavMenu.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/TopNavMenu.suite.ts
@@ -1,0 +1,50 @@
+import { TopNavMenuDriver } from '@atomic-testing/component-driver-astryx';
+import { byCssSelector, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { topNavMenuUIExample } from './TopNavMenu.examples';
+
+export const topNavMenuExampleScenePart = {
+  // TopNavMenu does not forward data-testid onto its trigger button, so the scene
+  // anchors on the semantic class (the only stable handle for the trigger).
+  menu: {
+    locator: byCssSelector('button.astryx-top-nav-menu'),
+    driver: TopNavMenuDriver,
+  },
+} satisfies ScenePart;
+
+export const topNavMenuExample: IExampleUnit<typeof topNavMenuExampleScenePart, JSX.Element> = {
+  ...topNavMenuUIExample,
+  scene: topNavMenuExampleScenePart,
+};
+
+export const topNavMenuExampleTestSuite: TestSuiteInfo<typeof topNavMenuExample.scene> = {
+  title: 'Astryx TopNavMenu',
+  url: '/top-nav-menu',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    describe(`${topNavMenuExample.title}`, () => {
+      const engine = useTestEngine(topNavMenuExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel reads the trigger label`, async () => {
+        assertEqual(await engine().parts.menu.getLabel(), 'Products');
+      });
+
+      // The panel is always mounted, so its items read even while the menu is closed.
+      // The menuitem text bundles title + description, so assert count and that each
+      // entry carries its title (substring) rather than an exact, layout-coupled string.
+      test(`getItemTitles reads the panel items while closed`, async () => {
+        const titles = await engine().parts.menu.getItemTitles();
+        assertEqual(titles.length, 2);
+        assertTrue(titles[0].includes('Analytics'));
+        assertTrue(titles[1].includes('Messaging'));
+      });
+
+      // Closed-state read only: opening is native-popover-driven and a no-op in jsdom,
+      // so isOpen() is false here (its true case is E2E-only — never asserted in the shared suite).
+      test(`isOpen reports the closed state`, async () => {
+        assertFalse(await engine().parts.menu.isOpen());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav-menu/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { topNavMenuExample, topNavMenuExampleTestSuite } from './TopNavMenu.suite';
+
+export { topNavMenuUIExample } from './TopNavMenu.examples';
+export { topNavMenuExample, topNavMenuExampleTestSuite };
+
+export const topNavMenuExamples = [topNavMenuExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav/TopNav.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav/TopNav.examples.tsx
@@ -1,0 +1,29 @@
+import { TopNav, TopNavHeading, TopNavItem } from '@astryxdesign/core/TopNav';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX } from 'react';
+
+/**
+ * Astryx TopNav scene.
+ *
+ * TopNav is a `<nav>` landmark whose `startContent` holds `TopNavItem` links
+ * (`<a class="astryx-top-nav-item">`). Rendering selected / normal / disabled items
+ * lets the driver exercise item-count and per-item ARIA state. `startContent` is
+ * used (not `children`) because Astryx drops the `children` alias when both are set.
+ */
+export const TopNavExample = () => (
+  <TopNav
+    label='Main navigation'
+    heading={<TopNavHeading heading='My App' headingHref='/' />}
+    startContent={[
+      <TopNavItem key='home' label='Home' href='/' isSelected />,
+      <TopNavItem key='products' label='Products' href='/products' />,
+      <TopNavItem key='disabled' label='Disabled' href='/x' isDisabled />,
+    ]}
+    data-testid='top-nav'
+  />
+);
+
+export const topNavUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx TopNav',
+  ui: <TopNavExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav/TopNav.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav/TopNav.suite.ts
@@ -1,0 +1,36 @@
+import { TopNavDriver } from '@atomic-testing/component-driver-astryx';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { topNavUIExample } from './TopNav.examples';
+
+export const topNavExampleScenePart = {
+  topNav: {
+    locator: byDataTestId('top-nav'),
+    driver: TopNavDriver,
+  },
+} satisfies ScenePart;
+
+export const topNavExample: IExampleUnit<typeof topNavExampleScenePart, JSX.Element> = {
+  ...topNavUIExample,
+  scene: topNavExampleScenePart,
+};
+
+export const topNavExampleTestSuite: TestSuiteInfo<typeof topNavExample.scene> = {
+  title: 'Astryx TopNav',
+  url: '/top-nav',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${topNavExample.title}`, () => {
+      const engine = useTestEngine(topNavExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`getLabel reads the navigation landmark name`, async () => {
+        assertEqual(await engine().parts.topNav.getLabel(), 'Main navigation');
+      });
+
+      test(`getItemCount counts the TopNavItem links`, async () => {
+        assertEqual(await engine().parts.topNav.getItemCount(), 3);
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/top-nav/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/top-nav/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { topNavExample, topNavExampleTestSuite } from './TopNav.suite';
+
+export { topNavUIExample } from './TopNav.examples';
+export { topNavExample, topNavExampleTestSuite };
+
+export const topNavExamples = [topNavExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-astryx/src/components/AppShellDriver.ts
+++ b/packages/component-driver-astryx/src/components/AppShellDriver.ts
@@ -1,0 +1,61 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx AppShell (`@astryxdesign/core/AppShell`).
+ *
+ * AppShell is a layout orchestrator with almost no testable surface of its own —
+ * it slots a `topNav`, a `sideNav`, and `children` into landmark regions and
+ * delegates behaviour to those child components. The scene anchors this driver on
+ * the root (`data-testid`, `data-variant`); its job is to confirm the regions are
+ * mounted and expose the variant, then hand off to the child drivers (TopNav,
+ * SideNav, etc.) for real interaction.
+ *
+ * The landmark anchors are stable and semantic — `role="main"` /
+ * `#astryx-app-shell-main` for content, a generated skip link, and the prefixed
+ * `astryx-app-shell-header` / `astryx-app-shell-sidenav` region classes (used only
+ * as a last resort, since these regions expose no role/testid). Responsive
+ * collapse and the mobile drawer are CSS/viewport-gated and therefore **E2E-only**.
+ */
+export class AppShellDriver extends ComponentDriver<{}> {
+  private region(selector: string): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector(selector));
+  }
+
+  /** The shell variant (`data-variant`, e.g. `'elevated'`). */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  /** Whether a header/top-nav region is mounted. */
+  async hasHeader(): Promise<boolean> {
+    return this.interactor.exists(this.region('.astryx-app-shell-header'));
+  }
+
+  /** Whether a side-nav region is mounted. */
+  async hasSideNav(): Promise<boolean> {
+    return this.interactor.exists(this.region('.astryx-app-shell-sidenav'));
+  }
+
+  /** Whether the main content landmark (`role="main"`) is mounted. */
+  async hasMain(): Promise<boolean> {
+    return this.interactor.exists(this.region('[role="main"]'));
+  }
+
+  /** The main content's text, read from the `role="main"` landmark. */
+  async getMainText(): Promise<Optional<string>> {
+    const main = this.region('[role="main"]');
+    if (!(await this.interactor.exists(main))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(main)) ?? undefined;
+  }
+
+  /** Whether the built-in "skip to content" link is present. */
+  async hasSkipLink(): Promise<boolean> {
+    return this.interactor.exists(this.region('[data-testid="skip-to-content"]'));
+  }
+
+  get driverName(): string {
+    return 'AstryxAppShellDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/AvatarDriver.ts
+++ b/packages/component-driver-astryx/src/components/AvatarDriver.ts
@@ -1,0 +1,60 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Avatar (`@astryxdesign/core/Avatar`) — a user/entity
+ * thumbnail with initials and icon fallbacks.
+ *
+ * Avatar renders a `<div role="img">` (self-anchoring `data-testid`) whose
+ * accessible name is the `aria-label` (`alt || name || 'Avatar'`) and whose size
+ * is `data-size`. The inner content is conditional: an `<img>` when `src` is set,
+ * otherwise the initials text (from `name`) or a person `<svg>` icon.
+ *
+ * NOTE: jsdom always materialises the `<img>` for a given `src` and never fires
+ * its `onError`, so {@link hasImage} here means "a `src` was supplied", not
+ * "the image loaded". The load-failure → initials fallback is therefore only
+ * observable in a real browser (E2E).
+ */
+export class AvatarDriver extends ComponentDriver<{}> {
+  /** The inner image, present only when a `src` was supplied. */
+  private get image(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('img'));
+  }
+
+  /** The accessible name — the verbatim `aria-label` (`alt`, else `name`, else `'Avatar'`). */
+  async getAccessibleName(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** The image source, or `undefined` when no `src` was supplied (initials/icon fallback). */
+  async getImageSrc(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.image))) {
+      return undefined;
+    }
+    return this.interactor.getAttribute(this.image, 'src');
+  }
+
+  /** Whether a `src` was supplied (see class note on jsdom vs. load-failure semantics). */
+  async hasImage(): Promise<boolean> {
+    return this.interactor.exists(this.image);
+  }
+
+  /**
+   * The initials shown when there is no image — the root's text. `undefined`
+   * when an image is present (no initials are rendered).
+   */
+  async getInitials(): Promise<Optional<string>> {
+    if (await this.interactor.exists(this.image)) {
+      return undefined;
+    }
+    return (await this.getText())?.trim() || undefined;
+  }
+
+  /** The avatar size (`data-size`): `'small'`, `'medium'`, … */
+  async getSize(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-size');
+  }
+
+  get driverName(): string {
+    return 'AstryxAvatarDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/AvatarGroupDriver.ts
+++ b/packages/component-driver-astryx/src/components/AvatarGroupDriver.ts
@@ -1,0 +1,54 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx AvatarGroup (`@astryxdesign/core/AvatarGroup`) — a
+ * clustered row of {@link AvatarDriver | Avatar}s with an optional overflow count.
+ *
+ * The root is a `<div role="group" aria-label="Avatars">` (the label is hardcoded,
+ * not configurable) that self-emits `data-testid`. Each visible avatar is a
+ * descendant `[role="img"]` carrying its own `aria-label` (its accessible name);
+ * an optional overflow chip is a `<span class="astryx-avatar-group-overflow">`
+ * whose `aria-label` reads `"{n} more"` (it is neither `role="img"` nor testid'd).
+ *
+ * Because every avatar always carries an `aria-label`, reading them with the
+ * multi-element `getAttribute(..., true)` is faithful (and a reliable count) in
+ * both jsdom and the browser — no null entries are dropped.
+ */
+export class AvatarGroupDriver extends ComponentDriver<{}> {
+  /** Every visible avatar within the group. */
+  private get avatars(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="img"]'));
+  }
+
+  /** The overflow chip, present only when avatars were collapsed. */
+  private get overflow(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-avatar-group-overflow'));
+  }
+
+  /** The number of avatars actually rendered (excludes the overflow chip). */
+  async getVisibleCount(): Promise<number> {
+    return (await this.getAvatarNames()).length;
+  }
+
+  /** Each visible avatar's accessible name (`aria-label`), in DOM order. */
+  async getAvatarNames(): Promise<readonly string[]> {
+    return this.interactor.getAttribute(this.avatars, 'aria-label', true);
+  }
+
+  /**
+   * The count of hidden avatars, parsed from the overflow chip's
+   * `aria-label` (`"{n} more"`). `undefined` when there is no overflow.
+   */
+  async getOverflowCount(): Promise<Optional<number>> {
+    if (!(await this.interactor.exists(this.overflow))) {
+      return undefined;
+    }
+    const ariaLabel = await this.interactor.getAttribute(this.overflow, 'aria-label');
+    const match = ariaLabel?.match(/(\d+)\s+more/);
+    return match ? Number(match[1]) : undefined;
+  }
+
+  get driverName(): string {
+    return 'AstryxAvatarGroupDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/BadgeDriver.ts
+++ b/packages/component-driver-astryx/src/components/BadgeDriver.ts
@@ -1,0 +1,22 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Badge (`@astryxdesign/core/Badge`) — the inline status
+ * pill.
+ *
+ * Badge renders a single `<span>` with NO role; the chosen `variant` is reflected
+ * onto the root as `data-variant`, and the `label` is the element's text content
+ * (inherited {@link getText}). The scene anchors on the forwarded `data-testid`,
+ * reading the variant from the stable `data-variant` rather than the StyleX-hashed
+ * class list.
+ */
+export class BadgeDriver extends ComponentDriver<{}> {
+  /** The visual variant (`data-variant`): `'neutral'`, `'success'`, `'purple'`, etc. */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  override get driverName(): string {
+    return 'AstryxBadgeDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/BlockquoteDriver.ts
+++ b/packages/component-driver-astryx/src/components/BlockquoteDriver.ts
@@ -1,0 +1,31 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Blockquote (`@astryxdesign/core/Blockquote`) — the
+ * semantic `<blockquote>` with optional attribution.
+ *
+ * Blockquote has NO role and no `data-*` theme attributes. When a `cite` is
+ * supplied it is rendered as a `<footer><cite>…</cite></footer>` descendant;
+ * otherwise no `cite` exists. Inherited {@link getText} returns the WHOLE element
+ * text — quote PLUS any citation concatenated — so {@link getCitation} reads the
+ * `<cite>` descendant in isolation and returns `undefined` when absent. The scene
+ * anchors on the forwarded `data-testid`.
+ */
+export class BlockquoteDriver extends ComponentDriver<{}> {
+  /** The attribution `<cite>` descendant. */
+  private get cite(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('cite'));
+  }
+
+  /** The attribution text (the `<cite>`), or `undefined` when the quote has no `cite`. */
+  async getCitation(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.cite))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.cite)) ?? undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxBlockquoteDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/BreadcrumbItemDriver.ts
+++ b/packages/component-driver-astryx/src/components/BreadcrumbItemDriver.ts
@@ -1,0 +1,48 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for a single Astryx breadcrumb (`<li class="astryx-breadcrumb-item">`).
+ *
+ * A crumb's `<li>` holds a **leading separator** `<span aria-hidden="true">/</span>`
+ * followed by its content, which is one of four shapes: an `<a href>` (linked), a
+ * `<button>` (action-only), a `<span aria-current="page">` (explicit current), or a
+ * bare `<span>` (plain). The current crumb is marked either by `aria-current="page"`
+ * on that inner content (explicit `isCurrent`) **or** on the `<li>` itself (Astryx's
+ * auto-detection of the last crumb). The label is read from the content element
+ * (the non-separator child) so the decorative `/` is excluded across every shape.
+ */
+export class BreadcrumbItemDriver extends ComponentDriver {
+  /** The crumb's content element — the child that is not the `aria-hidden` separator. */
+  private get content(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('> :not([aria-hidden="true"])'));
+  }
+
+  /** The crumb's visible label, read from its content element (separator excluded). */
+  async getLabel(): Promise<Optional<string>> {
+    return (await this.interactor.getText(this.content))?.trim() || undefined;
+  }
+
+  /** The crumb's `href` when it is a link, otherwise `undefined`. */
+  async getHref(): Promise<Optional<string>> {
+    const link = locatorUtil.append(this.locator, byCssSelector('a'));
+    if (!(await this.interactor.exists(link))) {
+      return undefined;
+    }
+    return this.interactor.getAttribute(link, 'href');
+  }
+
+  /**
+   * Whether this is the current crumb — `aria-current="page"` on the `<li>` itself
+   * (Astryx's auto-current last crumb) or on its inner content (explicit `isCurrent`).
+   */
+  async isCurrent(): Promise<boolean> {
+    if ((await this.interactor.getAttribute(this.locator, 'aria-current')) === 'page') {
+      return true;
+    }
+    return this.interactor.exists(locatorUtil.append(this.locator, byCssSelector('[aria-current="page"]')));
+  }
+
+  override get driverName(): string {
+    return 'AstryxBreadcrumbItemDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/BreadcrumbsDriver.ts
+++ b/packages/component-driver-astryx/src/components/BreadcrumbsDriver.ts
@@ -1,0 +1,66 @@
+import { byCssSelector, ComponentDriverCtor, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+import { PositionalListDriver } from '../internal/PositionalListDriver';
+import { BreadcrumbItemDriver } from './BreadcrumbItemDriver';
+
+/**
+ * Driver for the Astryx Breadcrumbs (`@astryxdesign/core/Breadcrumbs`).
+ *
+ * Breadcrumbs is a `<nav aria-label="Breadcrumb" class="astryx-breadcrumbs">` that
+ * forwards `data-testid` and wraps an `<ol>` of `<li class="astryx-breadcrumb-item">`
+ * crumbs (the separators are `aria-hidden` spans *inside* each crumb, not extra
+ * `<li>`s). The crumbs are the `<ol>`'s direct children, driven by
+ * {@link BreadcrumbItemDriver}; the count/labels surface comes from
+ * {@link PositionalListDriver}'s `:nth-child` walk, and the per-crumb label/href/
+ * current logic lives in the item driver — so a crumb with no link and no inner
+ * `aria-current` (Astryx's auto-current last crumb marks the `<li>` itself) is read
+ * faithfully instead of being silently dropped. The whole trail is rendered in the
+ * DOM, so every read is faithful in jsdom.
+ */
+export class BreadcrumbsDriver extends PositionalListDriver<BreadcrumbItemDriver> {
+  protected readonly itemSelector = 'li.astryx-breadcrumb-item';
+  protected readonly itemDriverClass: ComponentDriverCtor<BreadcrumbItemDriver> = BreadcrumbItemDriver;
+
+  protected override resolveListContainer(): Promise<PartLocator | null> {
+    return Promise.resolve(locatorUtil.append(this.locator, byCssSelector('ol')));
+  }
+
+  /** The accessible name of the breadcrumb landmark (`aria-label`, default "Breadcrumb"). */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** Every crumb's visible label, in DOM order. */
+  async getLabels(): Promise<readonly string[]> {
+    return this.getItemLabels();
+  }
+
+  /**
+   * The current crumb's label, or `undefined` when no crumb is marked current.
+   * The current crumb carries `aria-current="page"` on its `<li>` or inner content.
+   */
+  async getCurrentLabel(): Promise<Optional<string>> {
+    for (const crumb of await this.getItems()) {
+      if (await crumb.isCurrent()) {
+        return crumb.getLabel();
+      }
+    }
+    return undefined;
+  }
+
+  /** Every linked crumb's `href`, in DOM order (the current crumb has no link, so it is skipped). */
+  async getHrefs(): Promise<readonly string[]> {
+    const hrefs: string[] = [];
+    for (const crumb of await this.getItems()) {
+      const href = await crumb.getHref();
+      if (href != null) {
+        hrefs.push(href);
+      }
+    }
+    return hrefs;
+  }
+
+  override get driverName(): string {
+    return 'AstryxBreadcrumbsDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatComposerDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatComposerDriver.ts
@@ -1,0 +1,64 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatComposer (`@astryxdesign/core/ChatComposer`).
+ *
+ * ChatComposer wraps a {@link ChatComposerInputDriver | ChatComposerInput} (the
+ * `contenteditable` editor), a send/stop button, and an optional status message.
+ * The scene anchors on the root (`data-testid`, `data-density`). The embedded
+ * input carries no `data-testid` of its own, so it is reached by its
+ * `role="textbox"][contenteditable]`; the send button by its stable
+ * `astryx-chat-send-button` class (Astryx does not forward a testid there either).
+ *
+ * Reads are jsdom-faithful: `canSend` (the button's `disabled`), `isStopShown`
+ * (the button flips `aria-label` Send↔Stop), and the status text (`role="alert"`).
+ * Actual send-on-Enter and the contenteditable's append-only typing constraint are
+ * inherited from ChatComposerInput; Enter-to-submit is **E2E-only**.
+ */
+export class ChatComposerDriver extends ComponentDriver<{}> {
+  private get sendButton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-chat-send-button'));
+  }
+
+  private get editable(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="textbox"][contenteditable="true"]'));
+  }
+
+  /** The composer density (`data-density`). */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /** Append text to the embedded editor (append-only — see ChatComposerInput docs). */
+  async appendValue(text: string): Promise<void> {
+    return this.interactor.enterText(this.editable, text);
+  }
+
+  /** Click the send/stop button. */
+  async submit(): Promise<void> {
+    return this.interactor.click(this.sendButton);
+  }
+
+  /** Whether the send button is enabled (it is `disabled` while the editor is empty). */
+  async canSend(): Promise<boolean> {
+    return !(await this.interactor.hasAttribute(this.sendButton, 'disabled'));
+  }
+
+  /** Whether the button is in its "Stop" state (`aria-label="Stop"`) rather than "Send". */
+  async isStopShown(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.sendButton, 'aria-label')) === 'Stop';
+  }
+
+  /** The status message text (`role="alert"`), or `undefined` when no status is set. */
+  async getStatusMessage(): Promise<Optional<string>> {
+    const status = locatorUtil.append(this.locator, byCssSelector('[role="alert"]'));
+    if (!(await this.interactor.exists(status))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(status)) ?? undefined;
+  }
+
+  get driverName(): string {
+    return 'AstryxChatComposerDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatComposerInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatComposerInputDriver.ts
@@ -1,0 +1,65 @@
+import { byCssSelector, ComponentDriver, FocusOption, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatComposerInput (`@astryxdesign/core/ChatComposerInput`).
+ *
+ * The editor is a **`contenteditable` `div[role="textbox"]`**, not an `<input>`/
+ * `<textarea>`. That dictates the whole v1 surface:
+ *
+ * - The value is read from the element's text content ({@link getValue} via
+ *   `getText`), because the `getInputValue` interactor primitive returns `null`
+ *   for a contenteditable (no `.value`).
+ * - Typing is **append-only** ({@link appendValue} via `enterText`): `userEvent.clear`
+ *   throws on a contenteditable, so there is no portable "set from scratch".
+ *   Blocking dependency: a contenteditable-aware clear/set primitive.
+ *
+ * The placeholder is a separate `aria-hidden` sibling (not the HTML `placeholder`
+ * attribute), and the `@mention`/`/command` suggestion menu is a native popover
+ * whose open state (`aria-expanded` on the textbox) only transitions in a real
+ * browser — so suggestion *opening* is E2E-only; the closed `aria-expanded="false"`
+ * and the accessible name read faithfully in jsdom.
+ */
+export class ChatComposerInputDriver extends ComponentDriver<{}> {
+  /** The contenteditable editor element. */
+  protected get editable(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="textbox"][contenteditable="true"]'));
+  }
+
+  /** The current text, read from the contenteditable's text content (not `.value`). */
+  async getValue(): Promise<Optional<string>> {
+    return (await this.interactor.getText(this.editable)) ?? undefined;
+  }
+
+  /** Append text to the editor. Append-only — see class docs on the contenteditable constraint. */
+  async appendValue(text: string): Promise<void> {
+    return this.interactor.enterText(this.editable, text);
+  }
+
+  /** Focus the editor — the inner contenteditable, not the wrapper root. */
+  override async focus(option?: Partial<FocusOption>): Promise<void> {
+    return this.interactor.focus(this.editable, option);
+  }
+
+  /** The editor's accessible name (`aria-label`, from the `label` prop). */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.editable, 'aria-label');
+  }
+
+  /** The placeholder text (an `aria-hidden` sibling, not the native `placeholder` attribute). */
+  async getPlaceholder(): Promise<Optional<string>> {
+    const placeholder = locatorUtil.append(this.locator, byCssSelector('[aria-hidden="true"]'));
+    if (!(await this.interactor.exists(placeholder))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(placeholder)) ?? undefined;
+  }
+
+  /** Whether the suggestion menu is open (`aria-expanded` on the textbox) — the open transition is E2E-only. */
+  async isSuggestionsOpen(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.editable, 'aria-expanded')) === 'true';
+  }
+
+  get driverName(): string {
+    return 'AstryxChatComposerInputDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatDictationButtonDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatDictationButtonDriver.ts
@@ -1,0 +1,30 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatDictationButton (`@astryxdesign/core/Chat`) — the
+ * microphone toggle for voice input in a chat composer.
+ *
+ * It wraps an icon-only `<button>` in a `<span>` and, like {@link ChatSendButtonDriver},
+ * **does not forward `data-testid`**; the button also renders `null` when speech
+ * recognition is unsupported and `isHiddenWhenUnsupported` is left at its default.
+ * The scene therefore anchors directly on the inner button via its verbatim
+ * accessible name, which the icon-only Button writes as `aria-label`:
+ * `"Start dictation"` when idle and `"Stop dictation"` while listening. State is
+ * read from that name — {@link isListening} — since the visual difference (a static
+ * mic icon versus volume-reactive bars) is a browser-only rendering detail.
+ */
+export class ChatDictationButtonDriver extends ComponentDriver<{}> {
+  /** The button's accessible name (`aria-label`): `"Start dictation"` or `"Stop dictation"`. */
+  async getAccessibleName(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** Whether dictation is active — the button reads `aria-label="Stop dictation"`. */
+  async isListening(): Promise<boolean> {
+    return (await this.getAccessibleName()) === 'Stop dictation';
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatDictationButtonDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatLayoutDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatLayoutDriver.ts
@@ -1,0 +1,41 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatLayout (`@astryxdesign/core/Chat`) — the shell that
+ * places the message area in page flow with a composer docked to the bottom.
+ *
+ * The root `<div class="astryx-chat-layout">` forwards `data-testid` and carries
+ * the stable `data-density`. When `children` is empty the message area renders the
+ * caller's `emptyState` node instead; {@link getEmptyStateText} reads it via a part
+ * the scene anchors on the empty-state content (Astryx renders it verbatim, with no
+ * stable anchor of its own).
+ *
+ * The scroll-to-bottom button (`hasScrollButton`) drives `useChatStreamScroll`,
+ * which depends on real layout geometry and an `IntersectionObserver`; it is a
+ * browser-only concern, so it is intentionally not exposed here. Examples pass
+ * `scrollButton={null}` to suppress the default button under jsdom.
+ */
+export class ChatLayoutDriver extends ComponentDriver<{}> {
+  /** The visual density (`data-density`): `'compact'`, `'balanced'`, or `'spacious'`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /**
+   * The empty-state text, or `undefined` when the layout has message content.
+   *
+   * Reads a descendant matched by `selector` — the scene supplies a testid placed
+   * on its own empty-state node.
+   */
+  async getEmptyStateText(selector: string): Promise<Optional<string>> {
+    const emptyState: PartLocator = locatorUtil.append(this.locator, byCssSelector(selector));
+    if (!(await this.interactor.exists(emptyState))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(emptyState))?.trim() || undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatLayoutDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatMessageBubbleDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatMessageBubbleDriver.ts
@@ -1,0 +1,38 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatMessageBubble (`@astryxdesign/core/Chat`) — the
+ * styled "bubble" content container within a chat message.
+ *
+ * The bubble renders one `<div class="astryx-chat-message-bubble">` that reflects
+ * its visual props as stable `data-*` attributes: `data-sender` (inherited from the
+ * enclosing `ChatMessage` context, defaulting to `assistant` when standalone),
+ * `data-variant` (`filled` | `ghost`), and `data-density`. The scene anchors on
+ * the forwarded `data-testid`, and state is read from those data attributes rather
+ * than the StyleX-hashed classes.
+ */
+export class ChatMessageBubbleDriver extends ComponentDriver<{}> {
+  /** The bubble's text content. */
+  async getText(): Promise<Optional<string>> {
+    return (await super.getText())?.trim() || undefined;
+  }
+
+  /** The sender (`data-sender`): `'user'`, `'assistant'`, or `'system'`. */
+  async getSender(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-sender');
+  }
+
+  /** The visual variant (`data-variant`): `'filled'` (default) or `'ghost'`. */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  /** The visual density (`data-density`): `'compact'`, `'balanced'`, or `'spacious'`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatMessageBubbleDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatMessageDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatMessageDriver.ts
@@ -1,0 +1,63 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatMessage (`@astryxdesign/core/Chat`) — the per-message
+ * sender wrapper that aligns the avatar, name, bubble(s), and metadata for one
+ * turn in a conversation.
+ *
+ * ChatMessage renders an `<article class="astryx-chat-message {sender}">` carrying
+ * the stable `data-sender` and `data-density` attributes, and forwards
+ * `data-testid` onto that root. The sender name (when present) lives in an inner
+ * `<div id>` referenced by the article's `aria-labelledby`; that id is generated,
+ * not a CSS-expressible anchor and the article emits no name testid, so **the name
+ * is deliberately not exposed** (#909/#923 deferred name-aware lookup). The bubble
+ * and metadata are descendants targeted by their stable `astryx-chat-message-*`
+ * classes — the lone exception to the no-class rule, since those are semantic
+ * (not StyleX-hashed) and Astryx documents them as targetable.
+ */
+export class ChatMessageDriver extends ComponentDriver<{}> {
+  /** The message bubble (`.astryx-chat-message-bubble`), when the content is bubbled. */
+  private get bubble(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-chat-message-bubble'));
+  }
+
+  /** The footer metadata block (`.astryx-chat-message-metadata`), when present. */
+  private get metadata(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-chat-message-metadata'));
+  }
+
+  /** The sender (`data-sender`): `'user'`, `'assistant'`, or `'system'`. */
+  async getSender(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-sender');
+  }
+
+  /** The visual density (`data-density`): `'compact'`, `'balanced'`, or `'spacious'`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /** The whole message's visible text (name + bubble + metadata), trimmed. */
+  override async getText(): Promise<Optional<string>> {
+    return (await super.getText())?.trim() || undefined;
+  }
+
+  /** Just the bubble's text, or `undefined` when the message has no bubble. */
+  async getBubbleText(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.bubble))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.bubble))?.trim() || undefined;
+  }
+
+  /** The metadata block's text, or `undefined` when the message has no metadata. */
+  async getMetadataText(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.metadata))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.metadata))?.trim() || undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatMessageDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatMessageListDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatMessageListDriver.ts
@@ -1,0 +1,65 @@
+import {
+  byCssSelector,
+  IComponentDriverOption,
+  Interactor,
+  ListComponentDriver,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+import { ChatMessageDriver } from './ChatMessageDriver';
+
+/**
+ * Driver for the Astryx ChatMessageList (`@astryxdesign/core/Chat`) — the
+ * `role="log"` scroll container that holds a conversation's messages.
+ *
+ * The list root is a `<div role="log" aria-live="polite" class="astryx-chat-message-list">`
+ * that forwards `data-testid` and carries `data-density`. Each message is an
+ * `<article class="astryx-chat-message">` descendant, so rows are addressed by that
+ * stable semantic class and driven by {@link ChatMessageDriver}. Astryx renders the
+ * full history in the DOM (auto-scroll is a browser-only concern owned by
+ * `ChatLayout`), so enumeration is faithful in jsdom as well as the browser.
+ *
+ * When the list is empty it renders the caller's `emptyState` node instead of any
+ * messages; {@link getEmptyStateText} reads it via a part the scene anchors on the
+ * empty-state content (the empty state has no testid of its own).
+ */
+export class ChatMessageListDriver extends ListComponentDriver<ChatMessageDriver> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      itemClass: ChatMessageDriver,
+      itemLocator: byCssSelector('article.astryx-chat-message'),
+      ...option,
+    });
+  }
+
+  /** The number of rendered messages. */
+  async getMessageCount(): Promise<number> {
+    return this.getItemCount();
+  }
+
+  /** The visual density (`data-density`): `'compact'`, `'balanced'`, or `'spacious'`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /**
+   * The empty-state text, or `undefined` when the list has messages.
+   *
+   * Reads a descendant matched by `selector` — the scene supplies a testid placed
+   * on its own empty-state node, since Astryx renders the caller's `emptyState`
+   * verbatim without a stable anchor.
+   */
+  async getEmptyStateText(selector: string): Promise<Optional<string>> {
+    const emptyState = locatorUtil.append(this.locator, byCssSelector(selector));
+    if (!(await this.interactor.exists(emptyState))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(emptyState))?.trim() || undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatMessageListDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatSendButtonDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatSendButtonDriver.ts
@@ -1,0 +1,34 @@
+import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+
+/**
+ * Driver for the Astryx ChatSendButton (`@astryxdesign/core/Chat`) — the circular
+ * send/stop toggle for a chat composer.
+ *
+ * It renders an icon-only `<button class="astryx-chat-send-button">`. Crucially,
+ * **it does not forward `data-testid`** (it spreads props onto the inner `Button`,
+ * which keeps its own), so the scene anchors on the stable `astryx-chat-send-button`
+ * class, or — to disambiguate the two states — on the verbatim accessible name the
+ * icon-only Button writes as `aria-label`: `"Send"` (accent/primary) versus
+ * `"Stop"` (neutral/secondary). The send state disables via the native `disabled`
+ * attribute, so {@link isDisabled} is inherited from {@link HTMLButtonDriver}.
+ */
+export class ChatSendButtonDriver extends HTMLButtonDriver {
+  /** The accessible name the icon-only button exposes — `"Send"` or `"Stop"`. */
+  private async getAccessibleName(): Promise<string | undefined> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-label')) ?? undefined;
+  }
+
+  /** Whether the button is in its send state (`aria-label="Send"`). */
+  async isSend(): Promise<boolean> {
+    return (await this.getAccessibleName()) === 'Send';
+  }
+
+  /** Whether the button is in its stop state (`aria-label="Stop"`). */
+  async isStop(): Promise<boolean> {
+    return (await this.getAccessibleName()) === 'Stop';
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatSendButtonDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatSystemMessageDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatSystemMessageDriver.ts
@@ -1,0 +1,28 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatSystemMessage (`@astryxdesign/core/Chat`) — the
+ * centered, non-sender notice in a chat thread (e.g. "Conversation started", a
+ * date separator).
+ *
+ * Both variants render a `<div role="status" class="astryx-chat-system-message">`
+ * that forwards `data-testid` and carries the stable `data-variant` (`default` |
+ * `divider`); the divider variant adds an inner `role="separator"` but keeps the
+ * same root, so severity-style reads come from `data-variant` rather than the
+ * shifting inner structure.
+ */
+export class ChatSystemMessageDriver extends ComponentDriver<{}> {
+  /** The message text. */
+  override async getText(): Promise<Optional<string>> {
+    return (await super.getText())?.trim() || undefined;
+  }
+
+  /** The visual variant (`data-variant`): `'default'` or `'divider'`. */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatSystemMessageDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ChatToolCallsDriver.ts
+++ b/packages/component-driver-astryx/src/components/ChatToolCallsDriver.ts
@@ -1,0 +1,79 @@
+import {
+  byCssSelector,
+  childListHelper,
+  ComponentDriver,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ChatToolCalls (`@astryxdesign/core/Chat`) — the block that
+ * surfaces an LLM turn's tool/function invocations.
+ *
+ * The root `<div class="astryx-chat-tool-calls">` forwards `data-testid`. Its shape
+ * depends on the call count:
+ * - **Single call** — one inline call row, no group chrome and no `aria-expanded`.
+ * - **Multiple calls** — a collapsible header `<div role="button" aria-expanded>`
+ *   summarising the group, followed by a body that always renders every call row
+ *   in the DOM (it is only CSS-collapsed, never unmounted), so enumeration is
+ *   faithful in jsdom as well as the browser.
+ *
+ * Astryx assigns no per-row anchor (rows are StyleX-styled `<div>`s), so the group
+ * header — the one element carrying `aria-expanded` — is the stable handle for
+ * {@link isExpanded}/{@link toggleGroup}. {@link getCallCount} counts the call rows
+ * by their shape: a row is a `<div>` whose first child is the status-icon `<span>`,
+ * which excludes the StyleX wrapper `<div>`s (their first child is a `<div>`) and
+ * the group header (a `<div role="button">`). The multi-call body interleaves those
+ * wrapper `<div>`s with the rows, so the count uses `childListHelper`'s `:nth-child`
+ * walk (with a `'*'` group selector to descend through the body wrappers) rather
+ * than a tag-based `:nth-of-type` index that the wrappers throw off. `:has()` is
+ * supported by jsdom's nwsapi and every Playwright engine, mirroring `PowerSearchDriver`.
+ *
+ * NOTE — this row shape is a structural proxy: a stable per-row anchor (a `role` or
+ * `data-*` on each call row) is the right-altitude handle. Tracked upstream as part
+ * of the Astryx coverage gaps (#909).
+ */
+const CALL_ROW_SELECTOR = 'div:not([role]):has(> span:first-child)';
+
+export class ChatToolCallsDriver extends ComponentDriver<{}> {
+  /** The collapsible group header — present only when there is more than one call. */
+  private get groupHeader(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="button"][aria-expanded]'));
+  }
+
+  /** Whether this is a multi-call group (it renders the collapsible header). */
+  async isGrouped(): Promise<boolean> {
+    return this.interactor.exists(this.groupHeader);
+  }
+
+  /**
+   * The number of tool calls. A single call reports `1`; a group reports the number
+   * of rows rendered in its (DOM-resident) body, regardless of expanded state.
+   */
+  async getCallCount(): Promise<number> {
+    return childListHelper.countMatchingChildren(this.interactor, this.locator, CALL_ROW_SELECTOR, '*');
+  }
+
+  /**
+   * Whether the group is expanded, or `undefined` for a single call (which has no
+   * expandable header). Read from the header's `aria-expanded`.
+   */
+  async isExpanded(): Promise<Optional<boolean>> {
+    if (!(await this.isGrouped())) {
+      return undefined;
+    }
+    return (await this.interactor.getAttribute(this.groupHeader, 'aria-expanded')) === 'true';
+  }
+
+  /** Toggle the group's expanded state by clicking its header. No-op for a single call. */
+  async toggleGroup(): Promise<void> {
+    if (await this.isGrouped()) {
+      await this.interactor.click(this.groupHeader);
+    }
+  }
+
+  override get driverName(): string {
+    return 'AstryxChatToolCallsDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/CitationDriver.ts
+++ b/packages/component-driver-astryx/src/components/CitationDriver.ts
@@ -1,0 +1,49 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Citation (`@astryxdesign/core/Citation`) — an inline
+ * reference marker.
+ *
+ * Citation's root tag is CONDITIONAL: an `<a>` when its source has a `url`,
+ * otherwise a `<span>`; both always carry `role="doc-noteref"`, an
+ * `aria-label="Citation {number}: {title}"`, a `title` (the source title), and a
+ * `data-variant` (`'label'` | `'number'`). Astryx forwards `data-testid` onto
+ * whichever element it renders, so the scene anchors there tag-agnostically and
+ * detects the link case by the presence of `href` rather than by sniffing the tag.
+ */
+export class CitationDriver extends ComponentDriver<{}> {
+  /** The source title — the `title` attribute (also the visible text in the `label` variant). */
+  async getTitle(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'title');
+  }
+
+  /**
+   * The citation number, parsed from the `aria-label` (`"Citation {n}: {title}"`)
+   * so it is read identically for both the `label` and `number` variants.
+   * `undefined` when the label does not carry a number.
+   */
+  async getNumber(): Promise<Optional<number>> {
+    const ariaLabel = await this.interactor.getAttribute(this.locator, 'aria-label');
+    const match = ariaLabel?.match(/Citation\s+(\d+)/);
+    return match ? Number(match[1]) : undefined;
+  }
+
+  /** The link target — the `href`, or `undefined` when the citation has no `url` (renders a `<span>`). */
+  async getHref(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'href');
+  }
+
+  /** Whether the citation is a link — Astryx renders an `<a href>` only when its source has a `url`. */
+  async isLink(): Promise<boolean> {
+    return (await this.getHref()) != null;
+  }
+
+  /** The variant (`data-variant`): `'label'` or `'number'`. */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  get driverName(): string {
+    return 'AstryxCitationDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/CodeBlockDriver.ts
+++ b/packages/component-driver-astryx/src/components/CodeBlockDriver.ts
@@ -1,0 +1,82 @@
+import {
+  byCssSelector,
+  childListHelper,
+  ComponentDriver,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx CodeBlock (`@astryxdesign/core/CodeBlock`).
+ *
+ * CodeBlock renders a `<pre data-language>` root (carrying `data-testid`) around a
+ * `<code>` whose lines are `<div data-line="N">`. A header row appears when the
+ * block has a language label or is collapsible; the collapsible header is a
+ * `<div role="button" aria-expanded>` toggle, and a copy `<button aria-label="Copy
+ * code">` flips to `"Copied"` after use. The driver reads the language off the
+ * root, the source off `<code>`, and counts lines via the `data-line` markers.
+ *
+ * The copied state is clipboard-driven and only flips in a real browser, so it is
+ * intentionally NOT exposed here (E2E/clipboard-only).
+ */
+export class CodeBlockDriver extends ComponentDriver<{}> {
+  /** The `<code>` element holding the highlighted source. */
+  private get code(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('code'));
+  }
+
+  /** The collapsible header toggle (`role="button"` with `aria-expanded`), present only when collapsible. */
+  private get collapseToggle(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="button"][aria-expanded]'));
+  }
+
+  /** The source language from the root's `data-language` (e.g. `"javascript"`). */
+  async getLanguage(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-language');
+  }
+
+  /** The full source text. */
+  async getCode(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.code))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.code)) ?? undefined;
+  }
+
+  /**
+   * Number of code lines (`<div data-line>` markers).
+   *
+   * Above `LINE_CHUNK_THRESHOLD` (100) lines, Astryx wraps every chunk of lines in
+   * an intermediate `<div>`, so the `data-line` markers are no longer flat children
+   * of `<code>` — a tag-based `:nth-of-type` walk stops at the first chunk boundary.
+   * The count therefore uses `childListHelper`'s `:nth-child` walk with a `'*'` group
+   * selector, which descends through the chunk wrappers (and reads the flat case too).
+   */
+  async getLineCount(): Promise<number> {
+    return childListHelper.countMatchingChildren(this.interactor, this.code, '[data-line]', '*');
+  }
+
+  /**
+   * Whether the block is currently collapsed — `true` only when a collapsible
+   * header is present and its `aria-expanded` is `"false"`. A non-collapsible
+   * block has no toggle and reports `false`.
+   */
+  async isCollapsed(): Promise<boolean> {
+    if (!(await this.interactor.exists(this.collapseToggle))) {
+      return false;
+    }
+    return (await this.interactor.getAttribute(this.collapseToggle, 'aria-expanded')) === 'false';
+  }
+
+  /** Toggle the collapsible header (expand/collapse). No-op when the block is not collapsible. */
+  async toggleCollapse(): Promise<void> {
+    if (await this.interactor.exists(this.collapseToggle)) {
+      await this.interactor.click(this.collapseToggle);
+    }
+  }
+
+  override get driverName(): string {
+    return 'AstryxCodeBlockDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/CodeDriver.ts
+++ b/packages/component-driver-astryx/src/components/CodeDriver.ts
@@ -1,0 +1,15 @@
+import { ComponentDriver } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Code (`@astryxdesign/core/Code`) — the inline
+ * `<code class="astryx-code">` element.
+ *
+ * Code is a pure display leaf with NO role and no `data-*` theme attributes; the
+ * only thing to read is its text content (inherited {@link getText}). The scene
+ * anchors on the forwarded `data-testid`.
+ */
+export class CodeDriver extends ComponentDriver<{}> {
+  override get driverName(): string {
+    return 'AstryxCodeDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ContextMenuDriver.ts
+++ b/packages/component-driver-astryx/src/components/ContextMenuDriver.ts
@@ -1,0 +1,56 @@
+import { byCssSelector, Optional, PartLocator } from '@atomic-testing/core';
+
+import { AstryxMenuDriver } from './AstryxMenuDriver';
+
+/**
+ * Driver for the Astryx ContextMenu (`@astryxdesign/core/ContextMenu`).
+ *
+ * The scene anchors this driver on the **trigger** `<div>`, which carries only
+ * `aria-haspopup="menu"` (Astryx forwards `data-testid` here). Unlike Popover, the
+ * trigger has **no `aria-expanded` and no `aria-controls`** — the only way to open
+ * the menu is a `contextmenu`/right-click event, and the `role="menu"` layer is a
+ * `popover` rendered as a sibling at the document root with no id link back to the
+ * trigger. So:
+ *
+ * - {@link open} uses the `contextMenu` interactor primitive (the dedicated
+ *   right-click event — the menu has no controlled-open prop to flip).
+ * - the item reads come from {@link AstryxMenuDriver}: it enumerates the
+ *   `role="menuitem"` children of the document-rooted `role="menu"` via
+ *   `childListHelper`'s portable `:nth-child` walk, so interleaved `role="separator"`
+ *   dividers and `role="group"` sections (both first-class `ContextMenuOption`s, and
+ *   both `<div>`s like the items) are handled — not silently truncated. Astryx keeps
+ *   the layer mounted even while closed, so labels/count read in jsdom.
+ * - **`isOpen` is intentionally absent**: the trigger exposes no open-state ARIA
+ *   and the menu element is always present in the DOM, so open/closed is
+ *   indistinguishable in jsdom (the native Popover API is a no-op there). Open-state
+ *   verification is **E2E-only** — blocking dependency: a stable open-state anchor
+ *   on the trigger or layer (filed upstream / tracked in the coverage matrix).
+ *
+ * Single-instance best-effort: the document-rooted menu read does not scope to a
+ * specific trigger, so a page with multiple ContextMenus would need a scoped
+ * variant. Documented as a v1 limitation.
+ */
+export class ContextMenuDriver extends AstryxMenuDriver {
+  /** Open the menu by dispatching a right-click on the trigger. */
+  async open(): Promise<void> {
+    return this.interactor.contextMenu(this.locator);
+  }
+
+  /**
+   * The `role="menu"` layer, re-rooted at the document. Astryx renders it as a
+   * body-level popover with no id link back to the trigger, so this is best-effort
+   * for a single ContextMenu per scene (documented v1 limit).
+   */
+  protected override resolveMenuLocator(): Promise<PartLocator | null> {
+    return Promise.resolve(byCssSelector('[role="menu"]', 'Root'));
+  }
+
+  /** The trigger's popup type (`aria-haspopup`, always `"menu"`). */
+  async getHasPopup(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-haspopup');
+  }
+
+  override get driverName(): string {
+    return 'AstryxContextMenuDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/DividerDriver.ts
+++ b/packages/component-driver-astryx/src/components/DividerDriver.ts
@@ -1,0 +1,42 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Divider (`@astryxdesign/core/Divider`) — the
+ * `<div role="separator">` rule.
+ *
+ * The root carries `data-variant`, `data-orientation`, and a mirrored
+ * `aria-orientation`. When a `label` is supplied, Divider renders THREE inner
+ * `<div>`s (line | label | line), so the label is the middle child
+ * (`div:nth-child(2)`); an unlabeled divider renders a single inner `<div>` and no
+ * middle child. {@link getLabel} therefore guards on that child's existence and
+ * returns `undefined` when the divider is unlabeled. The scene anchors on the
+ * forwarded `data-testid` (`role="separator"` is equally valid).
+ */
+export class DividerDriver extends ComponentDriver<{}> {
+  /** The middle inner `<div>` that holds the label — present only when labeled. */
+  private get labelSlot(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('div:nth-child(2)'));
+  }
+
+  /** The visual variant (`data-variant`): `'subtle'` or `'strong'`. */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  /** The orientation (`data-orientation`): `'horizontal'` or `'vertical'`. */
+  async getOrientation(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-orientation');
+  }
+
+  /** The centered label text, or `undefined` when the divider is unlabeled. */
+  async getLabel(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.labelSlot))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.labelSlot)) ?? undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxDividerDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/EmptyStateDriver.ts
+++ b/packages/component-driver-astryx/src/components/EmptyStateDriver.ts
@@ -1,0 +1,78 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx EmptyState (`@astryxdesign/core/EmptyState`).
+ *
+ * EmptyState renders a `<div role="status">` (the live-region root, where
+ * `data-testid` is forwarded) wrapping a heading (`<h1>`–`<h6>`, defaulting to
+ * `<h3>`), a `<p>` description, and — when `actions` are supplied — a trailing
+ * actions `<div>` holding the action `<button>`s. The scene anchors on the root
+ * and reaches the heading/description/action by their native tags rather than by
+ * StyleX-hashed classes. The heading level is read off whichever `h*` tag exists,
+ * since the rendered level varies with the `headingLevel` prop.
+ */
+export class EmptyStateDriver extends ComponentDriver<{}> {
+  /**
+   * The heading at a specific level. Probed one level at a time (a single `h${n}`
+   * tag) rather than via an `h1,…,h6` selector list — a comma list would leave the
+   * later alternatives unscoped, matching another EmptyState's heading on the page.
+   */
+  private headingAt(level: number): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector(`h${level}`));
+  }
+
+  private get description(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('p'));
+  }
+
+  private get action(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button'));
+  }
+
+  /** The heading text, read from whichever `h1`–`h6` level is rendered. */
+  async getTitle(): Promise<Optional<string>> {
+    for (let level = 1; level <= 6; level++) {
+      const heading = this.headingAt(level);
+      if (await this.interactor.exists(heading)) {
+        return (await this.interactor.getText(heading)) ?? undefined;
+      }
+    }
+    return undefined;
+  }
+
+  /** The description paragraph text, or `undefined` when no description is rendered. */
+  async getDescription(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.description))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.description)) ?? undefined;
+  }
+
+  /**
+   * The heading level (1–6) derived from the rendered tag name. Astryx renders the
+   * heading at `headingLevel` (default 3), so the level is discovered by probing
+   * `h1`…`h6` rather than read from an attribute.
+   */
+  async getHeadingLevel(): Promise<Optional<number>> {
+    for (let level = 1; level <= 6; level++) {
+      if (await this.interactor.exists(this.headingAt(level))) {
+        return level;
+      }
+    }
+    return undefined;
+  }
+
+  /** Whether the empty state is present in the DOM. */
+  async isPresent(): Promise<boolean> {
+    return this.exists();
+  }
+
+  /** Whether an action button is rendered (the `actions` prop was supplied). */
+  async hasAction(): Promise<boolean> {
+    return this.interactor.exists(this.action);
+  }
+
+  override get driverName(): string {
+    return 'AstryxEmptyStateDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/FileInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/FileInputDriver.ts
@@ -1,0 +1,89 @@
+import { HTMLFileInputDriver } from '@atomic-testing/component-driver-html';
+import { byCssSelector, Optional } from '@atomic-testing/core';
+
+import { resolveLinkedLabelText } from '../internal/linkedLocators';
+
+/**
+ * Driver for the Astryx FileInput (`@astryxdesign/core/FileInput`).
+ *
+ * Astryx forwards `data-testid` onto the **hidden native `<input type="file">`**,
+ * not the visible `div[role="button"]` dropzone — which is convenient, because the
+ * input is the element every meaningful read and the upload itself live on:
+ * `accept`, `multiple`, `aria-required`, `aria-invalid`, `disabled`, and the
+ * `aria-describedby` → status-message link are all attributes of the input, and
+ * `setInputFiles` must target a real `<input type="file">`. The scene therefore
+ * anchors this driver on that input.
+ *
+ * It extends {@link HTMLFileInputDriver} to inherit `uploadFiles` (the
+ * `setInputFiles` primitive — `userEvent.upload` in jsdom, `locator.setInputFiles`
+ * in Playwright), and resolves its label through the shared `<label for>`↔`id`
+ * helper. The *rendered selected-file list* is consumer-`value`-controlled, and the
+ * OS file picker and drag-and-drop are native — so file-chip readback and dropzone
+ * DnD are **E2E-only** and not surfaced here.
+ */
+export class FileInputDriver extends HTMLFileInputDriver {
+  /** The accepted MIME/extension filter (`accept`), or `undefined` when unrestricted. */
+  async getAccept(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'accept');
+  }
+
+  /** Whether multiple files may be selected (`multiple`). */
+  async isMultiple(): Promise<boolean> {
+    return this.interactor.hasAttribute(this.locator, 'multiple');
+  }
+
+  /** Whether the field is required (`aria-required="true"`). */
+  async isRequired(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-required')) === 'true';
+  }
+
+  /** Whether the field is in an error state (`aria-invalid="true"`, mirrored by the button's `data-status="error"`). */
+  async isInvalid(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-invalid')) === 'true';
+  }
+
+  /** Whether the field is disabled (native `disabled` on the input). */
+  async isDisabled(): Promise<boolean> {
+    return this.interactor.hasAttribute(this.locator, 'disabled');
+  }
+
+  /**
+   * The field's visible label, resolved through the native `<label for>`↔`id`
+   * link rather than a StyleX-hashed wrapper class. The id is matched through the
+   * escaping `byLinkedElement` builder (shared with the field-input drivers), so a
+   * consumer-supplied id with a CSS metacharacter cannot break the selector.
+   */
+  async getLabel(): Promise<Optional<string>> {
+    return resolveLinkedLabelText(this.interactor, this.locator);
+  }
+
+  /**
+   * The validation message text, resolved through the input's `aria-describedby`
+   * → status element id link. `undefined` when the field carries no status.
+   *
+   * `aria-describedby` is an IDREF *list*: Astryx points the input at both its
+   * description and its status when both are present (`FileInput` joins
+   * `descriptionID` + `statusMessageID`). The status is the `FieldStatus` element
+   * carrying a `data-type` severity marker (the description is a plain element
+   * without it), so each id is resolved and the one with `data-type` is returned —
+   * matching the whole multi-id attribute as a single id would find nothing. This
+   * mirrors {@link AstryxFieldInputDriver.getStatusMessage}.
+   */
+  async getStatusMessage(): Promise<Optional<string>> {
+    const describedBy = await this.interactor.getAttribute(this.locator, 'aria-describedby');
+    if (!describedBy) {
+      return undefined;
+    }
+    for (const id of describedBy.split(/\s+/).filter(Boolean)) {
+      const statusLocator = byCssSelector(`[id="${id}"][data-type]`, 'Root');
+      if (await this.interactor.exists(statusLocator)) {
+        return (await this.interactor.getText(statusLocator)) ?? undefined;
+      }
+    }
+    return undefined;
+  }
+
+  override get driverName(): string {
+    return 'AstryxFileInputDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/HeadingDriver.ts
+++ b/packages/component-driver-astryx/src/components/HeadingDriver.ts
@@ -1,0 +1,44 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Heading (`@astryxdesign/core/Heading`) — the semantic
+ * `<h1>`–`<h6>` (role `heading`).
+ *
+ * The visual/semantic `level` is reflected as `data-level` (a numeric string that
+ * is ALWAYS present), so {@link getLevel} reads it and parses to a number. The
+ * native element tag (`h1`…`h6`) also encodes the level. `aria-level` is emitted
+ * ONLY when `accessibilityLevel` differs from `level`, so {@link getAccessibilityLevel}
+ * prefers `aria-level` and falls back to `data-level` when the two coincide.
+ * The scene anchors on the forwarded `data-testid`.
+ */
+export class HeadingDriver extends ComponentDriver<{}> {
+  /** The heading level (`data-level`, always present) as a number, or `undefined` if unparseable. */
+  async getLevel(): Promise<Optional<number>> {
+    const raw = await this.interactor.getAttribute(this.locator, 'data-level');
+    if (raw == null) {
+      return undefined;
+    }
+    const level = Number.parseInt(raw, 10);
+    return Number.isNaN(level) ? undefined : level;
+  }
+
+  /**
+   * The accessibility level as a number. Reads `aria-level` when present (set only
+   * when `accessibilityLevel` ≠ `level`), otherwise falls back to the visual
+   * {@link getLevel}.
+   */
+  async getAccessibilityLevel(): Promise<Optional<number>> {
+    const raw = await this.interactor.getAttribute(this.locator, 'aria-level');
+    if (raw != null) {
+      const level = Number.parseInt(raw, 10);
+      if (!Number.isNaN(level)) {
+        return level;
+      }
+    }
+    return this.getLevel();
+  }
+
+  override get driverName(): string {
+    return 'AstryxHeadingDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/HoverCardDriver.ts
+++ b/packages/component-driver-astryx/src/components/HoverCardDriver.ts
@@ -1,0 +1,48 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+import { resolveLinkedElementText } from '../internal/linkedLocators';
+
+/**
+ * Driver for the Astryx HoverCard (`@astryxdesign/core/HoverCard`).
+ *
+ * **Best-effort v1** — HoverCard is structurally hard to anchor: the floating
+ * layer is a body-level `popover` with **no role, no testid, and no open-state
+ * attribute**. The only stable link is the trigger's injected
+ * `aria-describedby` → the layer's `id`, so the scene anchors on the trigger
+ * (`data-testid`) and {@link getContent} re-roots to the layer through that link
+ * (`'Root'`), mirroring how {@link PopoverDriver} follows `aria-controls`.
+ *
+ * The layer is always mounted in the DOM (jsdom does not implement the native
+ * Popover API), so its content reads in both states; the **open/closed transition
+ * is E2E-only** and there is no portable `isOpen`. Blocking dependency: Astryx
+ * exposing a `role`/`data-testid`/open-state attribute on the layer (filed
+ * upstream) — that would promote this driver from best-effort to first-class.
+ */
+export class HoverCardDriver extends ComponentDriver<{}> {
+  /** The trigger's own text. */
+  async getTriggerText(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /**
+   * The hover-card layer's content text, resolved through the trigger's
+   * `aria-describedby` → layer `id` link. `undefined` when the trigger has no
+   * linked layer.
+   */
+  async getContent(): Promise<Optional<string>> {
+    return resolveLinkedElementText(this.interactor, this.locator, 'aria-describedby');
+  }
+
+  /**
+   * Hover the trigger to reveal the card. The reveal itself (native popover) is
+   * only observable in a real browser; in jsdom this dispatches the hover but the
+   * layer's visibility does not change.
+   */
+  async open(): Promise<void> {
+    return this.hover();
+  }
+
+  get driverName(): string {
+    return 'AstryxHoverCardDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ItemDriver.ts
+++ b/packages/component-driver-astryx/src/components/ItemDriver.ts
@@ -1,0 +1,53 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Item (`@astryxdesign/core/Item`).
+ *
+ * Item renders a tag chosen by its `as` prop (`<div>` by default, also `<li>` or
+ * `<span>`), with `data-testid`, `data-density`, and `data-align` on that root.
+ * The selected state is expressed as `aria-selected="true"` ONLY on an `<li>`
+ * root (a `<div>` item never emits it). When the item is a link it wraps an inner
+ * `<a href>`; when it has an `onClick` it wraps an inner `<button>`. The driver
+ * anchors on the root and reads the label as its text content.
+ */
+export class ItemDriver extends ComponentDriver<{}> {
+  /** The inner `<a>`, present only when the item is rendered as a link. */
+  private get anchor(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('a'));
+  }
+
+  /** The item's visible label (its full text content). */
+  async getLabel(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /** The density token from `data-density`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /** The alignment token from `data-align`. */
+  async getAlign(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-align');
+  }
+
+  /**
+   * Whether the item is selected. Astryx emits `aria-selected="true"` only on an
+   * `<li>` root, so a `<div>`/`<span>` item always reports `false`.
+   */
+  async isSelected(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-selected')) === 'true';
+  }
+
+  /** The link target (`href` of the inner `<a>`), or `undefined` when the item is not a link. */
+  async getHref(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.anchor))) {
+      return undefined;
+    }
+    return this.interactor.getAttribute(this.anchor, 'href');
+  }
+
+  override get driverName(): string {
+    return 'AstryxItemDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/MarkdownDriver.ts
+++ b/packages/component-driver-astryx/src/components/MarkdownDriver.ts
@@ -1,0 +1,52 @@
+import { childListHelper, ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Markdown (`@astryxdesign/core/Markdown`).
+ *
+ * Markdown renders its source into native HTML under a root whose shape depends
+ * on `display`: a block `<div role="document">` or an inline `<span>` (no role).
+ * `data-testid` and `data-density` sit on that root. The driver detects inline
+ * mode by the ABSENCE of `role="document"`, and counts the rendered headings
+ * (`h1`–`h6`) and links (`a[href]`).
+ *
+ * A link or heading is **not** a direct child of the root — Markdown nests them in
+ * block wrappers (`<p>`/`<li>`/`<blockquote>`), each typically the sole element of
+ * its tag in that block, so a tag-based `:nth-of-type` walk undercounts a document
+ * whose links/headings span separate blocks. The counts therefore use
+ * `childListHelper`'s portable `:nth-child` walk with a `'*'` group selector, which
+ * descends through any layout wrapper and tallies matches across the whole subtree.
+ * The copy-code affordance on fenced blocks is clipboard-driven and not exercised
+ * here (E2E-only).
+ */
+export class MarkdownDriver extends ComponentDriver<{}> {
+  /**
+   * Whether the markdown was rendered inline. Block markdown carries
+   * `role="document"` on its root; the inline `<span>` does not.
+   */
+  async isInline(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'role')) !== 'document';
+  }
+
+  /** The density token from `data-density`. */
+  async getDensity(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-density');
+  }
+
+  /** Number of rendered headings (`<h1>`–`<h6>`), summed across levels. */
+  async getHeadingCount(): Promise<number> {
+    let count = 0;
+    for (let level = 1; level <= 6; level++) {
+      count += await childListHelper.countMatchingChildren(this.interactor, this.locator, `h${level}`, '*');
+    }
+    return count;
+  }
+
+  /** Number of rendered links (`<a href>`). */
+  async getLinkCount(): Promise<number> {
+    return childListHelper.countMatchingChildren(this.interactor, this.locator, 'a[href]', '*');
+  }
+
+  override get driverName(): string {
+    return 'AstryxMarkdownDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/MobileNavDriver.ts
+++ b/packages/component-driver-astryx/src/components/MobileNavDriver.ts
@@ -1,0 +1,52 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx MobileNav (`@astryxdesign/core/MobileNav`).
+ *
+ * MobileNav is an inline (not portalled) native `<dialog class="astryx-mobile-nav">`
+ * drawer that forwards `data-testid` onto the `<dialog>`, names itself with
+ * `aria-label`, and records its slide edge in `data-side`. It contains a header
+ * `<h2>`, a `<button aria-label="Close navigation">`, and `SideNavItem` links.
+ * Because the dialog is rendered in place, all of that structure is a normal
+ * descendant and reads faithfully in jsdom.
+ *
+ * The OPEN state is set by `dialog.showModal()`, which is a **no-op in jsdom** — the
+ * `open` attribute is never applied there — so {@link isOpen} reports `true` only
+ * under the E2E (browser) run. Never assert the open state in the shared suite;
+ * assert the closed-state structure (label, side, close button, items) instead.
+ */
+export class MobileNavDriver extends ComponentDriver<{}> {
+  /** The drawer's close affordance (`<button aria-label="Close navigation">`). */
+  private get closeButton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button[aria-label="Close navigation"]'));
+  }
+
+  /** The drawer's accessible name (`aria-label`). */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** The edge the drawer slides from, from `data-side` (`'start'` | `'end'`; `'auto'` resolves at runtime). */
+  async getSide(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-side');
+  }
+
+  /** Whether a close button is rendered. */
+  async hasCloseButton(): Promise<boolean> {
+    return this.interactor.exists(this.closeButton);
+  }
+
+  /**
+   * Whether the drawer is open — the native `<dialog>`'s `open` attribute.
+   *
+   * E2E-only for `true`: opening calls `showModal()`, a no-op in jsdom, so this
+   * always reports `false` there regardless of the `isOpen` prop.
+   */
+  async isOpen(): Promise<boolean> {
+    return this.interactor.hasAttribute(this.locator, 'open');
+  }
+
+  get driverName(): string {
+    return 'AstryxMobileNavDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/NavIconDriver.ts
+++ b/packages/component-driver-astryx/src/components/NavIconDriver.ts
@@ -1,0 +1,16 @@
+import { ComponentDriver } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx NavIcon (`@astryxdesign/core/NavIcon`).
+ *
+ * NavIcon is a display-only `<span class="astryx-navicon">` (with `data-testid`
+ * forwarded) wrapping the supplied `icon` node; the icon child is `aria-hidden`
+ * but the wrapper itself is not. There is no role or text semantics, so the
+ * driver only exposes presence and the rendered icon markup via the inherited
+ * {@link ComponentDriver.innerHTML}.
+ */
+export class NavIconDriver extends ComponentDriver<{}> {
+  override get driverName(): string {
+    return 'AstryxNavIconDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ProgressBarDriver.ts
+++ b/packages/component-driver-astryx/src/components/ProgressBarDriver.ts
@@ -1,0 +1,77 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx ProgressBar (`@astryxdesign/core/ProgressBar`).
+ *
+ * The root `<div>` carries `data-testid` and `data-variant` but is itself
+ * ROLELESS — the ARIA semantics live on an inner track `<div>` whose `role`
+ * SWITCHES with mode: `role="meter"` for a determinate bar (with
+ * `aria-valuenow`/`min`/`max`/`text`) and `role="progressbar"` for an
+ * indeterminate one (with NO `aria-value*`). The driver therefore reads the
+ * value attributes off the track and treats their absence (the `progressbar`
+ * role) as indeterminate. The label is the header `<span id>`; the variant is the
+ * root's `data-variant`.
+ */
+export class ProgressBarDriver extends ComponentDriver<{}> {
+  /**
+   * The inner track, where the `meter`/`progressbar` role and `aria-value*` live.
+   * Anchored on the stable `astryx-progressbar-track` class rather than a
+   * `[role=meter],[role=progressbar]` selector list — a comma list would leave the
+   * second alternative unscoped (matching another bar's track elsewhere on the
+   * page), and the role here switches with mode anyway.
+   */
+  private get track(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-progressbar-track'));
+  }
+
+  /** The header label (`<span id>`, referenced by the track's `aria-labelledby`). */
+  private get label(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('span[id]'));
+  }
+
+  /** The current value (`aria-valuenow`), or `undefined` for an indeterminate bar. */
+  async getValueNow(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.track, 'aria-valuenow');
+  }
+
+  /** The minimum value (`aria-valuemin`), or `undefined` for an indeterminate bar. */
+  async getValueMin(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.track, 'aria-valuemin');
+  }
+
+  /** The maximum value (`aria-valuemax`), or `undefined` for an indeterminate bar. */
+  async getValueMax(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.track, 'aria-valuemax');
+  }
+
+  /** The human-readable value (`aria-valuetext`, e.g. `"75%"`), or `undefined` when indeterminate. */
+  async getValueText(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.track, 'aria-valuetext');
+  }
+
+  /** The visible label text. */
+  async getLabel(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.label))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.label)) ?? undefined;
+  }
+
+  /** The style variant from the root's `data-variant` (e.g. `"accent"`). */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  /**
+   * Whether the bar is indeterminate. Indeterminate bars render the track with
+   * `role="progressbar"` (and no `aria-valuenow`); determinate bars use
+   * `role="meter"`.
+   */
+  async isIndeterminate(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.track, 'role')) === 'progressbar';
+  }
+
+  override get driverName(): string {
+    return 'AstryxProgressBarDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/SideNavDriver.ts
+++ b/packages/component-driver-astryx/src/components/SideNavDriver.ts
@@ -1,0 +1,58 @@
+import {
+  byCssSelector,
+  childListHelper,
+  ComponentDriver,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx SideNav (`@astryxdesign/core/SideNav`).
+ *
+ * SideNav is a `<nav role="navigation" aria-label="Side navigation">` that forwards
+ * `data-testid` onto its root; the accessible name is hardcoded (there is no
+ * `label` prop), so {@link getLabel} always reports "Side navigation". Its
+ * `children` render as `[role="group"]` sections, and `collapsible` adds a footer
+ * `<button aria-label="Collapse …">` — both are structural and read faithfully in
+ * jsdom.
+ *
+ * The collapsed (icon-only) state has no attribute in the initial DOM; it is driven
+ * by interaction + layout, so {@link isCollapsed} is **E2E-only** and intentionally
+ * omitted here — the shared suite asserts only the structural reads below.
+ */
+export class SideNavDriver extends ComponentDriver<{}> {
+  /** The collapse toggle, present only when SideNav is `collapsible`. */
+  private get collapseButton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button[aria-label^="Collapse"]'));
+  }
+
+  /** The landmark's accessible name — always "Side navigation" (Astryx hardcodes it). */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** Whether a collapse toggle is rendered (i.e. SideNav was made `collapsible`). */
+  async hasCollapseButton(): Promise<boolean> {
+    return this.interactor.exists(this.collapseButton);
+  }
+
+  /**
+   * Number of `SideNavSection` groups (`[role="group"]`) in the content area.
+   *
+   * The sections are not the only same-tag (`<div>`) children of their container — a
+   * top-level `SideNavItem` (e.g. a "Home" link) renders a roleless `<div>` among
+   * them — so a tag-based `:nth-of-type` walk mis-indexes them. The count uses
+   * `childListHelper`'s `:nth-child` walk with a `'*'` group selector, which descends
+   * through the layout wrappers and tallies only the `role="group"` sections; because
+   * a matched section is not recursed into, a collapsible item's own nested
+   * `role="group"` panel inside a section is not double-counted.
+   */
+  async getSectionCount(): Promise<number> {
+    return childListHelper.countMatchingChildren(this.interactor, this.locator, '[role="group"]', '*');
+  }
+
+  get driverName(): string {
+    return 'AstryxSideNavDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/SideNavItemDriver.ts
+++ b/packages/component-driver-astryx/src/components/SideNavItemDriver.ts
@@ -1,0 +1,80 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx SideNavItem (`@astryxdesign/core/SideNav`, `SideNavItem`).
+ *
+ * SideNavItem renders one of two shapes, both forwarding `data-testid` onto the
+ * root: a **leaf** link is an `<a class="astryx-side-nav-item">` (the root *is* the
+ * anchor), while a **collapsible-with-children** item is a `<div>` wrapping an
+ * `<a href>` plus a `<button aria-expanded aria-controls>` toggle and a sibling
+ * `[role="group"]` panel. To cope with both, the readers prefer the root and fall
+ * back to a descendant `<a>` — so the same driver works whether the testid lands on
+ * the anchor or its `<div>` wrapper.
+ *
+ * Selected state is `aria-current="page"`; expansion is the toggle's `aria-expanded`
+ * (absent — hence `undefined` — for a leaf). All are React-state-driven and faithful
+ * in jsdom; only the collapse *animation* is E2E-only.
+ */
+export class SideNavItemDriver extends ComponentDriver<{}> {
+  /** The item's anchor: the root itself for a leaf, else a descendant `<a>`. */
+  private get anchor(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('a'));
+  }
+
+  /** The expand/collapse toggle, present only for a collapsible item with children. */
+  private get toggle(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button[aria-expanded]'));
+  }
+
+  /** Reads an attribute from the root, falling back to the descendant `<a>` (collapsible shape). */
+  private async readLinkAttribute(name: string): Promise<Optional<string>> {
+    const own = await this.interactor.getAttribute(this.locator, name);
+    if (own != null) {
+      return own;
+    }
+    if (await this.interactor.exists(this.anchor)) {
+      return this.interactor.getAttribute(this.anchor, name);
+    }
+    return undefined;
+  }
+
+  /**
+   * The item's visible label. For a collapsible item the root `<div>` also contains
+   * the (icon-only) toggle, so the label is read from the inner `<a>` when present;
+   * a leaf has no descendant `<a>`, so its own text is used.
+   */
+  async getLabel(): Promise<Optional<string>> {
+    if (await this.interactor.exists(this.anchor)) {
+      const linkText = (await this.interactor.getText(this.anchor))?.trim();
+      if (linkText) {
+        return linkText;
+      }
+    }
+    return (await this.getText())?.trim() || undefined;
+  }
+
+  /** Whether this is the current page — `aria-current="page"` on the root or its anchor. */
+  async isSelected(): Promise<boolean> {
+    return (await this.readLinkAttribute('aria-current')) === 'page';
+  }
+
+  /** The navigation target — `href` on the root (leaf) or the descendant `<a>` (collapsible). */
+  async getHref(): Promise<Optional<string>> {
+    return this.readLinkAttribute('href');
+  }
+
+  /**
+   * Whether a collapsible item is expanded (its toggle's `aria-expanded === 'true'`),
+   * or `undefined` for a leaf item that has no toggle.
+   */
+  async isExpanded(): Promise<Optional<boolean>> {
+    if (!(await this.interactor.exists(this.toggle))) {
+      return undefined;
+    }
+    return (await this.interactor.getAttribute(this.toggle, 'aria-expanded')) === 'true';
+  }
+
+  get driverName(): string {
+    return 'AstryxSideNavItemDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/SpinnerDriver.ts
+++ b/packages/component-driver-astryx/src/components/SpinnerDriver.ts
@@ -1,0 +1,61 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Spinner (`@astryxdesign/core/Spinner`).
+ *
+ * Spinner's structure is CONDITIONAL on whether it has a visible label:
+ * - Unlabeled — the root IS the `<span role="status" aria-label>` (testid on it).
+ * - Labeled — the root is a roleless `<div>` wrapping the `role="status"` span
+ *   plus a visible label `<span class="astryx-text">`.
+ *
+ * So the role's `aria-label` (the accessible name, defaulting to `"Loading"`)
+ * lives on the root in the unlabeled case but on a descendant in the labeled
+ * case. {@link getAccessibleName} reads the root first and falls back to the
+ * descendant. The size is the root's `data-size`. (The spinner draws onto a
+ * `<canvas>`; jsdom logs a non-fatal `getContext` warning that does not affect
+ * these structural reads.)
+ */
+export class SpinnerDriver extends ComponentDriver<{}> {
+  /** The `role="status"` span — the root itself when unlabeled, a descendant when labeled. */
+  private get statusRegion(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('[role="status"]'));
+  }
+
+  /** The visible label (`astryx-text`), present only when a `label` is supplied. */
+  private get visibleLabel(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-text'));
+  }
+
+  /**
+   * The accessible name (`aria-label`, default `"Loading"`). Read from the root
+   * when the root itself carries the role (unlabeled), otherwise from the
+   * descendant `role="status"` span (labeled).
+   */
+  async getAccessibleName(): Promise<Optional<string>> {
+    const rootLabel = await this.getAttribute('aria-label');
+    if (rootLabel != null) {
+      return rootLabel;
+    }
+    if (!(await this.interactor.exists(this.statusRegion))) {
+      return undefined;
+    }
+    return this.interactor.getAttribute(this.statusRegion, 'aria-label');
+  }
+
+  /** The visible label text, or `undefined` when the spinner has no visible label. */
+  async getLabelText(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.visibleLabel))) {
+      return undefined;
+    }
+    return (await this.interactor.getText(this.visibleLabel)) ?? undefined;
+  }
+
+  /** The size token from the root's `data-size`. */
+  async getSize(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-size');
+  }
+
+  override get driverName(): string {
+    return 'AstryxSpinnerDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/StatusDotDriver.ts
+++ b/packages/component-driver-astryx/src/components/StatusDotDriver.ts
@@ -1,0 +1,32 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx StatusDot (`@astryxdesign/core/StatusDot`) — a small
+ * presence/severity indicator.
+ *
+ * StatusDot renders a single leaf `<span role="img">`; the `label` prop becomes
+ * the verbatim `aria-label` (its accessible name) and the severity lives in
+ * `data-variant`. It forwards `data-testid` onto that root, so the scene anchors
+ * there and reads both relationships directly off the element. The hover tooltip
+ * is presentational and E2E-only.
+ */
+export class StatusDotDriver extends ComponentDriver<{}> {
+  /** The accessible label — the verbatim `aria-label` (from the `label` prop). */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** The severity (`data-variant`): `'success'`, `'warning'`, `'error'`, … */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-variant');
+  }
+
+  /** Whether the dot is rendered. */
+  async isPresent(): Promise<boolean> {
+    return this.exists();
+  }
+
+  get driverName(): string {
+    return 'AstryxStatusDotDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TextDriver.ts
+++ b/packages/component-driver-astryx/src/components/TextDriver.ts
@@ -1,0 +1,28 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Text (`@astryxdesign/core/Text`) — the semantic typography
+ * primitive.
+ *
+ * Text renders a single element (a `<span>` by default, or whatever `as` selects)
+ * with NO role. The semantic `type` is reflected as `data-type`, and the color is
+ * reflected as the RESOLVED `data-color` — i.e. the theme-resolved value, not the
+ * authored prop. So `type='supporting'` (whose default color is `secondary`)
+ * surfaces `data-color="secondary"` even when no `color` prop is passed.
+ * The scene anchors on the forwarded `data-testid`.
+ */
+export class TextDriver extends ComponentDriver<{}> {
+  /** The semantic text type (`data-type`): `'body'`, `'supporting'`, `'label'`, etc. */
+  async getType(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-type');
+  }
+
+  /** The RESOLVED text color (`data-color`) — theme-resolved, not the authored `color` prop. */
+  async getColor(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-color');
+  }
+
+  override get driverName(): string {
+    return 'AstryxTextDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/ThumbnailDriver.ts
+++ b/packages/component-driver-astryx/src/components/ThumbnailDriver.ts
@@ -1,0 +1,65 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Thumbnail (`@astryxdesign/core/Thumbnail`) — a small media
+ * preview with loading, placeholder, and removable states.
+ *
+ * The root is a `<div class="astryx-thumbnail">` (no role) that self-emits
+ * `data-testid`; its `aria-label` is a composite accessible name (`"{label} —
+ * {alt}"`, `"{label} — placeholder"` when there is no `src`, or `"Loading"` while
+ * loading). The inner content is conditional: an `<img>` when `src` is set, a
+ * `<div class="astryx-skeleton">` while loading, or a person `<svg>` placeholder
+ * otherwise. A removable thumbnail also renders a `Remove …` button.
+ *
+ * The hover tooltip (a sibling `popover` element) and the click-to-open lightbox
+ * preview (a portal) are presentational/interactive behaviors that only manifest
+ * in a real browser (E2E); they are not modeled here.
+ */
+export class ThumbnailDriver extends ComponentDriver<{}> {
+  /** The inner image, present only when a `src` was supplied. */
+  private get image(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('img'));
+  }
+
+  /** The loading skeleton, present only while `isLoading`. */
+  private get skeleton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('.astryx-skeleton'));
+  }
+
+  /** The remove control, present only on a removable thumbnail. */
+  private get removeButton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button[aria-label^="Remove"]'));
+  }
+
+  /** The composite accessible name — the verbatim `aria-label`. */
+  async getAccessibleName(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /** The image source, or `undefined` when there is no `src` (placeholder/loading). */
+  async getImageSrc(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.image))) {
+      return undefined;
+    }
+    return this.interactor.getAttribute(this.image, 'src');
+  }
+
+  /** Whether the thumbnail is in its loading state — it renders a skeleton instead of content. */
+  async isLoading(): Promise<boolean> {
+    return this.interactor.exists(this.skeleton);
+  }
+
+  /** Whether the thumbnail is a placeholder — neither an image nor a loading skeleton is present. */
+  async isPlaceholder(): Promise<boolean> {
+    return !(await this.interactor.exists(this.image)) && !(await this.interactor.exists(this.skeleton));
+  }
+
+  /** Whether the thumbnail exposes a remove control. */
+  async canRemove(): Promise<boolean> {
+    return this.interactor.exists(this.removeButton);
+  }
+
+  get driverName(): string {
+    return 'AstryxThumbnailDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TimestampDriver.ts
+++ b/packages/component-driver-astryx/src/components/TimestampDriver.ts
@@ -1,0 +1,28 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Timestamp (`@astryxdesign/core/Timestamp`) — the semantic
+ * `<time>` element.
+ *
+ * Timestamp renders an outer `<span class="astryx-timestamp">` (carrying the
+ * theme `data-*` including `data-format`) wrapping an inner `<time datetime>`.
+ * Crucially, the component forwards `data-testid` onto the INNER `<time>`, so this
+ * driver anchors there: {@link getText} returns the human-readable display string
+ * and {@link getDateTime} returns the machine-readable ISO 8601 `datetime`.
+ *
+ * `data-format` lives on the PARENT span, not the `<time>`, so it is intentionally
+ * NOT exposed here — anchor a separate scene part on the wrapper
+ * (`byCssSelector('[data-format]')` with an `HTMLElementDriver`) to read the format
+ * without an interactor-side `closest`. The hover tooltip and live updates are
+ * browser-only behaviors and are not modeled.
+ */
+export class TimestampDriver extends ComponentDriver<{}> {
+  /** The machine-readable ISO 8601 timestamp (`datetime` attribute on `<time>`). */
+  async getDateTime(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'datetime');
+  }
+
+  override get driverName(): string {
+    return 'AstryxTimestampDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TokenDriver.ts
+++ b/packages/component-driver-astryx/src/components/TokenDriver.ts
@@ -1,0 +1,68 @@
+import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx Token (`@astryxdesign/core/Token`) — a compact chip/tag.
+ *
+ * Token's root tag is CONDITIONAL: a `<span>` by default, an `<a href>` when an
+ * `href` is supplied; the color lives in `data-color`. Astryx forwards
+ * `data-testid` onto whichever element it renders, so the scene anchors there
+ * tag-agnostically. The visible label is the first inner `<span>` (for the basic
+ * chip the whole text node also works); a removable token additionally renders a
+ * `<button aria-label="Remove {label}">`.
+ *
+ * NOTE: a disabled token is styled by class only — it carries no `disabled`/
+ * `aria-disabled` — so its disabled state is NOT detectable in jsdom and is
+ * deliberately not exposed here (it would only be observable via a browser).
+ */
+export class TokenDriver extends ComponentDriver<{}> {
+  /** The remove control, present only on a removable token. */
+  private get removeButton(): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector('button[aria-label^="Remove"]'));
+  }
+
+  /**
+   * The token's visible label — the direct-child `<span>`'s text when present
+   * (Token nests the label as an immediate child), falling back to the root's text
+   * otherwise. The child combinator (`> span`) matters: a removable token also has
+   * an icon `<span>` nested inside its remove `<button>`, so a descendant `span`
+   * would match two elements.
+   */
+  async getLabel(): Promise<Optional<string>> {
+    const labelSpan = locatorUtil.append(this.locator, byCssSelector('> span'));
+    if (await this.interactor.exists(labelSpan)) {
+      return (await this.interactor.getText(labelSpan))?.trim();
+    }
+    return (await this.getText())?.trim();
+  }
+
+  /** The color variant (`data-color`). */
+  async getVariant(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'data-color');
+  }
+
+  /** The link target — the `href`, or `undefined` for the default (non-link) `<span>` token. */
+  async getHref(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'href');
+  }
+
+  /** Whether the token can be removed — it renders a `Remove {label}` button. */
+  async isRemovable(): Promise<boolean> {
+    return this.interactor.exists(this.removeButton);
+  }
+
+  /**
+   * Remove the token by clicking its remove button.
+   * @returns `false` when the token is not removable.
+   */
+  async remove(): Promise<boolean> {
+    if (!(await this.interactor.exists(this.removeButton))) {
+      return false;
+    }
+    await this.interactor.click(this.removeButton);
+    return true;
+  }
+
+  get driverName(): string {
+    return 'AstryxTokenDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TooltipDriver.ts
+++ b/packages/component-driver-astryx/src/components/TooltipDriver.ts
@@ -1,0 +1,47 @@
+import { ComponentDriver, Optional } from '@atomic-testing/core';
+
+import { resolveLinkedElementText } from '../internal/linkedLocators';
+
+/**
+ * Driver for the Astryx Tooltip (`@astryxdesign/core/Tooltip`).
+ *
+ * **Best-effort v1** — the same structural constraint as {@link HoverCardDriver}:
+ * the tooltip layer is a body-level `popover` with **no role at all, no testid,
+ * and no open-state attribute**; the only stable link is the trigger's injected
+ * `aria-describedby` → the layer's `id`. The scene anchors on the trigger
+ * (`data-testid`); {@link getContent} re-roots to the layer through that link
+ * (`'Root'`). (The layer additionally carries an `astryx-tooltip` class, but the
+ * `aria-describedby` link is preferred — it is instance-safe.)
+ *
+ * The layer is always mounted (jsdom has no native Popover API), so its text reads
+ * in both states; the **open/closed transition is E2E-only** and there is no
+ * portable `isOpen`. Blocking dependency: an upstream `role="tooltip"`/open-state
+ * attribute on the layer (filed upstream).
+ */
+export class TooltipDriver extends ComponentDriver<{}> {
+  /** The trigger's own text. */
+  async getTriggerText(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /**
+   * The tooltip text, resolved through the trigger's `aria-describedby` → layer
+   * `id` link. `undefined` when the trigger has no linked layer.
+   */
+  async getContent(): Promise<Optional<string>> {
+    return resolveLinkedElementText(this.interactor, this.locator, 'aria-describedby');
+  }
+
+  /**
+   * Hover the trigger to reveal the tooltip. The reveal (native popover) is only
+   * observable in a real browser; in jsdom the hover dispatches but visibility is
+   * unchanged.
+   */
+  async open(): Promise<void> {
+    return this.hover();
+  }
+
+  get driverName(): string {
+    return 'AstryxTooltipDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TopNavDriver.ts
+++ b/packages/component-driver-astryx/src/components/TopNavDriver.ts
@@ -1,0 +1,44 @@
+import { ComponentDriverCtor, Optional, PartLocator } from '@atomic-testing/core';
+
+import { PositionalListDriver } from '../internal/PositionalListDriver';
+import { TopNavItemDriver } from './TopNavItemDriver';
+
+/**
+ * Driver for the Astryx TopNav (`@astryxdesign/core/TopNav`).
+ *
+ * TopNav is the application header landmark: a `<nav role="navigation">` that
+ * forwards `data-testid` onto its root and carries the accessible name in
+ * `aria-label`. Navigation links live in the `startContent` slot and render as
+ * `<a class="astryx-top-nav-item">`; the heading link sits in a separate slot under
+ * a different class.
+ *
+ * The items are nested inside StyleX layout `<div>`s rather than being direct
+ * children of the nav, so the count/labels/lookup/select surface comes from
+ * {@link PositionalListDriver} over `childListHelper`'s `:nth-child` walk: the
+ * `'*'` group selector descends through those wrappers, and the
+ * `a.astryx-top-nav-item` item selector keeps the heading link (a different class)
+ * and any menu triggers out of the tally — neither of which a tag-based
+ * `:nth-of-type` index could do reliably.
+ *
+ * Everything this driver reads (label, items, structure) is React-state-driven and
+ * faithful in jsdom. The hover-triggered overflow menus and the mobile-bar toggle
+ * are native-popover / layout behaviours exercised only by the E2E run.
+ */
+export class TopNavDriver extends PositionalListDriver<TopNavItemDriver> {
+  protected readonly itemSelector = 'a.astryx-top-nav-item';
+  protected readonly itemDriverClass: ComponentDriverCtor<TopNavItemDriver> = TopNavItemDriver;
+  protected override readonly groupSelector = '*';
+
+  protected override resolveListContainer(): Promise<PartLocator | null> {
+    return Promise.resolve(this.locator);
+  }
+
+  /** The navigation landmark's accessible name (`aria-label`), or `undefined` when unset. */
+  async getLabel(): Promise<Optional<string>> {
+    return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  override get driverName(): string {
+    return 'AstryxTopNavDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TopNavItemDriver.ts
+++ b/packages/component-driver-astryx/src/components/TopNavItemDriver.ts
@@ -1,0 +1,37 @@
+import { HTMLAnchorDriver } from '@atomic-testing/component-driver-html';
+import { Optional } from '@atomic-testing/core';
+
+/**
+ * Driver for the Astryx TopNavItem (`@astryxdesign/core/TopNav`, `TopNavItem`).
+ *
+ * TopNavItem always renders an `<a class="astryx-top-nav-item">` and forwards
+ * `data-testid` onto it, so the scene anchors there and {@link HTMLAnchorDriver}
+ * supplies `getHref`/`getTarget`/`click`. Astryx expresses item state with ARIA
+ * rather than native attributes: the selected item carries `aria-current="page"`
+ * and a disabled item carries `aria-disabled="true"` + `tabindex="-1"` while
+ * staying an `<a>` (there is no native `disabled` on anchors). All of this is
+ * React-state-driven, so every read is faithful in jsdom.
+ */
+export class TopNavItemDriver extends HTMLAnchorDriver {
+  /** The item's visible label. */
+  async getLabel(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /** Whether this is the current page — Astryx marks it with `aria-current="page"`. */
+  async isSelected(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-current')) === 'page';
+  }
+
+  /**
+   * Whether the item is disabled. Astryx keeps the `<a>` and signals disablement
+   * with `aria-disabled="true"` (plus `tabindex="-1"`), not the native attribute.
+   */
+  async isDisabled(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-disabled')) === 'true';
+  }
+
+  override get driverName(): string {
+    return 'AstryxTopNavItemDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TopNavMegaMenuDriver.ts
+++ b/packages/component-driver-astryx/src/components/TopNavMegaMenuDriver.ts
@@ -1,0 +1,65 @@
+import { byCssSelector, ComponentDriverCtor, Optional, PartLocator } from '@atomic-testing/core';
+
+import { PositionalListDriver } from '../internal/PositionalListDriver';
+import { MenuItemDriver } from './MenuItemDriver';
+
+/**
+ * Driver for the Astryx TopNavMegaMenu (`@astryxdesign/core/TopNav`,
+ * `TopNavMegaMenu`).
+ *
+ * TopNavMegaMenu renders a trigger `<button class="astryx-top-nav-mega-menu"
+ * aria-haspopup="true" aria-expanded>` and a full-width `role="menu"` panel whose
+ * entries are `astryx-top-nav-mega-menu-item` elements — an `<a>` when the entry has
+ * an `href`, a `<div>` otherwise — laid out in a grid. The trigger does **not**
+ * forward `data-testid`, so the scene anchors on `button.astryx-top-nav-mega-menu`.
+ * (Note `aria-haspopup="true"`, not `"dialog"`.)
+ *
+ * The panel is a sibling of the trigger with **no `aria-controls` id link** back to
+ * it, so {@link resolveListContainer} re-roots to the panel's `role="menu"` at the
+ * document (`'Root'`) — best-effort for a single mega menu per scene (documented v1
+ * limit). The count/labels come from {@link PositionalListDriver} over
+ * `childListHelper`'s `:nth-child` walk (with a `'*'` group selector to descend
+ * through the grid's column wrappers), which is tag-agnostic — so the `<a>`/`<div>`
+ * entry mix and any per-column wrapping enumerate faithfully, unlike the prior
+ * `:nth-of-type` index.
+ *
+ * Entry markup is always mounted, so {@link getItemTitles} and structural reads are
+ * faithful in jsdom. The OPEN transition uses the native Popover API
+ * (`showPopover()`), a **no-op in jsdom**, so {@link isExpanded} reports `true`
+ * only under the E2E (browser) run — never assert the expanded state in the shared
+ * suite; assert the closed-state (`aria-expanded="false"`) and item titles instead.
+ */
+export class TopNavMegaMenuDriver extends PositionalListDriver<MenuItemDriver> {
+  protected readonly itemSelector = '.astryx-top-nav-mega-menu-item';
+  protected readonly itemDriverClass: ComponentDriverCtor<MenuItemDriver> = MenuItemDriver;
+  protected override readonly groupSelector = '*';
+
+  /** The mega-menu panel's `role="menu"`, re-rooted at the document (best-effort single instance). */
+  protected override resolveListContainer(): Promise<PartLocator | null> {
+    return Promise.resolve(byCssSelector('[role="menu"]', 'Root'));
+  }
+
+  /** The trigger's visible label. */
+  async getLabel(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /**
+   * Whether the mega menu is expanded — read from the trigger's `aria-expanded`.
+   *
+   * E2E-only for `true`: expansion calls `showPopover()`, a no-op in jsdom, so this
+   * stays `false` there regardless of interaction.
+   */
+  async isExpanded(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-expanded')) === 'true';
+  }
+
+  /** Every mega-menu entry's title text, in DOM order (readable while the panel is closed). */
+  async getItemTitles(): Promise<readonly string[]> {
+    return this.getItemLabels();
+  }
+
+  override get driverName(): string {
+    return 'AstryxTopNavMegaMenuDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/components/TopNavMenuDriver.ts
+++ b/packages/component-driver-astryx/src/components/TopNavMenuDriver.ts
@@ -1,0 +1,67 @@
+import { byAttribute, byCssSelector, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+
+import { AstryxMenuDriver } from './AstryxMenuDriver';
+
+/**
+ * Driver for the Astryx TopNavMenu (`@astryxdesign/core/TopNav`, `TopNavMenu`).
+ *
+ * TopNavMenu renders a trigger `<button class="astryx-top-nav-menu"
+ * aria-haspopup="dialog" aria-expanded aria-controls>` and a **sibling** panel
+ * (`<div popover="auto"><div role="dialog" id={panelId}><div role="menu">…</div></div></div>`)
+ * whose items are `role="menuitem"` entries — an `<a>` when the item has an `href`,
+ * a `<div>` otherwise, so a menu mixing link and action items has heterogeneous
+ * same-role siblings. The trigger does **not** forward `data-testid`, so the scene
+ * anchors on `button.astryx-top-nav-menu` (the semantic class is the only stable
+ * handle).
+ *
+ * The panel is **not** a descendant of the trigger, so {@link resolveMenuLocator}
+ * re-roots to its `role="menu"` through the trigger's `aria-controls` → dialog `id`
+ * link (`'Root'`), mirroring {@link DropdownMenuDriver}; the item count/labels come
+ * from {@link AstryxMenuDriver}'s `childListHelper` `:nth-child` walk, which is
+ * tag-agnostic (so the `<a>`/`<div>` item mix enumerates faithfully).
+ *
+ * The panel markup is always mounted, so item reads are faithful in jsdom. The OPEN
+ * transition is native-popover-driven (`showPopover()`), a **no-op in jsdom**, so
+ * {@link isOpen} only ever reports `true` under the E2E (browser) run — never assert
+ * the open state in the shared suite; assert the closed-state (`aria-expanded="false"`)
+ * and the item titles instead.
+ */
+export class TopNavMenuDriver extends AstryxMenuDriver {
+  /**
+   * The `role="menu"` inside the popover panel linked by the trigger's
+   * `aria-controls` → dialog `id`, or `null` when unlinked. The id is matched
+   * through the escaping `byAttribute` builder, then drilled to the menu the
+   * dialog wraps.
+   */
+  protected override async resolveMenuLocator(): Promise<PartLocator | null> {
+    const panelId = await this.interactor.getAttribute(this.locator, 'aria-controls');
+    if (!panelId) {
+      return null;
+    }
+    return locatorUtil.append(byAttribute('id', panelId, 'Root'), byCssSelector('[role="menu"]'));
+  }
+
+  /** The trigger's visible label. */
+  async getLabel(): Promise<Optional<string>> {
+    return (await this.getText()) ?? undefined;
+  }
+
+  /**
+   * Whether the menu is open — read from the trigger's `aria-expanded`.
+   *
+   * E2E-only for `true`: opening calls `showPopover()`, which is a no-op in jsdom,
+   * so this stays `false` there regardless of interaction.
+   */
+  async isOpen(): Promise<boolean> {
+    return (await this.interactor.getAttribute(this.locator, 'aria-expanded')) === 'true';
+  }
+
+  /** Every menu item's title text, in DOM order (readable while the panel is closed). */
+  async getItemTitles(): Promise<readonly string[]> {
+    return this.getItemLabels();
+  }
+
+  override get driverName(): string {
+    return 'AstryxTopNavMenuDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/index.ts
+++ b/packages/component-driver-astryx/src/index.ts
@@ -72,3 +72,59 @@ export { DateRangeInputDriver } from './components/DateRangeInputDriver';
 
 // PowerSearch (Wave 3, best-effort v1)
 export { PowerSearchDriver } from './components/PowerSearchDriver';
+
+// Display & typography (Wave 4)
+export { BadgeDriver } from './components/BadgeDriver';
+export { TextDriver } from './components/TextDriver';
+export { HeadingDriver } from './components/HeadingDriver';
+export { CodeDriver } from './components/CodeDriver';
+export { BlockquoteDriver } from './components/BlockquoteDriver';
+export { TimestampDriver } from './components/TimestampDriver';
+export { DividerDriver } from './components/DividerDriver';
+
+// Media & status (Wave 4)
+export { StatusDotDriver } from './components/StatusDotDriver';
+export { CitationDriver } from './components/CitationDriver';
+export { TokenDriver } from './components/TokenDriver';
+export { AvatarDriver } from './components/AvatarDriver';
+export { AvatarGroupDriver } from './components/AvatarGroupDriver';
+export { ThumbnailDriver } from './components/ThumbnailDriver';
+
+// Feedback & misc (Wave 4)
+export { EmptyStateDriver } from './components/EmptyStateDriver';
+export { ProgressBarDriver } from './components/ProgressBarDriver';
+export { SpinnerDriver } from './components/SpinnerDriver';
+export { NavIconDriver } from './components/NavIconDriver';
+export { ItemDriver } from './components/ItemDriver';
+export { MarkdownDriver } from './components/MarkdownDriver';
+export { CodeBlockDriver } from './components/CodeBlockDriver';
+
+// Hard set, best-effort v1 (Wave 4)
+export { FileInputDriver } from './components/FileInputDriver';
+export { ContextMenuDriver } from './components/ContextMenuDriver';
+export { AppShellDriver } from './components/AppShellDriver';
+export { ChatComposerInputDriver } from './components/ChatComposerInputDriver';
+export { ChatComposerDriver } from './components/ChatComposerDriver';
+export { HoverCardDriver } from './components/HoverCardDriver';
+export { TooltipDriver } from './components/TooltipDriver';
+
+// Nav chrome (Wave 4)
+export { TopNavDriver } from './components/TopNavDriver';
+export { TopNavItemDriver } from './components/TopNavItemDriver';
+export { TopNavMenuDriver } from './components/TopNavMenuDriver';
+export { TopNavMegaMenuDriver } from './components/TopNavMegaMenuDriver';
+export { BreadcrumbsDriver } from './components/BreadcrumbsDriver';
+export { BreadcrumbItemDriver } from './components/BreadcrumbItemDriver';
+export { SideNavDriver } from './components/SideNavDriver';
+export { SideNavItemDriver } from './components/SideNavItemDriver';
+export { MobileNavDriver } from './components/MobileNavDriver';
+
+// Chat suite (Wave 4)
+export { ChatMessageDriver } from './components/ChatMessageDriver';
+export { ChatMessageBubbleDriver } from './components/ChatMessageBubbleDriver';
+export { ChatMessageListDriver } from './components/ChatMessageListDriver';
+export { ChatSystemMessageDriver } from './components/ChatSystemMessageDriver';
+export { ChatToolCallsDriver } from './components/ChatToolCallsDriver';
+export { ChatLayoutDriver } from './components/ChatLayoutDriver';
+export { ChatSendButtonDriver } from './components/ChatSendButtonDriver';
+export { ChatDictationButtonDriver } from './components/ChatDictationButtonDriver';

--- a/packages/component-driver-astryx/src/internal/linkedLocators.ts
+++ b/packages/component-driver-astryx/src/internal/linkedLocators.ts
@@ -1,11 +1,12 @@
-import { byLinkedElement, Interactor, Optional, PartLocator } from '@atomic-testing/core';
+import { byAttribute, byLinkedElement, Interactor, Optional, PartLocator } from '@atomic-testing/core';
 
 /**
- * Internal locator builders shared by Astryx field controls.
+ * Internal locator builders shared by Astryx controls.
  *
- * Astryx wires a control to its visible label and its status/description message
- * by native accessibility links rather than DOM nesting, so drivers anchored on
- * the control reach those elements by resolving the link — never by a
+ * Astryx wires a control to its visible label, its status/description message,
+ * and its floating layers by native accessibility links (`<label for>`,
+ * `aria-describedby`, `aria-controls`) rather than DOM nesting, so drivers
+ * anchored on the control reach those elements by resolving the link — never by a
  * StyleX-hashed class or a positional selector.
  */
 
@@ -33,4 +34,31 @@ export async function resolveLinkedLabelText(
     return undefined;
   }
   return (await interactor.getText(labelLocator)) ?? undefined;
+}
+
+/**
+ * Resolve the text of the element a control points at through a single-IDREF
+ * attribute (`aria-describedby` → a body-level layer, `aria-controls` → a panel).
+ * The id is matched through the escaping `byAttribute` builder rather than raw
+ * `[id="…"]` interpolation, and the lookup re-roots at the document (`'Root'`)
+ * because these layers render outside the control's subtree.
+ *
+ * Shared by the overlay drivers whose floating layer has no role/testid of its
+ * own (HoverCard, Tooltip). Returns `undefined` when the attribute is absent or
+ * the target is missing.
+ */
+export async function resolveLinkedElementText(
+  interactor: Interactor,
+  controlLocator: PartLocator,
+  idRefAttribute: string
+): Promise<Optional<string>> {
+  const id = await interactor.getAttribute(controlLocator, idRefAttribute);
+  if (!id) {
+    return undefined;
+  }
+  const target = byAttribute('id', id, 'Root');
+  if (!(await interactor.exists(target))) {
+    return undefined;
+  }
+  return (await interactor.getText(target)) ?? undefined;
 }


### PR DESCRIPTION

Astryx styles with StyleX, whose class names are build-time hashed and unusable as test anchors, so
its components are only reachable through stable role / accessible-name / `data-testid` hooks. This
change extends atomic-testing's driver pattern across the rest of Astryx's surface — nav chrome,
display and typography, the chat suite, and the structurally-hard components (portalled overlays,
contenteditable inputs, file input, and the layout shell) — with each locator grounded against the
real rendered DOM and the shared suite running unchanged in both jsdom and Playwright.

## Key Changes

- Add 43 component drivers + shared examples/suites; DOM suite (320 tests) and E2E green on all 3 browsers.
- Hard set (overlays, contenteditable, file input, shell) ships a documented best-effort v1.
- Add a driver coverage-matrix doc page; file upstream facebook/astryx#3240 for the Tooltip/HoverCard layer.

Closes #914. Part of #909.
