### PR TITLE
docs(core): declare the CSS/DOM-only locator boundary for 1.0

### DIFF
--- a/agent-docs/adr/008-css-dom-only-locator-boundary.md
+++ b/agent-docs/adr/008-css-dom-only-locator-boundary.md
@@ -1,0 +1,74 @@
+# ADR-008: The 1.0 locator boundary is CSS- and DOM-only
+
+## Status
+
+Accepted (2026-06-29). Part of the 1.0 freeze. Decision **D2** of the core gap audit (issue #963).
+
+## Context
+
+Every locator in the system reduces to a single CSS string through
+`locatorUtil.toCssSelector`, which is then handed to `document.querySelector`
+(jsdom) or `page.locator(css)` (Playwright). Concretely:
+
+- The locator set is **closed to CSS**: every builder (`byRole`, `byAriaLabel`,
+  `byAttribute`, `byDataTestId`, `byCssSelector`, …) emits a CSS fragment, and the
+  only locator verb the `Interactor` exposes is "turn this into CSS".
+- `byRole` / `byAriaLabel` are themselves just CSS attribute matchers
+  (`[role="…"]`, `[aria-label="…"]`).
+- There is **no seam** for an XPath / text / computed-accessible-name engine, nor
+  for a non-DOM target.
+
+This was an _implicit_ boundary. Freezing the surface at 1.0 forces the question:
+do we bless the CSS/DOM-only model, or introduce an indirection now so locators
+could later resolve through engine-native handles (required for non-DOM)?
+
+## Decision
+
+**Declare 1.0 deliberately DOM- and CSS-only, and document the boundary
+explicitly** (option (a)). The boundary is now stated in the TSDoc of the two
+public contract types and the one resolution seam:
+
+- `Interactor` — methods resolve via a single CSS selector run against a DOM; no
+  non-DOM seam; computed accessible names out of scope.
+- `PartLocator` — always reduces to one CSS selector; the locator model is closed
+  to CSS for 1.0; `byCssSelector` is the raw-CSS escape hatch and
+  {@link CssLocator.and} composes same-element matchers.
+- `locatorUtil.toCssSelector` — the single, CSS-only resolution seam.
+
+What stays **in** scope (all CSS): attribute/role/state matchers, same-element
+composition via `CssLocator.and`, and the `byCssSelector` raw escape hatch.
+
+What is **out** of scope for 1.0: computed ARIA accessible names
+(`aria-labelledby` / associated `<label>` / text content — not CSS-expressible),
+XPath, text-content engines, and non-DOM environments.
+
+We do **not** introduce a `resolve(locator)` indirection now (option (b)). That
+would be speculative abstraction with no present consumer; the one genuine gap —
+the computed accessible name — is addressed **additively** post-1.0 via an
+optional `Interactor` member per
+[ADR-007](007-interactor-evolution-and-composition.md), not by reworking the
+locator model. The verbatim role+name case is already covered by `CssLocator.and`.
+
+## Consequences
+
+- ✅ The boundary is explicit in docs + ADR, not implicit — consumers know exactly
+  what the locator model can and cannot express.
+- ✅ No speculative indirection added to the frozen surface.
+- ⚠️ If a non-DOM environment ever becomes a real ambition, adding the
+  `resolve(locator)` indirection would be a breaking `Interactor` change requiring
+  a major release. That is the accepted, documented cost of choosing the simpler
+  model now; the computed-name gap, by contrast, stays additive (ADR-007).
+
+## Alternatives considered
+
+| Alternative                                             | Why not chosen                                                                                                                                            |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Introduce a `resolve(locator)` indirection now (opt. b) | Speculative — no present non-DOM consumer; adds a layer to the frozen surface for a hypothetical future. Re-evaluate if/when non-DOM becomes a real goal. |
+| Leave the boundary implicit (status quo)                | The freeze is the moment to make limits explicit; an undocumented boundary invites Hyrum's-Law assumptions about XPath/accname support that do not exist. |
+
+## Related
+
+- [ADR-007](007-interactor-evolution-and-composition.md) — `CssLocator.and` (verbatim role+name) and the additive path for the deferred computed-name resolution.
+- [ADR-001](../../docs/adr/0001-interactor-primitives-and-name-aware-role.md) — Decision B: why the computed accessible name is not CSS-expressible (#923).
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) — the freeze that prompts making this boundary explicit.
+- Issues #963 (this decision), #923 (computed-name resolution).

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -549,7 +549,7 @@ export type Nullable<T> = T | null;
 // @public (undocumented)
 export type Optional<T> = T | undefined;
 
-// @public (undocumented)
+// @public
 export type PartLocator = CssLocator | CssLocatorChain;
 
 // @public (undocumented)

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -24,6 +24,17 @@ import type { PressKeyOption } from './PressKeyOption';
  * Component drivers delegate every interaction to an instance of this interface
  * so tests can run in different environments by simply providing a different
  * interactor implementation.
+ *
+ * **1.0 boundary — DOM and CSS only.** Every method resolves its target by
+ * reducing a {@link PartLocator} to a single CSS selector
+ * (`locatorUtil.toCssSelector`) and running it against a DOM — jsdom via
+ * `@testing-library` in `DOMInteractor`, or a real browser via Playwright. The
+ * 1.0 contract is therefore deliberately scoped to **DOM environments addressed
+ * by CSS**: there is no seam for a non-DOM target, and a computed ARIA accessible
+ * name (`aria-labelledby` / `<label>` / text — not CSS-expressible) is out of
+ * scope. See [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md);
+ * the deferred name-aware resolution is tracked in #923. Post-1.0 the interface
+ * grows additively per [ADR-007](../../../../agent-docs/adr/007-interactor-evolution-and-composition.md).
  */
 export interface Interactor {
   //#region Potentially DOM mutative interactions

--- a/packages/core/src/locators/PartLocator.ts
+++ b/packages/core/src/locators/PartLocator.ts
@@ -1,6 +1,19 @@
 import { CssLocator } from './CssLocator';
 
 export type CssLocatorChain = CssLocator[];
+
+/**
+ * A single {@link CssLocator} or a chain of them. A `PartLocator` always reduces
+ * to **one CSS selector** via `locatorUtil.toCssSelector`, which the interactor
+ * runs against the DOM.
+ *
+ * **1.0 boundary — CSS only.** The locator model is deliberately closed to CSS
+ * for 1.0: every builder (`byRole`, `byAriaLabel`, `byAttribute`, `byCssSelector`,
+ * …) emits a CSS fragment, same-element matchers compose via {@link CssLocator.and},
+ * and `byCssSelector` is the raw-CSS escape hatch. XPath, text, and computed-ARIA
+ * -name engines are out of scope — see
+ * [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md).
+ */
 export type PartLocator = CssLocator | CssLocatorChain;
 
 /**

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -65,6 +65,12 @@ async function getEffectiveLocator(locator: PartLocator, interactor: Interactor)
   return shouldSkip ? list : list.slice(rootLocatorIndex);
 }
 
+/**
+ * Reduce a {@link PartLocator} to the single CSS selector the interactor runs
+ * against the DOM. This is the one locator-resolution seam in the system, and it
+ * is **CSS-only by design** for 1.0 — every locator must express itself as CSS
+ * here (see [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md)).
+ */
 export async function toCssSelector(locator: PartLocator, interactor: Interactor): Promise<string> {
   const effectiveLocator = await getEffectiveLocator(locator, interactor);
   const statements: string[] = [];


### PR DESCRIPTION

The locator model already reduces every locator to a single CSS selector run
against a DOM, but that boundary was implicit. This documents it explicitly on the
public contract types so consumers know the 1.0 limits: locators are CSS-only,
interactors target a DOM, and computed accessible names / XPath / non-DOM engines
are out of scope. The verbatim role+name case is covered by `CssLocator.and`; the
computed-name gap stays additive per ADR-007.

## Key Changes

- Document the CSS/DOM-only boundary on `Interactor`, `PartLocator`, and
  `locatorUtil.toCssSelector`.
- Add ADR-008 recording the decision and why no `resolve()` indirection is added now.

Resolves #963.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/990).
* #992
* #991
* __->__ #990
* #989
* #988