### PR TITLE
refactor(core): narrow error payload to a serializable shape

### DIFF
--- a/agent-docs/adr/010-narrow-error-payload.md
+++ b/agent-docs/adr/010-narrow-error-payload.md
@@ -1,0 +1,65 @@
+# ADR-010: Narrow the error payload to a serializable shape
+
+## Status
+
+Accepted (2026-06-29). Part of the 1.0 freeze. Decision **D4** of the core gap audit (issue #965).
+
+## Context
+
+Every error extended `ErrorBase`, which exposed
+`public readonly driver: ComponentDriver<any>` — so a thrown error carried a
+**live driver** (and through it the `Interactor`, and through that the DOM) as
+part of the frozen, catchable contract. `InteractorErrorBase` likewise exposed
+`locator: PartLocator`, and `ItemNotFoundError` / `TooManyMatchingElementError`
+carried both. Freezing this at 1.0 would:
+
+- pin the error API to the still-evolving driver and locator types;
+- invite consumers to reach driver/DOM internals through a caught error; and
+- leak `any` into the public error surface via `ComponentDriver<any>`.
+
+## Decision
+
+**Narrow the error fields to a minimal, serializable payload** and remove the live
+references:
+
+- `ErrorBase` carries `driverName: string` (not the driver).
+- `InteractorErrorBase` carries `locatorDescription: string` (not the locator),
+  computed via `getLocatorInfoForErrorLog`.
+- `ItemNotFoundError` / `TooManyMatchingElementError` carry `locatorDescription`
+  (the live `locator` / `query` fields are gone); `MissingPartError` keeps its
+  serializable `missingPartName` and no longer carries the driver.
+
+To keep this a low-ripple change, the base constructors accept a **structural**
+`{ driverName: string }` rather than `ComponentDriver`: a `ComponentDriver`
+satisfies it, so the ~30 throw sites still pass `this` / the driver unchanged, but
+only the **name** is retained. No live driver or locator survives on a caught
+error, and neither `ComponentDriver`, `PartLocator`, nor `any` appears in any error
+**field**.
+
+## Consequences
+
+- ✅ The catchable contract is fully serializable and decoupled from the
+  `ComponentDriver` / `PartLocator` types; the `any` leak is gone.
+- ✅ Aligns with the unified element-not-found error contract
+  ([ADR-006](006-1.0-api-freeze-and-evolution.md) §5).
+- ⚠️ Breaking for anyone who read `error.driver` / `error.locator` / `error.query`
+  — no in-repo, test, or example reader exists; done now, before 1.0.
+- ℹ️ The interactor-level subclasses (`ElementNotFoundError`, `WaitForFailureError`,
+  `ItemNotFoundError`, `TooManyMatchingElementError`) still accept a live
+  `PartLocator` **at construction** to derive the message and description — a clean,
+  `any`-free type, used and discarded, never stored.
+- ℹ️ The out-of-freeze `MenuItemNotFoundError` (`component-driver-mui-*`) extends
+  `ErrorBase` and compiles unchanged (`ComponentDriver` satisfies the structural
+  param). Narrowing its own `driver` field belongs to the MUI packages' own review.
+
+## Alternatives considered
+
+| Alternative                                                              | Why not chosen                                                                                                                        |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep the live `driver` field, document only `.name`/`.message` as stable | Leaves a live driver (→ DOM) reachable from every caught error and `any` in the public type; a doc note cannot un-freeze that.        |
+| Take `driverName: string` directly in `ErrorBase`                        | Forces every throw site and each out-of-freeze subclass to pass `.driverName`; the structural param achieves the same with no ripple. |
+
+## Related
+
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) §5 — the unified error contract this aligns with.
+- Issue #965.

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -229,9 +229,11 @@ export interface EnterTextOption {
 
 // @public
 export class ErrorBase extends Error {
-    constructor(message: string, driver: ComponentDriver<any>);
+    constructor(message: string, driver: {
+        driverName: string;
+    });
     // (undocumented)
-    readonly driver: ComponentDriver<any>;
+    readonly driverName: string;
 }
 
 // @public (undocumented)
@@ -387,9 +389,9 @@ export interface Interactor {
 
 // @public
 export class InteractorErrorBase extends Error {
-    constructor(message: string, locator: PartLocator);
+    constructor(message: string, locatorDescription: string);
     // (undocumented)
-    readonly locator: PartLocator;
+    readonly locatorDescription: string;
 }
 
 // @public (undocumented)
@@ -411,9 +413,11 @@ export interface IRequirableDriver {
 
 // @public
 export class ItemNotFoundError extends ErrorBase {
-    constructor(query: PartLocator | string, driver: ComponentDriver<any>, message?: string);
+    constructor(query: PartLocator | string, driver: {
+        driverName: string;
+    }, message?: string);
     // (undocumented)
-    readonly query: PartLocator | string;
+    readonly locatorDescription: string;
 }
 
 // @public (undocumented)
@@ -516,9 +520,9 @@ export namespace locatorUtil {
 
 // @public (undocumented)
 export class MissingPartError<T extends ScenePart> extends ErrorBase {
-    constructor(missingPartName: keyof T | ReadonlyArray<keyof T>, driver: ComponentDriver<T>);
-    // (undocumented)
-    readonly driver: ComponentDriver<T>;
+    constructor(missingPartName: keyof T | ReadonlyArray<keyof T>, driver: {
+        driverName: string;
+    });
     // (undocumented)
     readonly missingPartName: keyof T | ReadonlyArray<keyof T>;
 }

--- a/packages/core/src/errors/ElementNotFoundError.ts
+++ b/packages/core/src/errors/ElementNotFoundError.ts
@@ -18,7 +18,7 @@ export class ElementNotFoundError extends InteractorErrorBase {
     locator: PartLocator,
     public readonly action: string
   ) {
-    super(getErrorMessage(locator, action), locator);
+    super(getErrorMessage(locator, action), getLocatorInfoForErrorLog(locator));
     this.name = ElementNotFoundErrorId;
   }
 }

--- a/packages/core/src/errors/ErrorBase.ts
+++ b/packages/core/src/errors/ErrorBase.ts
@@ -1,17 +1,19 @@
-import { ComponentDriver } from '../drivers';
-
 /**
- * Base class for errors that include a reference to the component driver
- * where the error occurred. The `any` type for the driver's ScenePart
- * parameter is intentional to allow subclasses to narrow the driver type
- * (e.g., MissingPartError has driver: ComponentDriver).
+ * Base class for errors raised from a component driver.
+ *
+ * Carries only a **serializable** snapshot of where the error occurred —
+ * `driverName` — rather than a live `ComponentDriver` reference. This keeps the
+ * frozen, catchable error contract decoupled from the evolving driver type (and
+ * free of the `any` a `ComponentDriver<any>` field would leak), and stops callers
+ * reaching driver/DOM internals through a caught error. The constructor accepts
+ * anything name-bearing (a driver satisfies `{ driverName: string }`) and stores
+ * only the name. See ADR-010.
  */
 export class ErrorBase extends Error {
-  constructor(
-    message: string,
+  readonly driverName: string;
 
-    public readonly driver: ComponentDriver<any>
-  ) {
+  constructor(message: string, driver: { driverName: string }) {
     super(message);
+    this.driverName = driver.driverName;
   }
 }

--- a/packages/core/src/errors/InteractorErrorBase.ts
+++ b/packages/core/src/errors/InteractorErrorBase.ts
@@ -1,14 +1,17 @@
-import { PartLocator } from '../locators';
-
 /**
- * Base class for errors thrown at the interactor level.
- * These errors don't have access to a ComponentDriver reference,
- * only the locator that was used when the error occurred.
+ * Base class for errors thrown at the interactor level, where no
+ * `ComponentDriver` is available — only the locator that was being resolved.
+ *
+ * Carries a **serializable** `locatorDescription` string rather than a live
+ * `PartLocator`, so the frozen, catchable error contract stays decoupled from the
+ * locator model and callers cannot reach locator internals through a caught
+ * error. Subclasses compute the description from the locator via
+ * `getLocatorInfoForErrorLog`. See ADR-010.
  */
 export class InteractorErrorBase extends Error {
   constructor(
     message: string,
-    public readonly locator: PartLocator
+    public readonly locatorDescription: string
   ) {
     super(message);
   }

--- a/packages/core/src/errors/ItemNotFoundError.ts
+++ b/packages/core/src/errors/ItemNotFoundError.ts
@@ -1,32 +1,32 @@
-import { ComponentDriver } from '../drivers/ComponentDriver';
 import { PartLocator } from '../locators';
 import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
 import { ErrorBase } from './ErrorBase';
 
 export const ItemNotFoundErrorId = 'ItemNotFoundError';
 
-function getErrorMessage(query: PartLocator | string): string {
-  const description = typeof query === 'string' ? query : getLocatorInfoForErrorLog(query);
-  return `Item not found.  Locator: ${description}`;
-}
-
 /**
  * The canonical "an item searched for in a collection was not found" error.
  * Component-specific list-miss errors (e.g. a menu's `MenuItemNotFoundError`)
  * subclass this so callers can catch the family with one `instanceof` check.
  *
+ * Per ADR-010 it retains only a serializable {@link locatorDescription} string —
+ * never the live locator — keeping the frozen error contract decoupled from the
+ * locator model.
+ *
  * @param query What was searched for — a {@link PartLocator} or a human-readable
  *   description such as an item label.
+ * @param driver Anything name-bearing (a driver satisfies `{ driverName }`); only
+ *   its `driverName` is retained.
  * @param message Optional override for the generated message, used by subclasses
  *   that phrase the miss in their own terms.
  */
 export class ItemNotFoundError extends ErrorBase {
-  constructor(
-    public readonly query: PartLocator | string,
-    driver: ComponentDriver<any>,
-    message: string = getErrorMessage(query)
-  ) {
-    super(message, driver);
+  readonly locatorDescription: string;
+
+  constructor(query: PartLocator | string, driver: { driverName: string }, message?: string) {
+    const locatorDescription = typeof query === 'string' ? query : getLocatorInfoForErrorLog(query);
+    super(message ?? `Item not found.  Locator: ${locatorDescription}`, driver);
+    this.locatorDescription = locatorDescription;
     this.name = ItemNotFoundErrorId;
   }
 }

--- a/packages/core/src/errors/MissingPartError.ts
+++ b/packages/core/src/errors/MissingPartError.ts
@@ -1,4 +1,3 @@
-import { ComponentDriver } from '../drivers/ComponentDriver';
 import { ScenePart } from '../partTypes';
 import { ErrorBase } from './ErrorBase';
 
@@ -7,10 +6,10 @@ export const MissingPartErrorId = 'MissingPartError';
 export class MissingPartError<T extends ScenePart> extends ErrorBase {
   constructor(
     public readonly missingPartName: keyof T | ReadonlyArray<keyof T>,
-    public readonly driver: ComponentDriver<T>
+    driver: { driverName: string }
   ) {
     const partNames = Array.isArray(missingPartName) ? missingPartName : [missingPartName];
-    const partNameString = partNames.map(name => `${name}`).join(', ');
+    const partNameString = partNames.map(name => `${String(name)}`).join(', ');
     super(`The part "${partNameString}" is missing`, driver);
     this.name = MissingPartErrorId;
   }

--- a/packages/core/src/errors/WaitForFailureError.ts
+++ b/packages/core/src/errors/WaitForFailureError.ts
@@ -12,7 +12,7 @@ function getErrorMessage(locator: PartLocator, option: WaitForOption): string {
 
 export class WaitForFailureError extends InteractorErrorBase {
   constructor(locator: PartLocator, option: WaitForOption) {
-    super(getErrorMessage(locator, option), locator);
+    super(getErrorMessage(locator, option), getLocatorInfoForErrorLog(locator));
     this.name = WaitForFailureErrorId;
   }
 }


### PR DESCRIPTION

Errors carried a live `ComponentDriver` (reachable through to the DOM) and a live
`PartLocator` as part of the frozen, catchable contract, and `ComponentDriver<any>`
leaked `any` into the public error type. The fields are narrowed to a serializable
snapshot — `driverName` and `locatorDescription` — so a caught error no longer
exposes driver/DOM internals and the error API is decoupled from the evolving
driver/locator types.

## Key Changes

- `ErrorBase` exposes `driverName`; `InteractorErrorBase` (and ItemNotFound /
  TooManyMatchingElement) expose `locatorDescription`; the live driver/locator/query
  fields are dropped.
- Base constructors accept a structural `{ driverName: string }`, so all ~30 throw
  sites pass the driver unchanged — zero throw-site churn, no `any` in the surface.
- Add ADR-010.

Resolves #965.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
