### PR TITLE
build: split core-group versioning from the drivers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,9 @@ jobs:
           echo "Determined version: $VERSION"
 
       - name: Set package versions
+        # Bumps the frozen CORE GROUP to the release tag's version (ADR-009). The
+        # independently-versioned component-driver-* drivers are released
+        # separately (`pnpm bumpVersion <ver> <folder>`), not by this core release.
         run: pnpm bumpVersion $VERSION
 
       - name: Upgrade npm for OIDC trusted publishing

--- a/agent-docs/INDEX.md
+++ b/agent-docs/INDEX.md
@@ -26,14 +26,15 @@ LLM-optimized docs for the `packages/` workspace of `atomic-testing` — a porta
 
 ## ADRs
 
-| ADR                                              | Decision                                                  |
-| ------------------------------------------------ | --------------------------------------------------------- |
-| [001](adr/001-component-driver-pattern.md)       | Component-driver pattern with declarative scene parts.    |
-| [002](adr/002-interactor-abstraction.md)         | `Interactor` abstraction for environment portability.     |
-| [003](adr/003-version-specific-packages.md)      | Version-specific packages for React and MUI majors.       |
-| [004](adr/004-shared-three-file-test-pattern.md) | Shared three-file test pattern via `TestFrameworkMapper`. |
-| [005](adr/005-drop-mui-5-support.md)             | End of support for MUI 5 and MUI-X 5.                     |
-| [006](adr/006-1.0-api-freeze-and-evolution.md)   | 1.0 public-API freeze, SemVer & deprecation policy.       |
+| ADR                                              | Decision                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------ |
+| [001](adr/001-component-driver-pattern.md)       | Component-driver pattern with declarative scene parts.       |
+| [002](adr/002-interactor-abstraction.md)         | `Interactor` abstraction for environment portability.        |
+| [003](adr/003-version-specific-packages.md)      | Version-specific packages for React and MUI majors.          |
+| [004](adr/004-shared-three-file-test-pattern.md) | Shared three-file test pattern via `TestFrameworkMapper`.    |
+| [005](adr/005-drop-mui-5-support.md)             | End of support for MUI 5 and MUI-X 5.                        |
+| [006](adr/006-1.0-api-freeze-and-evolution.md)   | 1.0 public-API freeze, SemVer & deprecation policy.          |
+| [009](adr/009-split-core-driver-versioning.md)   | Split versioning: frozen core group vs. independent drivers. |
 
 ## Fresh repo tree
 

--- a/agent-docs/adr/009-split-core-driver-versioning.md
+++ b/agent-docs/adr/009-split-core-driver-versioning.md
@@ -1,0 +1,70 @@
+# ADR-009: Split versioning — frozen core group vs. independent drivers
+
+## Status
+
+Accepted (2026-06-29). Part of the 1.0 freeze. Decision **D3** of the core gap audit (issue #964).
+
+## Context
+
+Every package was published lockstep at `0.88.0`: `bumpVersion <ver>` rewrote
+**all** package versions to the same value, and `publish.sh` (via `pnpm publish`)
+rewrites `workspace:*` deps to exact pins at publish time. Lockstep ties the
+**stable core's** SemVer guarantee to the **fast-moving drivers** — a one-line
+`component-driver-mui-x` patch would bump the core's version, and a core release
+would renumber every driver. Once the core is frozen at 1.0, its version number
+must mean something specific about the frozen surface, which lockstep prevents.
+
+## Decision
+
+**Split the version lines** (option (a)):
+
+- The **frozen core group** — the nine packages of
+  [ADR-006](006-1.0-api-freeze-and-evolution.md) (`core`, `dom-core`,
+  `react-core`, `react-18`, `react-19`, `react-legacy`, `vue-3`, `playwright`,
+  `component-driver-html`) — versions **in lockstep** at 1.0+ under SemVer against
+  the frozen surface.
+- The published **drivers** (`component-driver-mui-*`, `component-driver-mui-x-*`,
+  `component-driver-astryx`) version **independently**, each on its own cadence,
+  governed by the per-major support policy ([ADR-003](003-version-specific-packages.md),
+  [ADR-005](005-drop-mui-5-support.md)) rather than the core 1.0 contract.
+
+### How the tooling reflects it
+
+- `bumpVersion <ver>` bumps **only the core group** (drivers are skipped).
+- `bumpVersion <ver> <folder>` bumps **one** package, for releasing a single
+  driver on its own cadence (a mistyped folder fails loudly).
+- `publish.sh` needs no version logic: it publishes each package at the version in
+  its own `package.json` and skips versions already on npm — so a core release
+  leaves unchanged drivers alone (already-published → skipped), and a driver
+  release does not disturb the core. `publishOrder.js` is version-agnostic
+  (topological only) and is unchanged.
+- The release workflow's tag-driven `bumpVersion $VERSION` now releases the core
+  group; per-driver releases are a separate invocation.
+
+### Dependency pins (follow-up note)
+
+Drivers depend on core via `workspace:*`, pinned **exact** at publish, so a driver
+published today pins the exact core version it was built against. If a driver
+should accept future core **minors** without republishing, switch its core
+dependency to `workspace:^` (caret). That is a refinement, not required by the
+split, and is left as follow-up.
+
+## Consequences
+
+- ✅ The 1.0 core version means what it says — SemVer against the frozen surface,
+  decoupled from driver churn. Drivers iterate without renumbering the core.
+- ⚠️ The release process is now two-track: core releases via `v<X>` tags; driver
+  releases are independent. CI automation for per-driver release tags is follow-up
+  work; the scripts already support the manual path today.
+
+## Alternatives considered
+
+| Alternative                  | Why not chosen                                                                                                                |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Keep lockstep versioning (b) | Any driver change bumps the whole graph including the frozen core, so the core's SemVer number would no longer mean anything. |
+
+## Related
+
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) — defines the frozen core group this versions together.
+- [ADR-003](003-version-specific-packages.md), [ADR-005](005-drop-mui-5-support.md) — the per-major driver support policy that governs the independent lines.
+- Issue #964.

--- a/publish.sh
+++ b/publish.sh
@@ -10,6 +10,14 @@ set -euo pipefail
 #     ./bootstrap-new-package.sh <package-folder-name>
 # After that it publishes here automatically. To (re)apply every trusted-publisher
 # config at once: ./setup-trusted-publishers.sh
+#
+# Versioning (ADR-009): the frozen CORE GROUP (core, dom-core, the react/vue
+# adapters, playwright, component-driver-html) versions in lockstep — `pnpm
+# bumpVersion <ver>` bumps exactly that group. The published component-driver-*
+# drivers version INDEPENDENTLY (`pnpm bumpVersion <ver> <folder>`). This script
+# needs no version logic: it publishes each package at the version in its own
+# package.json and skips versions already on npm, so a core release leaves the
+# unchanged drivers untouched (already-published → skipped) and vice versa.
 
 BUILD_ONLY=false
 

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -3,6 +3,17 @@ const path = require('path');
 
 const skipPostBuildPackages = [];
 
+/**
+ * Packages that version INDEPENDENTLY of the frozen core group (see ADR-009): the
+ * published `component-driver-*` drivers track fast-moving third-party DOM on
+ * their own cadence, so a core-group version bump must NOT touch them.
+ * `component-driver-html` is part of the frozen core group (ADR-006), hence the
+ * explicit carve-out.
+ */
+function isIndependentlyVersioned(folderName) {
+  return folderName.startsWith('component-driver-') && folderName !== 'component-driver-html';
+}
+
 function isFolder(p) {
   return fs.statSync(p).isDirectory();
 }
@@ -17,7 +28,17 @@ function adjustFolderPackageJson(dir, version) {
   fs.writeFileSync(fileName, newContent);
 }
 
-function bumpVersion(dir, version) {
+/**
+ * Bump package versions under packages/.
+ *
+ * - `bumpVersion(dir, version)` bumps the CORE GROUP — every package except the
+ *   independently-versioned `component-driver-*` drivers — to `version`. This is
+ *   the lockstep frozen-core release (ADR-006 / ADR-009).
+ * - `bumpVersion(dir, version, targetFolder)` bumps ONLY `targetFolder`, so a
+ *   single driver can be released on its own cadence, e.g.
+ *   `pnpm bumpVersion 9.3.0 component-driver-mui-x-v9`.
+ */
+function bumpVersion(dir, version, targetFolder) {
   const sanitizedVersion = version.trim();
   if (sanitizedVersion.length < 1) {
     return;
@@ -28,16 +49,34 @@ function bumpVersion(dir, version) {
     const full = path.join(dir, p);
     return fs.existsSync(full) ? fs.readdirSync(full).map(c => path.join(p, c)) : [];
   });
+
+  let bumped = 0;
   for (const child of children) {
     const pkgName = path.basename(child);
     if (skipPostBuildPackages.includes(pkgName)) {
       continue;
     }
+    if (targetFolder) {
+      if (pkgName !== targetFolder) {
+        continue;
+      }
+    } else if (isIndependentlyVersioned(pkgName)) {
+      // Core-group bump leaves the independently-versioned drivers untouched.
+      continue;
+    }
     const childPath = path.join(dir, child);
     if (isFolder(childPath)) {
       adjustFolderPackageJson(childPath, sanitizedVersion);
+      bumped++;
     }
+  }
+
+  // A targeted bump that matched nothing is almost certainly a mistyped folder —
+  // fail loudly rather than silently produce an empty release.
+  if (targetFolder && bumped === 0) {
+    console.error(`bumpVersion: no package folder named "${targetFolder}" under packages/`);
+    process.exit(1);
   }
 }
 
-bumpVersion(process.cwd(), process.argv[2]);
+bumpVersion(process.cwd(), process.argv[2], process.argv[3]);


### PR DESCRIPTION

Everything published lockstep, so a fast-moving driver patch would renumber the
frozen core and a core release would renumber every driver — making the 1.0 core's
SemVer number meaningless. The frozen core group now versions together while the
`component-driver-*` drivers version independently, each on its own cadence.

## Key Changes

- `bumpVersion <ver>` bumps only the core group; `bumpVersion <ver> <folder>` bumps
  a single driver independently (a mistyped folder fails loudly).
- Document the scheme in publish.sh and the release workflow — publish.sh stays
  version-agnostic (publishes each package's own version, skips ones already on npm),
  so the split needs no publish-logic change.
- Add ADR-009 and index it in agent-docs/INDEX.md.

Resolves #964.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
