### PR TITLE
refactor(core): retract the locator source AST from the public surface

### DIFF
--- a/agent-docs/adr/011-retract-locator-source-ast.md
+++ b/agent-docs/adr/011-retract-locator-source-ast.md
@@ -1,0 +1,65 @@
+# ADR-011: Retract the locator descriptive `source` AST from the public surface
+
+## Status
+
+Accepted (2026-06-29). Part of the 1.0 freeze. Decision **D5** of the core gap audit (issue #966).
+
+## Context
+
+Every locator builder populates a descriptive `source` AST — `byRole` sets
+`{ _id: 'byRole', value, relative }`, and so on — and `CssLocator` exposed it
+through `public get source(): Optional<CssLocatorSource>`. But:
+
+- `.source` was **never read** for reinterpretation anywhere in the codebase.
+- `CssLocatorSource` and every `By*Source` member were **not exported** from the
+  barrel, so the getter returned an **unnameable** type — a public getter whose
+  return type a consumer cannot even spell.
+- It is the load-bearing piece for the project's stated "reinterpret a locator to
+  a non-CSS engine" goal (the TODO in `byInputType.ts`) — which has **no consumer
+  yet**.
+
+Freezing this at 1.0 would lock a half-built AST shape into the stable surface via
+a getter nobody can use.
+
+## Decision
+
+**Retract** (option (b)): drop the public `source` getter and keep the `_source`
+AST **private**, preserved through `clone()`. The redesign substrate survives —
+the builders still construct it and it rides along on clones — but its shape is no
+longer frozen into the 1.0 surface. `CssLocatorSource` and the `By*Source` union
+stay unexported.
+
+The getter was the only public **read** of the AST and the only public reference
+to the unexported `CssLocatorSource`; removing it eliminates both (the
+`ae-forgotten-export` note for `CssLocatorSource` is gone from the report).
+`LinkedCssLocator` never carried a `source`, so its `clone()` no longer needs to
+read the removed getter.
+
+If reinterpretation actually ships post-1.0, the source surface can be designed
+and committed **deliberately** then (export the types, document `_id` as the
+stable discriminant, build the consumer) — additively, unconstrained by a
+prematurely-frozen getter.
+
+## Consequences
+
+- ✅ No public getter returns an unexported type; the `CssLocatorSource`
+  forgotten-export is resolved.
+- ✅ Redesign freedom preserved — the build-time AST is still constructed and
+  retained privately, with zero behavior change.
+- ⚠️ `CssLocatorInitializer` remains a constructor-/`clone()`-parameter
+  forgotten-export. That is a construction detail, not a stable read API, and is
+  the separate pre-existing cleanup [ADR-006](006-1.0-api-freeze-and-evolution.md)
+  flagged as follow-up — out of scope here.
+
+## Alternatives considered
+
+| Alternative                                                                                                                                | Why not chosen                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Commit** (opt. a): export `CssLocatorSource` + `By*Source`, build a reinterpretation consumer, document `_id` as the stable discriminant | No consumer ships at 1.0; committing would freeze an AST shape we would most likely redesign once reinterpretation is actually built.    |
+| Keep the getter but tag it `@internal`                                                                                                     | The report still records `@internal` members, so the unnameable-return-type getter would remain in the surface; full removal is cleaner. |
+
+## Related
+
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) — the freeze, and the forgotten-export cleanup note this partially resolves.
+- [ADR-008](008-css-dom-only-locator-boundary.md) — the CSS-only boundary; reinterpretation to a non-CSS engine would be the future this AST serves.
+- Issue #966; the `byInputType.ts` reinterpretation TODO.

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -177,10 +177,6 @@ export class CssLocator {
     get relative(): LocatorRelativePosition;
     // (undocumented)
     readonly selector: string;
-    // Warning: (ae-forgotten-export) The symbol "CssLocatorSource" needs to be exported by the entry point index.d.mts
-    //
-    // (undocumented)
-    get source(): Optional<CssLocatorSource>;
 }
 
 // @public (undocumented)

--- a/packages/core/src/locators/CssLocator.ts
+++ b/packages/core/src/locators/CssLocator.ts
@@ -1,4 +1,3 @@
-import { Optional } from '../dataTypes';
 import { CssLocatorSource } from './CssLocatorSource';
 import { LocatorComplexity } from './LocatorComplexity';
 import type { LocatorRelativePosition } from './LocatorRelativePosition';
@@ -19,16 +18,12 @@ export class CssLocator {
   ) {
     if (initializeValue) {
       this._relativePosition = initializeValue.relative || this.relative;
-      this._source = initializeValue.source || this.source;
+      this._source = initializeValue.source;
     }
   }
 
   get relative(): LocatorRelativePosition {
     return this._relativePosition;
-  }
-
-  get source(): Optional<CssLocatorSource> {
-    return this._source;
   }
 
   chain(...locatorsToAppend: PartLocator[]): PartLocator {

--- a/packages/core/src/locators/LinkedCssLocator.ts
+++ b/packages/core/src/locators/LinkedCssLocator.ts
@@ -67,7 +67,7 @@ export class LinkedCssLocator extends CssLocator {
   clone(override?: Partial<LinkedCssLocatorInitializer> & Partial<CssLocatorInitializer>): LinkedCssLocator {
     return new LinkedCssLocator(this.selector, {
       relative: override?.relative ?? this.relative,
-      source: override?.source ?? this.source,
+      source: override?.source,
       valueExtract: override?.valueExtract ?? this._valueExtract,
       matchingTargetLocator: override?.matchingTargetLocator ?? this._matchingTargetLocator,
       matchingTargetValueExtract: override?.matchingTargetValueExtract ?? this._matchingTargetValueExtract,


### PR DESCRIPTION

CssLocator exposed a `source` getter returning `CssLocatorSource` — a type the
barrel never exported, so its return value was unnameable, and nothing ever read it
for reinterpretation. Rather than freeze that half-built AST into the 1.0 surface,
the getter is dropped and the descriptive AST is kept private (still built by the
locator builders and preserved through clone), so the future "reinterpret to a
non-CSS engine" goal keeps its substrate without committing to a shape.

## Key Changes

- Drop the public `CssLocator.source` getter; keep `_source` private (preserved
  through clone). Resolves the `CssLocatorSource` forgotten-export.
- Simplify `LinkedCssLocator.clone` (linked locators never carried a source).
- Add ADR-011 recording the retract decision (commit deferred until reinterpretation
  actually ships).

Resolves #966.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/atomic-testing/atomic-testing/pull/991).
* #992
* __->__ #991