### PR TITLE
feat(core): compose same-element matchers with CssLocator.and()

### DIFF
--- a/agent-docs/INDEX.md
+++ b/agent-docs/INDEX.md
@@ -26,14 +26,19 @@ LLM-optimized docs for the `packages/` workspace of `atomic-testing` — a porta
 
 ## ADRs
 
-| ADR                                              | Decision                                                  |
-| ------------------------------------------------ | --------------------------------------------------------- |
-| [001](adr/001-component-driver-pattern.md)       | Component-driver pattern with declarative scene parts.    |
-| [002](adr/002-interactor-abstraction.md)         | `Interactor` abstraction for environment portability.     |
-| [003](adr/003-version-specific-packages.md)      | Version-specific packages for React and MUI majors.       |
-| [004](adr/004-shared-three-file-test-pattern.md) | Shared three-file test pattern via `TestFrameworkMapper`. |
-| [005](adr/005-drop-mui-5-support.md)             | End of support for MUI 5 and MUI-X 5.                     |
-| [006](adr/006-1.0-api-freeze-and-evolution.md)   | 1.0 public-API freeze, SemVer & deprecation policy.       |
+| ADR                                                      | Decision                                                                   |
+| -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [001](adr/001-component-driver-pattern.md)               | Component-driver pattern with declarative scene parts.                     |
+| [002](adr/002-interactor-abstraction.md)                 | `Interactor` abstraction for environment portability.                      |
+| [003](adr/003-version-specific-packages.md)              | Version-specific packages for React and MUI majors.                        |
+| [004](adr/004-shared-three-file-test-pattern.md)         | Shared three-file test pattern via `TestFrameworkMapper`.                  |
+| [005](adr/005-drop-mui-5-support.md)                     | End of support for MUI 5 and MUI-X 5.                                      |
+| [006](adr/006-1.0-api-freeze-and-evolution.md)           | 1.0 public-API freeze, SemVer & deprecation policy.                        |
+| [007](adr/007-interactor-evolution-and-composition.md)   | Interactor evolution strategy & same-element `CssLocator.and` composition. |
+| [008](adr/008-css-dom-only-locator-boundary.md)          | The 1.0 locator boundary is CSS- and DOM-only.                             |
+| [010](adr/010-narrow-error-payload.md)                   | Narrow the error payload to a serializable shape.                          |
+| [011](adr/011-retract-locator-source-ast.md)             | Retract the locator descriptive `source` AST.                              |
+| [012](adr/012-remove-dead-clone-wait-from-interactor.md) | Remove dead `clone()` / `wait()` from the `Interactor` contract.           |
 
 ## Fresh repo tree
 

--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -124,6 +124,12 @@ detection rather than a bare required-method addition. The concrete mechanism is
 deferred to **D1** (the Interactor-evolution issue); this ADR fixes the
 constraint, not the implementation.
 
+> **Resolved in [ADR-007](007-interactor-evolution-and-composition.md):** the
+> blessed path is to **extend `DOMInteractor`** (additive-on-base growth is then
+> inherited non-breakingly), falling back to optional members / capability
+> detection; role + verbatim name is met at the locator layer by
+> `CssLocator.and()`, and the computed-name `findByRole` stays deferred to #923.
+
 ## Consequences
 
 - ✅ The public surface is explicit, reviewed, and CI-enforced; incidental

--- a/agent-docs/adr/007-interactor-evolution-and-composition.md
+++ b/agent-docs/adr/007-interactor-evolution-and-composition.md
@@ -1,0 +1,119 @@
+# ADR-007: Interactor evolution strategy & same-element locator composition
+
+## Status
+
+Accepted (2026-06-29). Resolves the §6 deferral in [ADR-006](006-1.0-api-freeze-and-evolution.md); part of the 1.0 freeze. Decision **D1** of the core gap audit (issue #962).
+
+## Context
+
+[ADR-006](006-1.0-api-freeze-and-evolution.md) §6 fixed a _constraint_ — post-1.0
+`Interactor` growth must be **additive without breaking implementers** — but
+deferred the _mechanism_ to this decision. Two concrete questions were open:
+
+1. **How does the flat `Interactor` interface evolve safely?** It is an
+   all-required interface of ~40 members. Adding any required member after 1.0 is
+   a compile-breaking change for anyone who `implements Interactor` by hand. The
+   interface is also the typing/consumption contract for every driver, so it
+   cannot simply be made fully optional.
+2. **Should a bespoke `findByRole` primitive land before the freeze?** The Astryx
+   work (#909) needs role + accessible-name selection. [ADR-001](../../docs/adr/0001-interactor-primitives-and-name-aware-role.md)
+   designed an accessible-name-correct `findByRole` but deliberately deferred its
+   implementation to a follow-up wave (#923) because the _computed_ accessible
+   name is not CSS-expressible. Adding a required `Interactor` method post-freeze
+   is exactly the break question (1) is about, so the timing matters.
+
+The shipped interactors do **not** all extend the same base, which shapes the
+answer:
+
+| Interactor              | Relationship      | Why                                                               |
+| ----------------------- | ----------------- | ----------------------------------------------------------------- |
+| `DOMInteractor`         | `implements`      | The jsdom base every other DOM-family adapter extends.            |
+| `ReactInteractor`       | `extends DOM`     | Wraps mutations in `act()`.                                       |
+| `VueInteractor`         | `extends DOM`     | Awaits `nextTick()`.                                              |
+| `LegacyReactInteractor` | `extends DOM`     | React 16/17 `act` via `react-dom/test-utils`.                     |
+| `PlaywrightInteractor`  | `implements` bare | Browser backing shares **no** implementation with the jsdom base. |
+
+## Decision
+
+### 1. The blessed extension path is "extend `DOMInteractor`"
+
+Adapter authors — especially third parties — should **extend `DOMInteractor`**,
+not `implement Interactor` bare. Extenders inherit a working default for every
+current member, and crucially for every member added in a future **minor**: a new
+method landed on the base is inherited automatically, so the addition is
+non-breaking for everyone on the blessed path.
+
+`PlaywrightInteractor` implements `Interactor` bare on purpose — its browser
+backing reuses none of the jsdom implementation, so there is nothing to inherit.
+It is first-party and shipped in lockstep, so it is updated in the same change
+that adds a member and never relies on the inheritance guarantee. Hand-written
+bare implementations are still _supported_, but they accept the additive-break
+risk; the docs steer external authors to the extension path instead.
+
+Post-1.0 `Interactor` growth therefore follows this priority order:
+
+1. **Add to `DOMInteractor` with a working default.** Extenders inherit it;
+   first-party bare implementers (`PlaywrightInteractor`) are updated in the same
+   release. Non-breaking for the blessed path and for external extenders.
+2. **If no sensible default exists, add an _optional_ interface member**
+   (`method?(...): ...`) and document the capability-detection convention
+   (`if (interactor.method) { … }`). Optional members never break even bare
+   implementers.
+3. **Capability detection / feature flags** as the fallback for cross-cutting
+   additions.
+
+The bare `Interactor` interface remains the typing and consumption contract; this
+decision governs how it _grows_, not whether it exists.
+
+### 2. No bespoke `findByRole` before 1.0 — compose at the locator layer instead
+
+The common need behind `findByRole` is "a `role` plus a verbatim accessible name
+on the same element". That is pure CSS, so it is met at the **locator** layer, not
+by a new `Interactor` method:
+
+`CssLocator.and(...)` compounds same-element matchers into one selector —
+`byRole('button').and(byAriaLabel('Open'))` → `[role="button"][aria-label="Open"]`.
+It supersedes the previous `locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same'))`
+form (no `'Same'` argument to remember, no wrapper) and stays entirely within the
+CSS/DOM-only boundary declared in [D2 (#963)](008-css-dom-only-locator-boundary.md).
+
+The _computed_ accessible name (`aria-labelledby` / associated `<label>` / text
+content) is genuinely not CSS-expressible and remains deferred to **#923**. Under
+Decision 1 it is now safe to add after 1.0 — as a default-bearing method on
+`DOMInteractor`, or an optional member — without a breaking change.
+
+### 3. Conformance seam
+
+The seam an external adapter must satisfy is "extends `DOMInteractor` (or
+implements the optional-member convention)". The conformance suite that exercises
+it is tracked separately (#972); this ADR documents the seam it targets.
+
+## Consequences
+
+- ✅ A documented, non-breaking growth path for the `Interactor` contract, with a
+  clear order of preference and an explicit note on the one bare first-party
+  implementer.
+- ✅ Role + verbatim-name selection ships now, ergonomically, with **one** new
+  method on `CssLocator` and zero new `Interactor` surface — the CSS/DOM-only
+  boundary stays intact.
+- ✅ The hard, cross-engine computed-name `findByRole` stays deferred (#923) yet
+  becomes safe to add later.
+- ⚠️ External authors who `implement Interactor` bare instead of extending
+  `DOMInteractor` still take an additive-break risk on a future minor; the
+  mitigation is documentation, not a type-level guarantee.
+
+## Alternatives considered
+
+| Alternative                                        | Why not chosen                                                                                                                                                             |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Land a bespoke accessible-name `findByRole` now    | Pulls #923's hard cross-engine accname work forward and breaches the CSS/DOM-only boundary D2 declares; the common verbatim case is fully met by `CssLocator.and()`.       |
+| Make every `Interactor` member optional at 1.0     | Weakens the type contract for _all_ consumers to hedge the rare external bare-implementer; the extension path covers the common adapter author, optional members the rest. |
+| `bySameElement(...)` free function for composition | Considered; `.and()` reads better at call sites and adds no new barrel export — only one method on an already-frozen class.                                                |
+| `byRole(value, { name })` option object            | Bakes `aria-label` into `byRole`, does not generalize to other attributes, and the `name` term invites confusion with the deferred _computed_-name resolution.             |
+
+## Related
+
+- [ADR-002](002-interactor-abstraction.md) — the `Interactor` abstraction and the per-adapter inheritance note this builds on.
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) §6 — the constraint this decision's mechanism resolves.
+- [ADR-001](../../docs/adr/0001-interactor-primitives-and-name-aware-role.md) — the deferred accessible-name `findByRole` design (Decision B) this keeps deferred (#923).
+- Issues #962 (this decision), #923 (computed-name `findByRole`), #972 (conformance suite), #909 (Astryx umbrella).

--- a/agent-docs/modules/core.md
+++ b/agent-docs/modules/core.md
@@ -78,7 +78,7 @@ Builders in [locators/](../../packages/core/src/locators/index.ts), each returni
 | `byCssSelector(sel, relative?)` | raw CSS (escape hatch)                | [byCssSelector.ts](../../packages/core/src/locators/byCssSelector.ts)         |
 | `byLinkedElement()`             | fluent → `LinkedCssLocator`           | [byLinkedElement.ts](../../packages/core/src/locators/byLinkedElement.ts#L19) |
 
-Composition lives in `locatorUtil` ([utils/locatorUtil.ts](../../packages/core/src/utils/locatorUtil.ts)): `append(...locators)` chains while respecting `Root` boundaries; `toCssSelector(locator, interactor)` resolves to a runtime selector (awaiting linked-locator resolution); `overrideLocatorRelativePosition(...)` rewrites a locator's relative position. Disambiguate two same-role elements by accessible name with `append(byRole(role), byAriaLabel(name, 'Same'))`; computed accessible names (not CSS-expressible) await the deferred name-aware `findByRole` (see #923).
+Composition lives in `locatorUtil` ([utils/locatorUtil.ts](../../packages/core/src/utils/locatorUtil.ts)): `append(...locators)` chains while respecting `Root` boundaries; `toCssSelector(locator, interactor)` resolves to a runtime selector (awaiting linked-locator resolution); `overrideLocatorRelativePosition(...)` rewrites a locator's relative position. Disambiguate two same-role elements by accessible name with the same-element compound `byRole(role).and(byAriaLabel(name))` ([CssLocator.and](../../packages/core/src/locators/CssLocator.ts) — supersedes the older `append(byRole(role), byAriaLabel(name, 'Same'))`); computed accessible names (not CSS-expressible) await the deferred name-aware `findByRole` (see #923).
 
 ## Utilities
 

--- a/package-tests/component-driver-html-test/src/examples/byRole/ByRole.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/byRole/ByRole.suite.ts
@@ -8,21 +8,28 @@ import { byRoleUIExample } from './ByRole.examples';
 export const byRoleExampleScenePart = {
   // Same role, distinguished only by verbatim aria-label — the disambiguation
   // rule under test: byRole composed with byAriaLabel on the SAME element →
-  // [role="..."][aria-label="..."]. `'Same'` makes byAriaLabel compound onto the
-  // preceding byRole rather than descend.
+  // [role="..."][aria-label="..."]. The fluent `.and()` compounds the matchers
+  // onto one element with no `'Same'` argument to remember.
   openButton: {
-    locator: locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same')),
+    locator: byRole('button').and(byAriaLabel('Open')),
     driver: HTMLElementDriver,
   },
   closeButton: {
-    locator: locatorUtil.append(byRole('button'), byAriaLabel('Close', 'Same')),
+    locator: byRole('button').and(byAriaLabel('Close')),
+    driver: HTMLElementDriver,
+  },
+  // The lower-level form `.and()` supersedes — `locatorUtil.append` with a
+  // `'Same'` child — must resolve the SAME element. Retained as a regression
+  // guard that both front doors compound identically.
+  openButtonViaAppend: {
+    locator: locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same')),
     driver: HTMLElementDriver,
   },
   // Multi-word verbatim aria-label (the common Astryx case). Guards that spaces
   // in the name escape and match, and that the match is the EXACT full label —
   // 'Close dialog' must not be reached by the 'Close' locator above.
   closeDialogButton: {
-    locator: locatorUtil.append(byRole('button'), byAriaLabel('Close dialog', 'Same')),
+    locator: byRole('button').and(byAriaLabel('Close dialog')),
     driver: HTMLElementDriver,
   },
   // Plain positional `relative` form — guards that byRole's original string
@@ -45,12 +52,12 @@ export const byRoleExampleTestSuite: TestSuiteInfo<typeof byRoleExample.scene> =
     describe(`${byRoleExample.title}`, () => {
       const engine = useTestEngine(byRoleExample.scene, getTestEngine, { beforeEach, afterEach });
 
-      test(`byRole + byAriaLabel('Open') resolves to the Open button`, async () => {
+      test(`byRole().and(byAriaLabel('Open')) resolves to the Open button`, async () => {
         assertTrue(await engine().parts.openButton.exists());
         assertEqual(await engine().parts.openButton.getText(), 'first');
       });
 
-      test(`byRole + byAriaLabel('Close') resolves to the Close button`, async () => {
+      test(`byRole().and(byAriaLabel('Close')) resolves to the Close button`, async () => {
         assertTrue(await engine().parts.closeButton.exists());
         assertEqual(await engine().parts.closeButton.getText(), 'second');
       });
@@ -59,6 +66,13 @@ export const byRoleExampleTestSuite: TestSuiteInfo<typeof byRoleExample.scene> =
       test(`aria-label disambiguates two same-role elements`, async () => {
         assertEqual(await engine().parts.openButton.getText(), 'first');
         assertEqual(await engine().parts.closeButton.getText(), 'second');
+      });
+
+      // `.and()` and the `locatorUtil.append(..., 'Same')` form it supersedes
+      // compound to the same compound selector → the same element.
+      test(`.and() resolves the same element as locatorUtil.append(..., 'Same')`, async () => {
+        assertEqual(await engine().parts.openButtonViaAppend.getText(), 'first');
+        assertEqual(await engine().parts.openButton.getText(), await engine().parts.openButtonViaAppend.getText());
       });
 
       // Multi-word name resolves (spaces escape correctly inside [aria-label="..."]).

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -146,6 +146,7 @@ export abstract class ContainerDriver<ContentT extends ScenePart, T extends Scen
 export class CssLocator {
     // Warning: (ae-forgotten-export) The symbol "CssLocatorInitializer" needs to be exported by the entry point index.d.mts
     constructor(selector: string, initializeValue?: Partial<CssLocatorInitializer>);
+    and(...locators: CssLocator[]): CssLocator;
     // (undocumented)
     chain(...locatorsToAppend: PartLocator[]): PartLocator;
     // (undocumented)

--- a/packages/core/src/locators/CssLocator.ts
+++ b/packages/core/src/locators/CssLocator.ts
@@ -53,6 +53,50 @@ export class CssLocator {
     return 'primitive';
   }
 
+  /**
+   * Compose additional matchers onto the SAME element, producing one compound
+   * CSS selector — e.g. `[role="button"]` and `[aria-label="Open"]` together
+   * become `[role="button"][aria-label="Open"]`.
+   *
+   * This is the ergonomic, footgun-free form of same-element composition: it
+   * supersedes `locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same'))`
+   * — there is no `'Same'` argument to remember (the relationship no longer has
+   * to be stored on the appended child) and no wrapper call. The result keeps
+   * THIS locator's position relative to its parent; the appended matchers
+   * contribute only their attribute/selector fragment.
+   *
+   * Same-element, pure-CSS only:
+   * - Put a tag-name matcher ({@link byTagName}) FIRST — a CSS type selector is
+   *   only valid at the start of a compound (`input[type="text"]`, never
+   *   `[type="text"]input`).
+   * - Computed accessible names (`aria-labelledby` / `<label>` / text) are not
+   *   CSS-expressible and stay out of scope (see #923); compose a verbatim
+   *   `aria-label` via {@link byAriaLabel} instead.
+   * - Linked locators ({@link byLinkedElement}) resolve at runtime and cannot be
+   *   folded into a static compound; calling `.and()` on one, or passing one,
+   *   throws.
+   *
+   * @param locators - Additional same-element matchers to compound onto this one.
+   * @example
+   * ```ts
+   * const openButton = byRole('button').and(byAriaLabel('Open'));
+   * const activeTab = byRole('tab').and(byAttribute('aria-selected', 'true'));
+   * ```
+   */
+  and(...locators: CssLocator[]): CssLocator {
+    const parts = [this, ...locators];
+    for (const part of parts) {
+      if (part.complexity !== 'primitive') {
+        throw new Error(
+          'CssLocator.and() composes same-element primitive matchers only; ' +
+            'linked locators resolve at runtime and cannot be folded into a static compound.'
+        );
+      }
+    }
+    const selector = parts.map(part => part.selector).join('');
+    return new CssLocator(selector, { relative: this._relativePosition });
+  }
+
   clone(override?: Partial<CssLocatorInitializer>): CssLocator {
     return new CssLocator(this.selector, {
       relative: override?.relative ?? this._relativePosition,

--- a/packages/core/src/locators/__tests__/CssLocator.test.ts
+++ b/packages/core/src/locators/__tests__/CssLocator.test.ts
@@ -1,0 +1,53 @@
+import { byAriaLabel } from '../byAriaLabel';
+import { byAttribute } from '../byAttribute';
+import { byDataTestId } from '../byDataTestId';
+import { byLinkedElement } from '../byLinkedElement';
+import { byRole } from '../byRole';
+import { byTagName } from '../byTagName';
+
+describe('CssLocator.and (same-element composition)', () => {
+  it('compounds a second matcher onto the same element', () => {
+    const locator = byRole('button').and(byAriaLabel('Open'));
+    expect(locator.selector).toBe('[role="button"][aria-label="Open"]');
+  });
+
+  it('keeps THIS locator position relative to its parent', () => {
+    const descendant = byRole('button').and(byAriaLabel('Open'));
+    expect(descendant.relative).toBe('Descendant');
+
+    const root = byRole('dialog', 'Root').and(byAriaLabel('Settings'));
+    expect(root.relative).toBe('Root');
+  });
+
+  it('compounds N matchers in a single fluent chain', () => {
+    const locator = byRole('tab').and(byAttribute('aria-selected', 'true')).and(byAttribute('data-state', 'ready'));
+    expect(locator.selector).toBe('[role="tab"][aria-selected="true"][data-state="ready"]');
+  });
+
+  it('places a leading tag-name matcher at the start of the compound', () => {
+    const locator = byTagName('input').and(byAttribute('type', 'text'));
+    expect(locator.selector).toBe('input[type="text"]');
+  });
+
+  it('produces the same selector as the locatorUtil.append(..., "Same") form it supersedes', () => {
+    const composed = byRole('button').and(byAriaLabel('Open'));
+    const appendedChild = byAriaLabel('Open', 'Same');
+    expect(composed.selector).toBe(byRole('button').selector + appendedChild.selector);
+  });
+
+  it('throws when the receiver is a linked locator', () => {
+    const linked = byLinkedElement()
+      .onLinkedElement(byDataTestId('input'))
+      .extractAttribute('for')
+      .toMatchMyAttribute('id');
+    expect(() => linked.and(byRole('button'))).toThrow(/linked/i);
+  });
+
+  it('throws when a linked locator is passed as an argument', () => {
+    const linked = byLinkedElement()
+      .onLinkedElement(byDataTestId('input'))
+      .extractAttribute('for')
+      .toMatchMyAttribute('id');
+    expect(() => byRole('button').and(linked)).toThrow(/linked/i);
+  });
+});

--- a/packages/core/src/locators/byAriaLabel.ts
+++ b/packages/core/src/locators/byAriaLabel.ts
@@ -18,12 +18,12 @@ export type ByAriaLabelSource = {
  *
  * Most commonly composed with {@link byRole} on the SAME element to tell two
  * same-role siblings apart without relying on unstable (e.g. StyleX-hashed) class
- * names — pass `'Same'` so the selector compounds rather than descends:
+ * names. Use {@link CssLocator.and} to compound the matchers onto one element:
  *
  * ```ts
- * import { byAriaLabel, byRole, locatorUtil } from '@atomic-testing/core';
- * const openButton = locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same'));
- * const closeButton = locatorUtil.append(byRole('button'), byAriaLabel('Close', 'Same'));
+ * import { byAriaLabel, byRole } from '@atomic-testing/core';
+ * const openButton = byRole('button').and(byAriaLabel('Open'));
+ * const closeButton = byRole('button').and(byAriaLabel('Close'));
  * ```
  *
  * @param value - Verbatim `aria-label` to match.

--- a/packages/core/src/locators/byRole.ts
+++ b/packages/core/src/locators/byRole.ts
@@ -12,11 +12,12 @@ export type ByRoleSource = {
  * Locate elements by their ARIA `role` attribute.
  *
  * To additionally disambiguate two same-role elements by their accessible name,
- * compose with {@link byAriaLabel} (verbatim `aria-label`) on the SAME element:
+ * compose with {@link byAriaLabel} (verbatim `aria-label`) on the SAME element
+ * via {@link CssLocator.and}:
  *
  * ```ts
- * import { byAriaLabel, byRole, locatorUtil } from '@atomic-testing/core';
- * const openButton = locatorUtil.append(byRole('button'), byAriaLabel('Open', 'Same'));
+ * import { byAriaLabel, byRole } from '@atomic-testing/core';
+ * const openButton = byRole('button').and(byAriaLabel('Open'));
  * ```
  *
  * Computed accessible names (`aria-labelledby` / `<label>` / text content) are


### PR DESCRIPTION

Adds a fluent `.and()` to CssLocator that compounds same-element matchers into one
selector — `byRole('button').and(byAriaLabel('Open'))` becomes
`[role="button"][aria-label="Open"]`. It is the ergonomic, footgun-free replacement
for `locatorUtil.append(..., 'Same')` and meets the role + verbatim-name need at the
locator layer, adding no new Interactor surface. ADR-007 ratifies the Interactor
evolution strategy (extend DOMInteractor) and records why a bespoke findByRole is not
added before the 1.0 freeze.

## Key Changes

- Add `CssLocator.and(...)`: same-element compound selector, preserves the base's
  relative position, throws on runtime-resolved linked locators.
- Add ADR-007 (Interactor evolution + composition); resolve the ADR-006 §6 deferral.
- Move the byRole/byAriaLabel docs and the cross-engine ByRole suite to the `.and()` form.
- Index the core-stack decision ADRs (007, 008, 010–012) in agent-docs/INDEX.md.

Resolves #962.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/988).
* #992
* #991
* #990
* #989
* __->__ #988