### PR TITLE
feat(examples): add Astryx AI chat + admin workspace example (#986)

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -231,3 +231,40 @@ jobs:
       - name: Run dom test
         run: pnpm test:dom
         working-directory: ./examples/example-mui-signup-form
+
+  example-astryx-workspace-test:
+    name: Test example Astryx workspace
+    runs-on: ubuntu-latest
+    # Standalone example: it installs from its OWN lockfile and consumes PUBLISHED
+    # @atomic-testing/* packages, so it does not depend on the monorepo build
+    # (no `needs: build`) — it runs immediately for the fastest regression signal.
+    # Fast check only: type-check + jsdom unit tests (e2e needs browsers + a dev server).
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: PNPM Setup
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install .
+        working-directory: ./examples/example-astryx-workspace
+
+      - name: Type check
+        run: pnpm check:type
+        working-directory: ./examples/example-astryx-workspace
+
+      - name: Run dom test
+        run: pnpm test:dom
+        working-directory: ./examples/example-astryx-workspace

--- a/examples/example-astryx-workspace/.gitignore
+++ b/examples/example-astryx-workspace/.gitignore
@@ -1,0 +1,30 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/tasks.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/examples/example-astryx-workspace/README.md
+++ b/examples/example-astryx-workspace/README.md
@@ -1,0 +1,79 @@
+# Atomic testing example — Astryx AI chat + admin workspace
+
+A standalone example app built on the [Astryx design system](https://www.npmjs.com/package/@astryxdesign/core)
+(`@astryxdesign/core`, React 19) showing how [atomic-testing](https://www.atomic-testing.dev/) lets you
+write **one set of page-object drivers** and run the **same flow** in both a fast jsdom unit
+test (Vitest) and a real cross-browser end-to-end test (Playwright).
+
+It is a sibling to [`example-mui-signup-form`](../example-mui-signup-form) and consumes
+`@atomic-testing/*` and `@astryxdesign/*` straight from npm — exactly as a real consumer would.
+
+## The app
+
+One [`AppShell`](https://www.npmjs.com/package/@astryxdesign/core) with a side nav that switches
+between two co-equal sections (routed with `react-router-dom`):
+
+- **Chat** (`/`) — a `ChatLayout` message log with a docked `ChatComposer`. Sending appends your
+  message plus a **deterministic** assistant reply that includes a tool-call group (no backend, so
+  DOM and E2E assertions are stable). A header `Selector` picks the model; **⌘K** opens a
+  `CommandPalette` ("New chat", "Clear chat", "Open settings").
+- **Admin** (`/admin`) — a settings console: a `TabList` (General / Notifications / Appearance) over
+  `Field` / `TextInput` / `SegmentedControl` / `CheckboxList` / `RadioList` / `Switch` / `Selector` /
+  `DateInput`, an unsaved-changes `Banner`, a Save `Button` → `Toast`, and a "Delete workspace"
+  `Button` → confirm `AlertDialog`.
+
+## The point: dedup at the driver layer + readable tests
+
+Shipped Astryx drivers are composed into **page-object drivers** ([`src/testing/`](src/testing)),
+composed again into one top-level `WorkspaceDriver`:
+
+```text
+WorkspaceDriver
+├── WorkspaceShellDriver   AppShellDriver + SideNavDriver + SideNavItemDriver   gotoChat / gotoAdmin / getCurrentSection
+├── ChatPanelDriver        ChatLayout + ChatMessageList + ChatComposer + Selector + ChatToolCalls
+│                                                          send / getLastAssistantText / getToolCallCount / selectModel
+├── AdminSettingsDriver    TabList + the form + Banner + Button + Toast + AlertDialog
+│                                                          setValue(SettingsModel) / save / hasUnsavedBanner / deleteWorkspace
+└── CommandBarDriver       CommandPaletteDriver            open / run / getCommands
+```
+
+Because the drivers carry the behaviour, the tests read like a person using the app:
+
+```ts
+await workspace.gotoAdmin();
+await workspace.admin.setValue({ orgName: 'Globex', plan: 'Pro', channels: ['Email'], beta: true });
+await workspace.admin.save();
+expect(await workspace.admin.getToastMessage()).toMatch(/saved/i);
+```
+
+**The dedup story:** the DOM spec ([`src/__tests__/workspace.test.tsx`](src/__tests__/workspace.test.tsx))
+and the E2E spec ([`e2e/workspace.spec.ts`](e2e/workspace.spec.ts)) import the **same**
+[`workspaceParts`](src/testing/workspaceParts.ts) scene and the **same** composed drivers. The only
+difference is how the engine is built:
+
+| | Engine construction |
+| --- | --- |
+| DOM (Vitest, jsdom) | `createTestEngine(<App />, workspaceParts)` — from `@atomic-testing/react-19` |
+| E2E (Playwright) | `createTestEngine(page, workspaceParts)` — from `@atomic-testing/playwright` |
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `pnpm install` | Install deps (standalone — this package has its own lockfile and is outside the repo's pnpm workspace) |
+| `pnpm dev` | Run the app at <http://localhost:5173> (override with `PORT`) |
+| `pnpm test:dom` | Vitest (jsdom) — `src/**/__tests__/*.test.tsx` |
+| `pnpm test:e2e:chrome` | Playwright on Chromium (fast iteration; the Vite server auto-starts) |
+| `pnpm test:e2e` | Playwright on Chromium, Firefox, and WebKit |
+| `pnpm check:type` | `tsc --noEmit` |
+
+## Stack
+
+`react@^19.2` · `react-router-dom@^7` · `@astryxdesign/core@^0.1.2` +
+`@astryxdesign/theme-neutral@^0.1` · `@atomic-testing/{core,dom-core,react-19,playwright,component-driver-html,component-driver-astryx}@^0.89.0`
+· `vite` · `vitest@^4` · `@playwright/test@^1.61`.
+
+> The Astryx driver surface used here is gap-free — every action these scenarios need is a shipped
+> driver method. The `vitest.setup.ts` polyfills the browser overlay APIs jsdom lacks (Popover,
+> `<dialog>` modal methods, `ResizeObserver`/`IntersectionObserver`, `matchMedia`); real overlay
+> behaviour is covered by the Playwright run.

--- a/examples/example-astryx-workspace/README.md
+++ b/examples/example-astryx-workspace/README.md
@@ -61,7 +61,7 @@ difference is how the engine is built:
 | Command | Description |
 | --- | --- |
 | `pnpm install` | Install deps (standalone — this package has its own lockfile and is outside the repo's pnpm workspace) |
-| `pnpm dev` | Run the app at <http://localhost:5173> (override with `PORT`) |
+| `pnpm dev` | Run the app at <http://localhost:8088> (a dedicated port, distinct from every other app in the repo; override with `PORT`) |
 | `pnpm test:dom` | Vitest (jsdom) — `src/**/__tests__/*.test.tsx` |
 | `pnpm test:e2e:chrome` | Playwright on Chromium (fast iteration; the Vite server auto-starts) |
 | `pnpm test:e2e` | Playwright on Chromium, Firefox, and WebKit |

--- a/examples/example-astryx-workspace/e2e/workspace.spec.ts
+++ b/examples/example-astryx-workspace/e2e/workspace.spec.ts
@@ -1,0 +1,83 @@
+import type { ISODateString } from '@astryxdesign/core/Calendar';
+import { createTestEngine } from '@atomic-testing/playwright';
+import { expect, test } from '@playwright/test';
+
+import { workspaceParts } from '../src/testing/workspaceParts';
+
+/**
+ * E2E (real browser) run of the workspace scenarios. The engine is built from the
+ * Playwright `page`; the `workspaceParts` scene + composed drivers are the very same
+ * imports the Vitest DOM spec uses (src/__tests__/workspace.test.tsx). The flows read
+ * identically because the drivers carry the behaviour — only this construction differs.
+ */
+test('sends a message and gets a reply with a tool-call group', async ({ page }) => {
+  await page.goto('/');
+  const { workspace } = createTestEngine(page, workspaceParts).parts;
+
+  expect(await workspace.chat.canSend()).toBe(false);
+
+  const before = await workspace.chat.getMessageCount();
+  await workspace.chat.send('plan a trip');
+
+  expect(await workspace.chat.getMessageCount()).toBe(before + 2);
+  expect(await workspace.chat.getToolCallCount()).toBeGreaterThanOrEqual(1);
+  expect(await workspace.chat.getLastAssistantText()).toMatch(/plan a trip/i);
+});
+
+test('switches the model', async ({ page }) => {
+  await page.goto('/');
+  const { workspace } = createTestEngine(page, workspaceParts).parts;
+
+  await workspace.chat.selectModel('Claude Opus');
+  expect(await workspace.chat.getSelectedModel()).toBe('Claude Opus');
+});
+
+test('opens settings from the command palette', async ({ page }) => {
+  await page.goto('/');
+  const { workspace } = createTestEngine(page, workspaceParts).parts;
+
+  await workspace.commandBar.open();
+  expect(await workspace.commandBar.isOpen()).toBe(true);
+
+  await workspace.commandBar.run('Open settings');
+  // Selecting the command routes asynchronously — poll until the section settles.
+  await expect.poll(() => workspace.getCurrentSection()).toBe('admin');
+});
+
+test('saves admin settings and clears the unsaved banner', async ({ page }) => {
+  await page.goto('/');
+  const { workspace } = createTestEngine(page, workspaceParts).parts;
+
+  await workspace.gotoAdmin();
+
+  await workspace.admin.setValue({
+    orgName: 'Globex',
+    plan: 'Pro',
+    channels: ['Email'],
+    beta: true,
+    renewal: '2026-07-15' as ISODateString,
+  });
+  expect(await workspace.admin.hasUnsavedBanner()).toBe(true);
+
+  await workspace.admin.save();
+  expect(await workspace.admin.getToastMessage()).toMatch(/saved/i);
+  expect(await workspace.admin.hasUnsavedBanner()).toBe(false);
+});
+
+test('guards workspace deletion behind the alert dialog', async ({ page }) => {
+  await page.goto('/');
+  const { workspace } = createTestEngine(page, workspaceParts).parts;
+
+  await workspace.gotoAdmin();
+
+  await workspace.admin.openDeleteDialog();
+  expect(await workspace.admin.deleteDialog.isOpen()).toBe(true);
+  expect(await workspace.admin.deleteDialog.getActionLabel()).toBe('Delete');
+
+  await workspace.admin.deleteDialog.clickCancel();
+  expect(await workspace.admin.deleteDialog.isOpen()).toBe(false);
+
+  await workspace.admin.openDeleteDialog();
+  await workspace.admin.deleteDialog.clickAction();
+  expect(await workspace.admin.deleteDialog.isOpen()).toBe(false);
+});

--- a/examples/example-astryx-workspace/index.html
+++ b/examples/example-astryx-workspace/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic testing example - Astryx AI chat + admin workspace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/example-astryx-workspace/package.json
+++ b/examples/example-astryx-workspace/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "example-astryx-workspace",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check:type": "tsc --noEmit",
+    "test:dom": "vitest run",
+    "test:dom:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:chrome": "playwright test --project=chromium"
+  },
+  "dependencies": {
+    "@astryxdesign/core": "^0.1.2",
+    "@astryxdesign/theme-neutral": "^0.1.2",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router-dom": "^7.7.1"
+  },
+  "devDependencies": {
+    "@atomic-testing/component-driver-astryx": "^0.89.0",
+    "@atomic-testing/component-driver-html": "^0.89.0",
+    "@atomic-testing/core": "^0.89.0",
+    "@atomic-testing/dom-core": "^0.89.0",
+    "@atomic-testing/playwright": "^0.89.0",
+    "@atomic-testing/react-19": "^0.89.0",
+    "@playwright/test": "^1.61.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/example-astryx-workspace/playwright.config.ts
+++ b/examples/example-astryx-workspace/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Matches vite.config.ts — defaults to 5173, override with PORT.
+const port = process.env.PORT ?? '5173';
+const baseURL = `http://localhost:${port}`;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  /* Run the Vite dev server before starting the tests. */
+  webServer: {
+    command: 'pnpm dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/examples/example-astryx-workspace/playwright.config.ts
+++ b/examples/example-astryx-workspace/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
-// Matches vite.config.ts — defaults to 5173, override with PORT.
-const port = process.env.PORT ?? '5173';
+// Matches vite.config.ts — defaults to the example's dedicated port 8088, override with PORT.
+const port = process.env.PORT ?? '8088';
 const baseURL = `http://localhost:${port}`;
 
 /**

--- a/examples/example-astryx-workspace/pnpm-lock.yaml
+++ b/examples/example-astryx-workspace/pnpm-lock.yaml
@@ -1,0 +1,1569 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@astryxdesign/core':
+        specifier: ^0.1.2
+        version: 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/theme-neutral':
+        specifier: ^0.1.2
+        version: 0.1.2(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.7.1
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@atomic-testing/component-driver-astryx':
+        specifier: ^0.89.0
+        version: 0.89.0(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@atomic-testing/component-driver-html':
+        specifier: ^0.89.0
+        version: 0.89.0
+      '@atomic-testing/core':
+        specifier: ^0.89.0
+        version: 0.89.0
+      '@atomic-testing/dom-core':
+        specifier: ^0.89.0
+        version: 0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@atomic-testing/playwright':
+        specifier: ^0.89.0
+        version: 0.89.0(@playwright/test@1.61.1)
+      '@atomic-testing/react-19':
+        specifier: ^0.89.0
+        version: 0.89.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.3(vite@8.1.0)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.0
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(jsdom@29.1.1)(vite@8.1.0)
+
+packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@astryxdesign/core@0.1.2':
+    resolution: {integrity: sha512-SJOEXUaRvcVgGbdPwV5UL5aYMbwIl09H2yQb3hPh4NNGWqmLTHE05IFTNRi37Mk9ywoo01+UM2ZrewmJe39f0A==}
+    peerDependencies:
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+
+  '@astryxdesign/theme-neutral@0.1.2':
+    resolution: {integrity: sha512-kEBBJ7O5H+27IACsGEqZSEVFy2r4VlBu4Vzfm/LOJ/Ez6C/RBTCXq9Iu8CoZS4Qt/WkYUvqLPDiJlgXuALy9uQ==}
+    peerDependencies:
+      '@astryxdesign/core': 0.1.2
+      react: '>=19'
+
+  '@atomic-testing/component-driver-astryx@0.89.0':
+    resolution: {integrity: sha512-DW4JEQLfO02mAfWyIHllXvnSfquWV+0alzvmFw4vtJlJjXfuKD08+TeH40mj8uxZFZu4cIGnSCjICMrraF64AQ==}
+    peerDependencies:
+      '@astryxdesign/core': ^0.1.1
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+
+  '@atomic-testing/component-driver-html@0.89.0':
+    resolution: {integrity: sha512-aRwBrML2vT4GKs/tzEjNIcd6nfbsI/jakl3md9bOfJGnz4oWQZdXz7NUzIa7sFDo92n3Uo+pWMK9Bj8AxILzkQ==}
+
+  '@atomic-testing/core@0.89.0':
+    resolution: {integrity: sha512-n23vzugj0C//dpo0vAxErBng1fa2EHP3ExyZ1jYA64G0e9V5NedUqgVopGglnIul25RX1X0R2EyK6edKmVZELw==}
+
+  '@atomic-testing/dom-core@0.89.0':
+    resolution: {integrity: sha512-re9UyI1dg3Riitmf40ak+R2hilKJmPmgZq8UkblzoyF0+4qlkkA3ERSeHgvjLYbXC1ppB1mWquaNOzk6bIx/7g==}
+    peerDependencies:
+      '@testing-library/dom': '>=10.4.1'
+      '@testing-library/user-event': '>=14.0.0'
+
+  '@atomic-testing/playwright@0.89.0':
+    resolution: {integrity: sha512-QZaJmLJ85yXl97MpVGiZb8VFEowF9ablShqT/JvRlwViCfWOdjh7pWCCIfY3kT3H8XqMPk2xOzPgX5XkZdaF+g==}
+    peerDependencies:
+      '@playwright/test': '>=1.50.0'
+
+  '@atomic-testing/react-19@0.89.0':
+    resolution: {integrity: sha512-GP7kyVub7mTnQrU5leRRrKfXU4VMbYAyZXo3s90g07TDnFaKUZYstBvBUE5uHzw5OnJIvHlSv5MaWrPPVawmkQ==}
+    peerDependencies:
+      '@testing-library/dom': '>=10.2.0'
+      '@testing-library/react': '>=16.2.0'
+      '@testing-library/user-event': '>=14.0.0'
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+
+  '@atomic-testing/react-core@0.89.0':
+    resolution: {integrity: sha512-/KHWxG2avDc/ygi8+PPXR3ShOlhIU3IC2REXIl2btAsxvR3lGHq8swxQz0HDuNR7DN/tqPsfuLb77By/u6z8TA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stylexjs/stylex@0.18.3':
+    resolution: {integrity: sha512-15gDzAJAorOE0yzxaWLNxldW2aqdmCiLG5QcPD8nmVCVqvrWp0Asgv45zk7LtN86WJb/4Ym9eQ6qT5MJW59tWQ==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  css-mediaquery@0.1.2:
+    resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lucide-react@1.22.0:
+    resolution: {integrity: sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.1.3:
+    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  styleq@0.2.1:
+    resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.5:
+    resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
+
+  tldts@7.4.5:
+    resolution: {integrity: sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  vite@8.1.0:
+    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@stylexjs/stylex': 0.18.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@astryxdesign/theme-neutral@0.1.2(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@astryxdesign/core': 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      lucide-react: 1.22.0(react@19.2.7)
+      react: 19.2.7
+
+  '@atomic-testing/component-driver-astryx@0.89.0(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@astryxdesign/core': 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@atomic-testing/component-driver-html': 0.89.0
+      '@atomic-testing/core': 0.89.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@atomic-testing/component-driver-html@0.89.0':
+    dependencies:
+      '@atomic-testing/core': 0.89.0
+
+  '@atomic-testing/core@0.89.0': {}
+
+  '@atomic-testing/dom-core@0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))':
+    dependencies:
+      '@atomic-testing/core': 0.89.0
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+
+  '@atomic-testing/playwright@0.89.0(@playwright/test@1.61.1)':
+    dependencies:
+      '@atomic-testing/core': 0.89.0
+      '@playwright/test': 1.61.1
+
+  '@atomic-testing/react-19@0.89.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/core': 0.89.0
+      '@atomic-testing/dom-core': 0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@atomic-testing/react-core': 0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@atomic-testing/react-core@0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/core': 0.89.0
+      '@atomic-testing/dom-core': 0.89.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - '@testing-library/user-event'
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@exodus/bytes@1.15.1': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.137.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@stylexjs/stylex@0.18.3':
+    dependencies:
+      css-mediaquery: 0.1.2
+      invariant: 2.2.4
+      styleq: 0.2.1
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.0)':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.0
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.0)':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.0
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  css-mediaquery@0.1.2: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@11.5.1: {}
+
+  lucide-react@1.22.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  nanoid@3.3.15: {}
+
+  obug@2.1.3: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  react@19.2.7: {}
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.1.3:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.3
+      '@rolldown/binding-darwin-arm64': 1.1.3
+      '@rolldown/binding-darwin-x64': 1.1.3
+      '@rolldown/binding-freebsd-x64': 1.1.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
+      '@rolldown/binding-linux-arm64-gnu': 1.1.3
+      '@rolldown/binding-linux-arm64-musl': 1.1.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
+      '@rolldown/binding-linux-s390x-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-musl': 1.1.3
+      '@rolldown/binding-openharmony-arm64': 1.1.3
+      '@rolldown/binding-wasm32-wasi': 1.1.3
+      '@rolldown/binding-win32-arm64-msvc': 1.1.3
+      '@rolldown/binding-win32-x64-msvc': 1.1.3
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  styleq@0.2.1: {}
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.5: {}
+
+  tldts@7.4.5:
+    dependencies:
+      tldts-core: 7.4.5
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.5
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  undici@7.28.0: {}
+
+  vite@8.1.0:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.1.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.9(jsdom@29.1.1)(vite@8.1.0):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.0)
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.2.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.0
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/examples/example-astryx-workspace/pnpm-workspace.yaml
+++ b/examples/example-astryx-workspace/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+# Marks this example as its OWN pnpm workspace root so it installs standalone (its own
+# lockfile, isolated from the monorepo's root workspace — it is intentionally not a member
+# of that one). The excludes opt the pinned, recently-published versions past a
+# minimum-release-age supply-chain gate; they are a no-op where no such gate is configured.
+minimumReleaseAgeExclude:
+  - '@astryxdesign/core@0.1.2'
+  - '@astryxdesign/theme-neutral@0.1.2'
+  - '@atomic-testing/component-driver-astryx@0.89.0'
+  - '@atomic-testing/component-driver-html@0.89.0'
+  - '@atomic-testing/core@0.89.0'
+  - '@atomic-testing/dom-core@0.89.0'
+  - '@atomic-testing/playwright@0.89.0'
+  - '@atomic-testing/react-19@0.89.0'
+  - '@atomic-testing/react-core@0.89.0'

--- a/examples/example-astryx-workspace/src/App.tsx
+++ b/examples/example-astryx-workspace/src/App.tsx
@@ -1,0 +1,30 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+
+import { AppDataTestId } from './AppDataTestId';
+import { AdminSettings } from './components/adminSettings/AdminSettings';
+import { ChatPanel } from './components/chatPanel/ChatPanel';
+import { WorkspaceShell } from './components/workspaceShell/WorkspaceShell';
+import { ChatSessionProvider } from './hooks/ChatSessionProvider';
+
+/**
+ * The whole workspace behind one AppShell: the SideNav switches between the co-equal
+ * Chat (`/`) and Admin (`/admin`) sections. The `data-testid` root is the single anchor
+ * the shared {@link workspaceParts} scene resolves from — in both jsdom and the browser.
+ */
+export default function App() {
+  return (
+    <div data-testid={AppDataTestId.root}>
+      <ChatSessionProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route element={<WorkspaceShell />}>
+              <Route index element={<ChatPanel />} />
+              <Route path='admin' element={<AdminSettings />} />
+              <Route path='*' element={<Navigate to='/' replace />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </ChatSessionProvider>
+    </div>
+  );
+}

--- a/examples/example-astryx-workspace/src/AppDataTestId.ts
+++ b/examples/example-astryx-workspace/src/AppDataTestId.ts
@@ -1,0 +1,17 @@
+/**
+ * Stable `data-testid` anchors for the top-level workspace regions. Both the
+ * Vitest DOM specs and the Playwright E2E specs locate the app through these, so
+ * the same {@link workspaceParts} scene map drives both runners unchanged.
+ */
+export const AppDataTestId = {
+  /** Root element wrapping the whole app — every other anchor is a descendant. */
+  root: 'workspace-root',
+  /** Astryx `AppShell` (header + side nav + main). */
+  shell: 'workspace-shell',
+  /** Chat section root (mounted on the `/` route). */
+  chatSection: 'chat-section',
+  /** Admin settings section root (mounted on the `/admin` route). */
+  adminSection: 'admin-section',
+  /** Command bar wrapper (⌘K trigger + `CommandPalette`), always mounted in the header. */
+  commandBar: 'command-bar',
+} as const;

--- a/examples/example-astryx-workspace/src/__tests__/workspace.test.tsx
+++ b/examples/example-astryx-workspace/src/__tests__/workspace.test.tsx
@@ -1,0 +1,89 @@
+import type { ISODateString } from '@astryxdesign/core/Calendar';
+import { TestEngine } from '@atomic-testing/core';
+import { createTestEngine } from '@atomic-testing/react-19';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import App from '../App';
+import { workspaceParts } from '../testing/workspaceParts';
+
+/**
+ * DOM (jsdom) run of the workspace scenarios. The engine renders <App /> directly and
+ * the `workspaceParts` scene + composed drivers are imported verbatim — the E2E spec in
+ * e2e/workspace.spec.ts runs the very same flow against a real browser, differing only
+ * in how the engine is constructed.
+ */
+describe('Astryx workspace (DOM)', () => {
+  let engine: TestEngine<typeof workspaceParts>;
+
+  beforeEach(() => {
+    // Reset the BrowserRouter back to the chat route between tests.
+    window.history.pushState({}, '', '/');
+    engine = createTestEngine(<App />, workspaceParts);
+  });
+
+  afterEach(async () => {
+    await engine.cleanUp();
+  });
+
+  test('sends a message and gets a reply with a tool-call group', async () => {
+    const { workspace } = engine.parts;
+    expect(await workspace.chat.canSend()).toBe(false);
+
+    const before = await workspace.chat.getMessageCount();
+    await workspace.chat.send('plan a trip');
+
+    expect(await workspace.chat.getMessageCount()).toBe(before + 2);
+    expect(await workspace.chat.getToolCallCount()).toBeGreaterThanOrEqual(1);
+    expect(await workspace.chat.getLastAssistantText()).toMatch(/plan a trip/i);
+  });
+
+  test('switches the model', async () => {
+    const { workspace } = engine.parts;
+    await workspace.chat.selectModel('Claude Opus');
+    expect(await workspace.chat.getSelectedModel()).toBe('Claude Opus');
+  });
+
+  test('opens settings from the command palette', async () => {
+    const { workspace } = engine.parts;
+    await workspace.commandBar.open();
+    expect(await workspace.commandBar.isOpen()).toBe(true);
+
+    await workspace.commandBar.run('Open settings');
+    // Selecting the command routes asynchronously — poll until the section settles.
+    await expect.poll(() => workspace.getCurrentSection()).toBe('admin');
+  });
+
+  test('saves admin settings and clears the unsaved banner', async () => {
+    const { workspace } = engine.parts;
+    await workspace.gotoAdmin();
+
+    await workspace.admin.setValue({
+      orgName: 'Globex',
+      plan: 'Pro',
+      channels: ['Email'],
+      beta: true,
+      renewal: '2026-07-15' as ISODateString,
+    });
+    expect(await workspace.admin.hasUnsavedBanner()).toBe(true);
+
+    await workspace.admin.save();
+    expect(await workspace.admin.getToastMessage()).toMatch(/saved/i);
+    expect(await workspace.admin.hasUnsavedBanner()).toBe(false);
+  });
+
+  test('guards workspace deletion behind the alert dialog', async () => {
+    const { workspace } = engine.parts;
+    await workspace.gotoAdmin();
+
+    await workspace.admin.openDeleteDialog();
+    expect(await workspace.admin.deleteDialog.isOpen()).toBe(true);
+    expect(await workspace.admin.deleteDialog.getActionLabel()).toBe('Delete');
+
+    await workspace.admin.deleteDialog.clickCancel();
+    expect(await workspace.admin.deleteDialog.isOpen()).toBe(false);
+
+    await workspace.admin.openDeleteDialog();
+    await workspace.admin.deleteDialog.clickAction();
+    expect(await workspace.admin.deleteDialog.isOpen()).toBe(false);
+  });
+});

--- a/examples/example-astryx-workspace/src/components/adminSettings/AdminSettings.tsx
+++ b/examples/example-astryx-workspace/src/components/adminSettings/AdminSettings.tsx
@@ -3,30 +3,28 @@ import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { CheckboxList, CheckboxListItem } from '@astryxdesign/core/CheckboxList';
 import { DateInput } from '@astryxdesign/core/DateInput';
-import { Field } from '@astryxdesign/core/Field';
+import { FormLayout } from '@astryxdesign/core/FormLayout';
 import { RadioList, RadioListItem } from '@astryxdesign/core/RadioList';
 import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
 import { Selector } from '@astryxdesign/core/Selector';
+import { Stack } from '@astryxdesign/core/Stack';
 import { Switch } from '@astryxdesign/core/Switch';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
+import { TextInput } from '@astryxdesign/core/TextInput';
 import { Toast } from '@astryxdesign/core/Toast';
 import { useState } from 'react';
 
 import { AppDataTestId } from '../../AppDataTestId';
 import { useAdminSettings } from '../../hooks/useAdminSettings';
-import {
-  CHANNEL_OPTIONS,
-  DENSITY_OPTIONS,
-  MODEL_OPTIONS,
-  PLAN_OPTIONS,
-} from '../../models/SettingsModel';
-import { ADMIN_TABS, AdminSettingsDataTestId, ORG_INPUT_ID, PLAN_LABEL } from './AdminSettingsDataTestId';
+import { CHANNEL_OPTIONS, DENSITY_OPTIONS, MODEL_OPTIONS, PLAN_OPTIONS } from '../../models/SettingsModel';
+import { ADMIN_TABS, AdminSettingsDataTestId, PLAN_LABEL } from './AdminSettingsDataTestId';
 
 /**
- * The admin settings console: a TabList over Field-wrapped form controls, a persistent
- * footer with the unsaved-changes Banner + Save + Delete, a confirm AlertDialog, and a
- * success Toast. State lives in {@link useAdminSettings}, so switching tabs never loses
- * a draft edit.
+ * The admin settings console: a TabList over form controls (each tab's fields laid out
+ * with FormLayout for uniform spacing), a persistent footer with the unsaved-changes
+ * Banner + Save + Delete, a confirm AlertDialog, and a success Toast. State lives in
+ * {@link useAdminSettings}, so switching tabs never loses a draft edit. The content is
+ * width-capped so a settings form does not sprawl across a wide viewport.
  */
 export function AdminSettings() {
   const { draft, dirty, savedToast, update, save, dismissToast, reset } = useAdminSettings();
@@ -34,62 +32,57 @@ export function AdminSettings() {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   return (
-    <section data-testid={AppDataTestId.adminSection}>
-      <TabList data-testid={AdminSettingsDataTestId.tabs} value={activeTab} onChange={setActiveTab}>
+    <Stack as='section' data-testid={AppDataTestId.adminSection} gap={4} style={{ maxWidth: 720 }}>
+      <TabList data-testid={AdminSettingsDataTestId.tabs} value={activeTab} onChange={setActiveTab} hasDivider>
         {ADMIN_TABS.map((tab) => (
           <Tab key={tab.value} value={tab.value} label={tab.label} />
         ))}
       </TabList>
 
       {activeTab === 'general' && (
-        <div>
-          <Field
-            data-testid={AdminSettingsDataTestId.orgField}
+        <FormLayout>
+          <TextInput
+            data-testid={AdminSettingsDataTestId.orgInput}
             label='Organization name'
-            inputID={ORG_INPUT_ID}
             isRequired
+            value={draft.orgName}
+            onChange={(orgName) => update({ orgName })}
             status={
               draft.orgName.trim().length > 0
                 ? undefined
                 : { type: 'error', message: 'Organization name is required' }
-            }>
-            <input
-              id={ORG_INPUT_ID}
-              data-testid={AdminSettingsDataTestId.orgInput}
-              value={draft.orgName}
-              onChange={(e) => update({ orgName: e.target.value })}
-            />
-          </Field>
-
+            }
+          />
           <SegmentedControl value={draft.plan} onChange={(plan) => update({ plan })} label={PLAN_LABEL}>
             {PLAN_OPTIONS.map((option) => (
               <SegmentedControlItem key={option.value} value={option.value} label={option.label} />
             ))}
           </SegmentedControl>
-
           <DateInput
             data-testid={AdminSettingsDataTestId.renewal}
             label='Renews'
             value={draft.renewal}
             onChange={(renewal) => renewal != null && update({ renewal })}
           />
-        </div>
+        </FormLayout>
       )}
 
       {activeTab === 'notifications' && (
-        <CheckboxList
-          data-testid={AdminSettingsDataTestId.channels}
-          label='Notification channels'
-          value={draft.channels}
-          onChange={(channels) => update({ channels })}>
-          {CHANNEL_OPTIONS.map((option) => (
-            <CheckboxListItem key={option.value} value={option.value} label={option.label} />
-          ))}
-        </CheckboxList>
+        <FormLayout>
+          <CheckboxList
+            data-testid={AdminSettingsDataTestId.channels}
+            label='Notification channels'
+            value={draft.channels}
+            onChange={(channels) => update({ channels })}>
+            {CHANNEL_OPTIONS.map((option) => (
+              <CheckboxListItem key={option.value} value={option.value} label={option.label} />
+            ))}
+          </CheckboxList>
+        </FormLayout>
       )}
 
       {activeTab === 'appearance' && (
-        <div>
+        <FormLayout>
           <RadioList
             data-testid={AdminSettingsDataTestId.density}
             label='Density'
@@ -99,22 +92,21 @@ export function AdminSettings() {
               <RadioListItem key={option.value} value={option.value} label={option.label} />
             ))}
           </RadioList>
-
           <div data-testid={AdminSettingsDataTestId.betaField}>
             <Switch label='Beta features' value={draft.beta} onChange={(beta) => update({ beta })} />
           </div>
-
           <Selector
             data-testid={AdminSettingsDataTestId.model}
             label='Default model'
             value={draft.model}
             onChange={(model) => update({ model })}
             options={[...MODEL_OPTIONS]}
+            width={280}
           />
-        </div>
+        </FormLayout>
       )}
 
-      <footer>
+      <Stack gap={3}>
         {dirty && (
           <Banner
             data-testid={AdminSettingsDataTestId.unsavedBanner}
@@ -123,14 +115,16 @@ export function AdminSettings() {
             description='Save to apply your settings.'
           />
         )}
-        <Button data-testid={AdminSettingsDataTestId.save} label='Save changes' variant='primary' onClick={save} />
-        <Button
-          data-testid={AdminSettingsDataTestId.deleteTrigger}
-          label='Delete workspace'
-          variant='secondary'
-          onClick={() => setIsDeleteOpen(true)}
-        />
-      </footer>
+        <Stack direction='horizontal' gap={2} align='center'>
+          <Button data-testid={AdminSettingsDataTestId.save} label='Save changes' variant='primary' onClick={save} />
+          <Button
+            data-testid={AdminSettingsDataTestId.deleteTrigger}
+            label='Delete workspace'
+            variant='destructive'
+            onClick={() => setIsDeleteOpen(true)}
+          />
+        </Stack>
+      </Stack>
 
       <AlertDialog
         data-testid={AdminSettingsDataTestId.deleteDialog}
@@ -149,6 +143,6 @@ export function AdminSettings() {
       {savedToast && (
         <Toast type='info' body='Settings saved' isAutoHide={false} autoHideDuration={5000} onDismiss={dismissToast} />
       )}
-    </section>
+    </Stack>
   );
 }

--- a/examples/example-astryx-workspace/src/components/adminSettings/AdminSettings.tsx
+++ b/examples/example-astryx-workspace/src/components/adminSettings/AdminSettings.tsx
@@ -1,0 +1,154 @@
+import { AlertDialog } from '@astryxdesign/core/AlertDialog';
+import { Banner } from '@astryxdesign/core/Banner';
+import { Button } from '@astryxdesign/core/Button';
+import { CheckboxList, CheckboxListItem } from '@astryxdesign/core/CheckboxList';
+import { DateInput } from '@astryxdesign/core/DateInput';
+import { Field } from '@astryxdesign/core/Field';
+import { RadioList, RadioListItem } from '@astryxdesign/core/RadioList';
+import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
+import { Selector } from '@astryxdesign/core/Selector';
+import { Switch } from '@astryxdesign/core/Switch';
+import { Tab, TabList } from '@astryxdesign/core/TabList';
+import { Toast } from '@astryxdesign/core/Toast';
+import { useState } from 'react';
+
+import { AppDataTestId } from '../../AppDataTestId';
+import { useAdminSettings } from '../../hooks/useAdminSettings';
+import {
+  CHANNEL_OPTIONS,
+  DENSITY_OPTIONS,
+  MODEL_OPTIONS,
+  PLAN_OPTIONS,
+} from '../../models/SettingsModel';
+import { ADMIN_TABS, AdminSettingsDataTestId, ORG_INPUT_ID, PLAN_LABEL } from './AdminSettingsDataTestId';
+
+/**
+ * The admin settings console: a TabList over Field-wrapped form controls, a persistent
+ * footer with the unsaved-changes Banner + Save + Delete, a confirm AlertDialog, and a
+ * success Toast. State lives in {@link useAdminSettings}, so switching tabs never loses
+ * a draft edit.
+ */
+export function AdminSettings() {
+  const { draft, dirty, savedToast, update, save, dismissToast, reset } = useAdminSettings();
+  const [activeTab, setActiveTab] = useState<string>('general');
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  return (
+    <section data-testid={AppDataTestId.adminSection}>
+      <TabList data-testid={AdminSettingsDataTestId.tabs} value={activeTab} onChange={setActiveTab}>
+        {ADMIN_TABS.map((tab) => (
+          <Tab key={tab.value} value={tab.value} label={tab.label} />
+        ))}
+      </TabList>
+
+      {activeTab === 'general' && (
+        <div>
+          <Field
+            data-testid={AdminSettingsDataTestId.orgField}
+            label='Organization name'
+            inputID={ORG_INPUT_ID}
+            isRequired
+            status={
+              draft.orgName.trim().length > 0
+                ? undefined
+                : { type: 'error', message: 'Organization name is required' }
+            }>
+            <input
+              id={ORG_INPUT_ID}
+              data-testid={AdminSettingsDataTestId.orgInput}
+              value={draft.orgName}
+              onChange={(e) => update({ orgName: e.target.value })}
+            />
+          </Field>
+
+          <SegmentedControl value={draft.plan} onChange={(plan) => update({ plan })} label={PLAN_LABEL}>
+            {PLAN_OPTIONS.map((option) => (
+              <SegmentedControlItem key={option.value} value={option.value} label={option.label} />
+            ))}
+          </SegmentedControl>
+
+          <DateInput
+            data-testid={AdminSettingsDataTestId.renewal}
+            label='Renews'
+            value={draft.renewal}
+            onChange={(renewal) => renewal != null && update({ renewal })}
+          />
+        </div>
+      )}
+
+      {activeTab === 'notifications' && (
+        <CheckboxList
+          data-testid={AdminSettingsDataTestId.channels}
+          label='Notification channels'
+          value={draft.channels}
+          onChange={(channels) => update({ channels })}>
+          {CHANNEL_OPTIONS.map((option) => (
+            <CheckboxListItem key={option.value} value={option.value} label={option.label} />
+          ))}
+        </CheckboxList>
+      )}
+
+      {activeTab === 'appearance' && (
+        <div>
+          <RadioList
+            data-testid={AdminSettingsDataTestId.density}
+            label='Density'
+            value={draft.density}
+            onChange={(density) => update({ density })}>
+            {DENSITY_OPTIONS.map((option) => (
+              <RadioListItem key={option.value} value={option.value} label={option.label} />
+            ))}
+          </RadioList>
+
+          <div data-testid={AdminSettingsDataTestId.betaField}>
+            <Switch label='Beta features' value={draft.beta} onChange={(beta) => update({ beta })} />
+          </div>
+
+          <Selector
+            data-testid={AdminSettingsDataTestId.model}
+            label='Default model'
+            value={draft.model}
+            onChange={(model) => update({ model })}
+            options={[...MODEL_OPTIONS]}
+          />
+        </div>
+      )}
+
+      <footer>
+        {dirty && (
+          <Banner
+            data-testid={AdminSettingsDataTestId.unsavedBanner}
+            status='warning'
+            title='You have unsaved changes'
+            description='Save to apply your settings.'
+          />
+        )}
+        <Button data-testid={AdminSettingsDataTestId.save} label='Save changes' variant='primary' onClick={save} />
+        <Button
+          data-testid={AdminSettingsDataTestId.deleteTrigger}
+          label='Delete workspace'
+          variant='secondary'
+          onClick={() => setIsDeleteOpen(true)}
+        />
+      </footer>
+
+      <AlertDialog
+        data-testid={AdminSettingsDataTestId.deleteDialog}
+        isOpen={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        title='Delete workspace?'
+        description='This permanently removes the workspace and cannot be undone.'
+        actionLabel='Delete'
+        cancelLabel='Cancel'
+        onAction={() => {
+          reset();
+          setIsDeleteOpen(false);
+        }}
+      />
+
+      {savedToast && (
+        <Toast type='info' body='Settings saved' isAutoHide={false} autoHideDuration={5000} onDismiss={dismissToast} />
+      )}
+    </section>
+  );
+}

--- a/examples/example-astryx-workspace/src/components/adminSettings/AdminSettingsDataTestId.ts
+++ b/examples/example-astryx-workspace/src/components/adminSettings/AdminSettingsDataTestId.ts
@@ -1,6 +1,5 @@
 export const AdminSettingsDataTestId = {
   tabs: 'admin-tabs',
-  orgField: 'org-field',
   orgInput: 'org-input',
   channels: 'admin-channels',
   density: 'admin-density',
@@ -12,9 +11,6 @@ export const AdminSettingsDataTestId = {
   deleteTrigger: 'delete-button',
   deleteDialog: 'delete-dialog',
 } as const;
-
-/** Links the org-name `Field`'s label to its raw `<input>` via `inputID`/`id`. */
-export const ORG_INPUT_ID = 'org-name-control';
 
 /** Tab values/labels for the settings console. */
 export const ADMIN_TABS = [

--- a/examples/example-astryx-workspace/src/components/adminSettings/AdminSettingsDataTestId.ts
+++ b/examples/example-astryx-workspace/src/components/adminSettings/AdminSettingsDataTestId.ts
@@ -1,0 +1,27 @@
+export const AdminSettingsDataTestId = {
+  tabs: 'admin-tabs',
+  orgField: 'org-field',
+  orgInput: 'org-input',
+  channels: 'admin-channels',
+  density: 'admin-density',
+  betaField: 'admin-beta',
+  model: 'admin-model',
+  renewal: 'admin-renewal',
+  unsavedBanner: 'unsaved-banner',
+  save: 'save-button',
+  deleteTrigger: 'delete-button',
+  deleteDialog: 'delete-dialog',
+} as const;
+
+/** Links the org-name `Field`'s label to its raw `<input>` via `inputID`/`id`. */
+export const ORG_INPUT_ID = 'org-name-control';
+
+/** Tab values/labels for the settings console. */
+export const ADMIN_TABS = [
+  { value: 'general', label: 'General' },
+  { value: 'notifications', label: 'Notifications' },
+  { value: 'appearance', label: 'Appearance' },
+] as const;
+
+/** SegmentedControl / Switch accessible labels — anchored by role + label (no testid forwarded). */
+export const PLAN_LABEL = 'Plan';

--- a/examples/example-astryx-workspace/src/components/chatPanel/ChatPanel.tsx
+++ b/examples/example-astryx-workspace/src/components/chatPanel/ChatPanel.tsx
@@ -1,0 +1,64 @@
+import {
+  ChatComposer,
+  ChatLayout,
+  ChatMessage,
+  ChatMessageBubble,
+  ChatMessageList,
+  ChatSystemMessage,
+  ChatToolCalls,
+} from '@astryxdesign/core/Chat';
+import { Selector } from '@astryxdesign/core/Selector';
+
+import { AppDataTestId } from '../../AppDataTestId';
+import { useChatSession } from '../../hooks/ChatSessionProvider';
+import { MODEL_OPTIONS } from '../../models/SettingsModel';
+import { ChatPanelDataTestId } from './ChatPanelDataTestId';
+
+/**
+ * The chat section: a header with the model picker, then the Astryx ChatLayout — a
+ * scrolling message log with a docked composer. Sending routes through the shared
+ * chat session, which appends the user's message plus a deterministic assistant reply
+ * carrying a tool-call group.
+ */
+export function ChatPanel() {
+  const { messages, model, send, selectModel } = useChatSession();
+  const lastIndex = messages.length - 1;
+
+  return (
+    <section data-testid={AppDataTestId.chatSection}>
+      <header data-testid={ChatPanelDataTestId.header}>
+        <Selector
+          data-testid={ChatPanelDataTestId.modelSelector}
+          label='Model'
+          value={model}
+          onChange={selectModel}
+          options={[...MODEL_OPTIONS]}
+        />
+      </header>
+      <ChatLayout
+        data-testid={ChatPanelDataTestId.layout}
+        density='compact'
+        composer={
+          <ChatComposer data-testid={ChatPanelDataTestId.composer} placeholder='Type a message…' onSubmit={send} />
+        }>
+        <ChatMessageList
+          data-testid={ChatPanelDataTestId.messageList}
+          density='compact'
+          emptyState={<div data-testid={ChatPanelDataTestId.listEmptyState}>No messages yet — say hello 👋</div>}>
+          {messages.length > 0 && <ChatSystemMessage variant='divider'>Today</ChatSystemMessage>}
+          {messages.map((message, index) => (
+            <ChatMessage key={message.id} sender={message.sender} name={message.sender === 'user' ? 'You' : 'Assistant'}>
+              <ChatMessageBubble>{message.text}</ChatMessageBubble>
+              {message.toolCalls != null && (
+                <ChatToolCalls
+                  data-testid={index === lastIndex ? ChatPanelDataTestId.toolCalls : undefined}
+                  calls={message.toolCalls}
+                />
+              )}
+            </ChatMessage>
+          ))}
+        </ChatMessageList>
+      </ChatLayout>
+    </section>
+  );
+}

--- a/examples/example-astryx-workspace/src/components/chatPanel/ChatPanel.tsx
+++ b/examples/example-astryx-workspace/src/components/chatPanel/ChatPanel.tsx
@@ -8,6 +8,7 @@ import {
   ChatToolCalls,
 } from '@astryxdesign/core/Chat';
 import { Selector } from '@astryxdesign/core/Selector';
+import { Stack } from '@astryxdesign/core/Stack';
 
 import { AppDataTestId } from '../../AppDataTestId';
 import { useChatSession } from '../../hooks/ChatSessionProvider';
@@ -25,7 +26,7 @@ export function ChatPanel() {
   const lastIndex = messages.length - 1;
 
   return (
-    <section data-testid={AppDataTestId.chatSection}>
+    <Stack as='section' data-testid={AppDataTestId.chatSection} gap={3} height='100%'>
       <header data-testid={ChatPanelDataTestId.header}>
         <Selector
           data-testid={ChatPanelDataTestId.modelSelector}
@@ -33,17 +34,18 @@ export function ChatPanel() {
           value={model}
           onChange={selectModel}
           options={[...MODEL_OPTIONS]}
+          width={240}
         />
       </header>
       <ChatLayout
         data-testid={ChatPanelDataTestId.layout}
-        density='compact'
+        density='balanced'
         composer={
           <ChatComposer data-testid={ChatPanelDataTestId.composer} placeholder='Type a message…' onSubmit={send} />
         }>
         <ChatMessageList
           data-testid={ChatPanelDataTestId.messageList}
-          density='compact'
+          density='balanced'
           emptyState={<div data-testid={ChatPanelDataTestId.listEmptyState}>No messages yet — say hello 👋</div>}>
           {messages.length > 0 && <ChatSystemMessage variant='divider'>Today</ChatSystemMessage>}
           {messages.map((message, index) => (
@@ -59,6 +61,6 @@ export function ChatPanel() {
           ))}
         </ChatMessageList>
       </ChatLayout>
-    </section>
+    </Stack>
   );
 }

--- a/examples/example-astryx-workspace/src/components/chatPanel/ChatPanelDataTestId.ts
+++ b/examples/example-astryx-workspace/src/components/chatPanel/ChatPanelDataTestId.ts
@@ -1,0 +1,10 @@
+export const ChatPanelDataTestId = {
+  header: 'chat-header',
+  modelSelector: 'chat-model-selector',
+  layout: 'chat-layout',
+  messageList: 'chat-message-list',
+  listEmptyState: 'chat-empty-state',
+  composer: 'chat-composer',
+  /** Carried only by the latest assistant reply's tool-call group, so the anchor is unique. */
+  toolCalls: 'chat-tool-calls',
+} as const;

--- a/examples/example-astryx-workspace/src/components/commandBar/CommandBar.tsx
+++ b/examples/example-astryx-workspace/src/components/commandBar/CommandBar.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@astryxdesign/core/Button';
+import { CommandPalette } from '@astryxdesign/core/CommandPalette';
+import { createStaticSource } from '@astryxdesign/core/Typeahead';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AppDataTestId } from '../../AppDataTestId';
+import { useChatSession } from '../../hooks/ChatSessionProvider';
+import { COMMAND_PALETTE_LABEL, CommandBarDataTestId } from './CommandBarDataTestId';
+
+interface CommandItem {
+  id: string;
+  label: string;
+}
+
+const COMMANDS: CommandItem[] = [
+  { id: 'new-chat', label: 'New chat' },
+  { id: 'clear-chat', label: 'Clear chat' },
+  { id: 'open-settings', label: 'Open settings' },
+];
+
+const commandSource = createStaticSource<CommandItem>(COMMANDS);
+
+/**
+ * The ⌘K command bar: a trigger button plus the Astryx CommandPalette. Selecting an
+ * item routes ("Open settings" → /admin) or acts on the shared chat session. The
+ * wrapper carries the {@link AppDataTestId.commandBar} anchor; the palette dialog
+ * (a descendant) is reached by its accessible label.
+ */
+export function CommandBar() {
+  const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
+  const { clear } = useChatSession();
+
+  // ⌘K / Ctrl+K opens the palette, mirroring the on-screen hint.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsOpen(true);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const run = (id: string) => {
+    switch (id) {
+      case 'open-settings':
+        navigate('/admin');
+        break;
+      case 'new-chat':
+        clear();
+        navigate('/');
+        break;
+      case 'clear-chat':
+        clear();
+        break;
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <div data-testid={AppDataTestId.commandBar}>
+      <Button
+        data-testid={CommandBarDataTestId.trigger}
+        label='⌘K'
+        variant='secondary'
+        onClick={() => setIsOpen(true)}
+      />
+      <CommandPalette<CommandItem>
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        searchSource={commandSource}
+        label={COMMAND_PALETTE_LABEL}
+        onValueChange={run}
+      />
+    </div>
+  );
+}

--- a/examples/example-astryx-workspace/src/components/commandBar/CommandBarDataTestId.ts
+++ b/examples/example-astryx-workspace/src/components/commandBar/CommandBarDataTestId.ts
@@ -1,0 +1,6 @@
+export const CommandBarDataTestId = {
+  trigger: 'cmdk-trigger',
+} as const;
+
+/** Command palette dialog accessible label — the driver anchors the dialog by it. */
+export const COMMAND_PALETTE_LABEL = 'Commands';

--- a/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShell.tsx
+++ b/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShell.tsx
@@ -1,5 +1,8 @@
 import { AppShell } from '@astryxdesign/core/AppShell';
+import { Button } from '@astryxdesign/core/Button';
+import { HStack } from '@astryxdesign/core/HStack';
 import { SideNav, SideNavHeading, SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
+import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { TopNav, TopNavHeading } from '@astryxdesign/core/TopNav';
 import { MouseEvent } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -8,11 +11,18 @@ import { AppDataTestId } from '../../AppDataTestId';
 import { CommandBar } from '../commandBar/CommandBar';
 import { WorkspaceShellDataTestId } from './WorkspaceShellDataTestId';
 
+const APP_NAME = 'Astryx Workspace';
+
+const DEMO_DISCLAIMER =
+  'This is a demo — there is no real backend. Replies, saves, and deletes are simulated client-side and reset on reload.';
+
 /**
- * The Astryx AppShell chrome: a top nav (app heading + ⌘K command bar), a side nav
- * switching between the two co-equal sections (Chat / Admin), and the routed section
- * in the main region. Nav items keep their `href` for accessibility but navigate via
- * the router so both jsdom and the browser stay single-page.
+ * The Astryx AppShell chrome: a top nav (a route-derived section label + a subtle "Demo"
+ * disclaimer + the ⌘K command bar), a side nav switching between the two co-equal sections
+ * (Chat / Admin), and the routed section in the main region. The product name lives once
+ * (the SideNav heading); the top nav shows the *current section* so the two never repeat.
+ * Nav items keep their `href` for accessibility but navigate via the router so both jsdom
+ * and the browser stay single-page.
  */
 export function WorkspaceShell() {
   const navigate = useNavigate();
@@ -27,13 +37,25 @@ export function WorkspaceShell() {
   return (
     <AppShell
       data-testid={AppDataTestId.shell}
+      contentPadding={4}
       topNav={
-        <TopNav label='Workspace' heading={<TopNavHeading heading='Astryx Workspace' />} endContent={<CommandBar />} />
+        <TopNav
+          label='Workspace'
+          heading={<TopNavHeading heading={isAdmin ? 'Admin' : 'Chat'} />}
+          endContent={
+            <HStack gap={2} align='center'>
+              <Tooltip content={DEMO_DISCLAIMER} placement='below'>
+                <Button variant='ghost' size='sm' label='Demo' />
+              </Tooltip>
+              <CommandBar />
+            </HStack>
+          }
+        />
       }
       sideNav={
         <SideNav
           data-testid={WorkspaceShellDataTestId.sideNav}
-          header={<SideNavHeading heading='Astryx Workspace' headingHref='/' />}
+          header={<SideNavHeading heading={APP_NAME} headingHref='/' />}
           collapsible>
           <SideNavSection title='Workspace'>
             <SideNavItem

--- a/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShell.tsx
+++ b/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShell.tsx
@@ -1,0 +1,63 @@
+import { AppShell } from '@astryxdesign/core/AppShell';
+import { SideNav, SideNavHeading, SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
+import { TopNav, TopNavHeading } from '@astryxdesign/core/TopNav';
+import { MouseEvent } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+
+import { AppDataTestId } from '../../AppDataTestId';
+import { CommandBar } from '../commandBar/CommandBar';
+import { WorkspaceShellDataTestId } from './WorkspaceShellDataTestId';
+
+/**
+ * The Astryx AppShell chrome: a top nav (app heading + ⌘K command bar), a side nav
+ * switching between the two co-equal sections (Chat / Admin), and the routed section
+ * in the main region. Nav items keep their `href` for accessibility but navigate via
+ * the router so both jsdom and the browser stay single-page.
+ */
+export function WorkspaceShell() {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const isAdmin = pathname.startsWith('/admin');
+
+  const go = (to: string) => (e: MouseEvent) => {
+    e.preventDefault();
+    navigate(to);
+  };
+
+  return (
+    <AppShell
+      data-testid={AppDataTestId.shell}
+      topNav={
+        <TopNav label='Workspace' heading={<TopNavHeading heading='Astryx Workspace' />} endContent={<CommandBar />} />
+      }
+      sideNav={
+        <SideNav
+          data-testid={WorkspaceShellDataTestId.sideNav}
+          header={<SideNavHeading heading='Astryx Workspace' headingHref='/' />}
+          collapsible>
+          <SideNavSection title='Workspace'>
+            <SideNavItem
+              data-testid={WorkspaceShellDataTestId.chatNav}
+              label='Chat'
+              href='/'
+              isSelected={!isAdmin}
+              onClick={go('/')}
+            />
+            <SideNavItem
+              data-testid={WorkspaceShellDataTestId.adminNav}
+              label='Admin'
+              href='/admin'
+              isSelected={isAdmin}
+              onClick={go('/admin')}
+            />
+          </SideNavSection>
+          <SideNavSection title='Chats'>
+            <SideNavItem label='Trip planning' href='/' onClick={go('/')} />
+            <SideNavItem label='Code review' href='/' onClick={go('/')} />
+          </SideNavSection>
+        </SideNav>
+      }>
+      <Outlet />
+    </AppShell>
+  );
+}

--- a/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShellDataTestId.ts
+++ b/examples/example-astryx-workspace/src/components/workspaceShell/WorkspaceShellDataTestId.ts
@@ -1,0 +1,5 @@
+export const WorkspaceShellDataTestId = {
+  sideNav: 'workspace-sidenav',
+  chatNav: 'nav-chat',
+  adminNav: 'nav-admin',
+} as const;

--- a/examples/example-astryx-workspace/src/hooks/ChatSessionProvider.tsx
+++ b/examples/example-astryx-workspace/src/hooks/ChatSessionProvider.tsx
@@ -1,0 +1,52 @@
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+import { buildAssistantReply, buildUserMessage, ChatMessageModel } from '../models/ChatSession';
+import { defaultSettings } from '../models/SettingsModel';
+
+interface ChatSession {
+  messages: ChatMessageModel[];
+  model: string;
+  send: (text: string) => void;
+  clear: () => void;
+  selectModel: (model: string) => void;
+}
+
+const ChatSessionContext = createContext<ChatSession | null>(null);
+
+/**
+ * Holds the chat transcript and selected model. Lifted above the routes so the
+ * command palette ("New chat", "Clear chat") and the chat panel share one session.
+ * Replies are a deterministic client-side mock — no backend.
+ */
+export function ChatSessionProvider({ children }: { children: ReactNode }) {
+  const [messages, setMessages] = useState<ChatMessageModel[]>([]);
+  const [model, setModel] = useState<string>(defaultSettings.model);
+
+  const send = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    setMessages((prev) => {
+      const turn = prev.length;
+      return [...prev, buildUserMessage(trimmed, turn), buildAssistantReply(trimmed, turn + 1)];
+    });
+  }, []);
+
+  const clear = useCallback(() => setMessages([]), []);
+
+  const value = useMemo<ChatSession>(
+    () => ({ messages, model, send, clear, selectModel: setModel }),
+    [messages, model, send, clear],
+  );
+
+  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>;
+}
+
+export function useChatSession(): ChatSession {
+  const ctx = useContext(ChatSessionContext);
+  if (ctx == null) {
+    throw new Error('useChatSession must be used within a ChatSessionProvider');
+  }
+  return ctx;
+}

--- a/examples/example-astryx-workspace/src/hooks/useAdminSettings.ts
+++ b/examples/example-astryx-workspace/src/hooks/useAdminSettings.ts
@@ -1,0 +1,43 @@
+import { useMemo, useState } from 'react';
+
+import { defaultSettings, SettingsModel, settingsEqual } from '../models/SettingsModel';
+
+export interface AdminSettingsController {
+  draft: SettingsModel;
+  /** True when the draft diverges from the last saved baseline. */
+  dirty: boolean;
+  /** Shown briefly after a successful save. */
+  savedToast: boolean;
+  update: (patch: Partial<SettingsModel>) => void;
+  save: () => void;
+  dismissToast: () => void;
+  /** Resets the draft to the saved baseline (used by the delete-confirm flow). */
+  reset: () => void;
+}
+
+/**
+ * Owns the settings form state: an editable `draft` over a saved baseline. The
+ * unsaved-changes banner, the Save button, and the toast all derive from here so the
+ * component stays a thin view.
+ */
+export function useAdminSettings(): AdminSettingsController {
+  const [saved, setSaved] = useState<SettingsModel>(defaultSettings);
+  const [draft, setDraft] = useState<SettingsModel>(defaultSettings);
+  const [savedToast, setSavedToast] = useState(false);
+
+  return useMemo<AdminSettingsController>(
+    () => ({
+      draft,
+      dirty: !settingsEqual(draft, saved),
+      savedToast,
+      update: (patch) => setDraft((current) => ({ ...current, ...patch })),
+      save: () => {
+        setSaved(draft);
+        setSavedToast(true);
+      },
+      dismissToast: () => setSavedToast(false),
+      reset: () => setDraft(saved),
+    }),
+    [draft, saved, savedToast],
+  );
+}

--- a/examples/example-astryx-workspace/src/index.css
+++ b/examples/example-astryx-workspace/src/index.css
@@ -1,0 +1,12 @@
+/* Astryx ships pre-built CSS — import order maps to the layer cascade:
+   reset → component base → theme token overrides. */
+@import '@astryxdesign/core/reset.css';
+@import '@astryxdesign/core/astryx.css';
+@import '@astryxdesign/theme-neutral/theme.css';
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}

--- a/examples/example-astryx-workspace/src/main.tsx
+++ b/examples/example-astryx-workspace/src/main.tsx
@@ -1,0 +1,18 @@
+import { Theme } from '@astryxdesign/core/theme';
+import { neutralTheme } from '@astryxdesign/theme-neutral/built';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+import './index.css';
+
+// The Theme provider lives at the browser app shell. The jsdom suite renders <App />
+// without it (Astryx components render bare under jsdom; drivers read DOM/ARIA), so the
+// fully themed setup is exercised end-to-end only in the Playwright run.
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Theme theme={neutralTheme}>
+      <App />
+    </Theme>
+  </StrictMode>,
+);

--- a/examples/example-astryx-workspace/src/models/ChatSession.ts
+++ b/examples/example-astryx-workspace/src/models/ChatSession.ts
@@ -1,0 +1,32 @@
+import type { ChatToolCallItem } from '@astryxdesign/core/Chat';
+
+export type ChatSender = 'user' | 'assistant';
+
+export interface ChatMessageModel {
+  id: string;
+  sender: ChatSender;
+  text: string;
+  /** Present on assistant replies — the deterministic tool-call group. */
+  toolCalls?: ChatToolCallItem[];
+}
+
+/**
+ * The canned assistant reply. Sending appends the user's message plus this reply —
+ * deterministic so the same DOM and E2E assertions hold without a backend. The reply
+ * always carries a tool-call group, which `ChatPanelDriver.getToolCallCount()` reads.
+ */
+export function buildAssistantReply(prompt: string, index: number): ChatMessageModel {
+  return {
+    id: `assistant-${index}`,
+    sender: 'assistant',
+    text: `Here's a plan for "${prompt}". I searched a couple of sources first.`,
+    toolCalls: [
+      { name: 'search', target: 'web', status: 'complete', duration: '0.4s' },
+      { name: 'search', target: 'docs', status: 'complete', duration: '0.3s' },
+    ],
+  };
+}
+
+export function buildUserMessage(text: string, index: number): ChatMessageModel {
+  return { id: `user-${index}`, sender: 'user', text };
+}

--- a/examples/example-astryx-workspace/src/models/SettingsModel.ts
+++ b/examples/example-astryx-workspace/src/models/SettingsModel.ts
@@ -1,0 +1,68 @@
+import type { ISODateString } from '@astryxdesign/core/Calendar';
+
+/**
+ * The admin workspace settings, as a driver-facing value object. Field values are
+ * deliberately the same strings a human reads on screen (segment/option labels, day
+ * ISO date) so `AdminSettingsDriver.setValue`/`getValue` read like the UI.
+ */
+export interface SettingsModel {
+  orgName: string;
+  /** Segment value — see {@link PLAN_OPTIONS}. */
+  plan: string;
+  /** Checked channel labels — see {@link CHANNEL_OPTIONS}. */
+  channels: string[];
+  /** Radio value — see {@link DENSITY_OPTIONS}. */
+  density: string;
+  beta: boolean;
+  /** Selector option (value === label) — see {@link MODEL_OPTIONS}. */
+  model: string;
+  renewal: ISODateString;
+}
+
+export const PLAN_OPTIONS = [
+  { value: 'Free', label: 'Free' },
+  { value: 'Pro', label: 'Pro' },
+] as const;
+
+export const CHANNEL_OPTIONS = [
+  { value: 'Email', label: 'Email' },
+  { value: 'SMS', label: 'SMS' },
+  { value: 'Push', label: 'Push' },
+] as const;
+
+export const DENSITY_OPTIONS = [
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'compact', label: 'Compact' },
+] as const;
+
+/** Shared by the chat model picker and the admin "default model" Selector. */
+export const MODEL_OPTIONS = [
+  { value: 'Claude Sonnet', label: 'Claude Sonnet' },
+  { value: 'Claude Opus', label: 'Claude Opus' },
+  { value: 'Claude Haiku', label: 'Claude Haiku' },
+] as const;
+
+/** The saved baseline — matches the values drawn in the issue's admin mock. */
+export const defaultSettings: SettingsModel = {
+  orgName: 'Acme Inc',
+  plan: 'Free',
+  channels: [],
+  density: 'comfortable',
+  beta: false,
+  model: 'Claude Sonnet',
+  renewal: '2026-07-01' as ISODateString,
+};
+
+/** Structural equality, used to derive the unsaved-changes (dirty) state. */
+export function settingsEqual(a: SettingsModel, b: SettingsModel): boolean {
+  return (
+    a.orgName === b.orgName &&
+    a.plan === b.plan &&
+    a.density === b.density &&
+    a.beta === b.beta &&
+    a.model === b.model &&
+    a.renewal === b.renewal &&
+    a.channels.length === b.channels.length &&
+    a.channels.every((c) => b.channels.includes(c))
+  );
+}

--- a/examples/example-astryx-workspace/src/testing/AdminSettingsDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/AdminSettingsDriver.ts
@@ -4,7 +4,6 @@ import {
   ButtonDriver,
   CheckboxListDriver,
   DateInputDriver,
-  FieldDriver,
   RadioListDriver,
   SegmentedControlDriver,
   SelectorDriver,
@@ -49,7 +48,6 @@ export interface AdminSettingsSnapshot {
  */
 const parts = {
   tabs: { locator: byDataTestId(T.tabs), driver: TabListDriver },
-  orgField: { locator: byDataTestId(T.orgField), driver: FieldDriver },
   orgInput: { locator: byDataTestId(T.orgInput), driver: TextInputDriver },
   plan: { locator: locatorUtil.append(byRole('radiogroup'), byAriaLabel(PLAN_LABEL, 'Same')), driver: SegmentedControlDriver },
   channels: { locator: byDataTestId(T.channels), driver: CheckboxListDriver },
@@ -158,10 +156,6 @@ export class AdminSettingsDriver extends ComponentDriver<typeof parts> {
 
   get tabs(): TabListDriver {
     return this.parts.tabs;
-  }
-
-  get orgField(): FieldDriver {
-    return this.parts.orgField;
   }
 
   get deleteDialog(): AlertDialogDriver {

--- a/examples/example-astryx-workspace/src/testing/AdminSettingsDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/AdminSettingsDriver.ts
@@ -1,0 +1,174 @@
+import {
+  AlertDialogDriver,
+  BannerDriver,
+  ButtonDriver,
+  CheckboxListDriver,
+  DateInputDriver,
+  FieldDriver,
+  RadioListDriver,
+  SegmentedControlDriver,
+  SelectorDriver,
+  SwitchDriver,
+  TabListDriver,
+  TextInputDriver,
+  ToastDriver,
+} from '@atomic-testing/component-driver-astryx';
+import {
+  byAriaLabel,
+  byCssSelector,
+  byDataTestId,
+  byRole,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { AdminSettingsDataTestId as T, PLAN_LABEL } from '../components/adminSettings/AdminSettingsDataTestId';
+import { SettingsModel } from '../models/SettingsModel';
+
+/** Read-back of the form. `renewal` is the DateInput's displayed string, not ISO. */
+export interface AdminSettingsSnapshot {
+  orgName: string | null;
+  plan: string | null;
+  channels: string[];
+  density: string | null;
+  beta: boolean;
+  model: Optional<string>;
+  renewal: Optional<string>;
+}
+
+/**
+ * Composes the entire settings form into one page object. `setValue` drives each
+ * control through its shipped driver, switching tabs as needed — so the test reads as
+ * "fill the form and save", and the tab choreography stays here. SegmentedControl and
+ * Switch forward no testid, so they are anchored by role (+ accessible name).
+ */
+const parts = {
+  tabs: { locator: byDataTestId(T.tabs), driver: TabListDriver },
+  orgField: { locator: byDataTestId(T.orgField), driver: FieldDriver },
+  orgInput: { locator: byDataTestId(T.orgInput), driver: TextInputDriver },
+  plan: { locator: locatorUtil.append(byRole('radiogroup'), byAriaLabel(PLAN_LABEL, 'Same')), driver: SegmentedControlDriver },
+  channels: { locator: byDataTestId(T.channels), driver: CheckboxListDriver },
+  density: { locator: byDataTestId(T.density), driver: RadioListDriver },
+  beta: { locator: locatorUtil.append(byDataTestId(T.betaField), byRole('switch')), driver: SwitchDriver },
+  model: { locator: byDataTestId(T.model), driver: SelectorDriver },
+  renewal: { locator: byDataTestId(T.renewal), driver: DateInputDriver },
+  unsavedBanner: { locator: byDataTestId(T.unsavedBanner), driver: BannerDriver },
+  save: { locator: byDataTestId(T.save), driver: ButtonDriver },
+  deleteTrigger: { locator: byDataTestId(T.deleteTrigger), driver: ButtonDriver },
+  deleteDialog: { locator: byDataTestId(T.deleteDialog), driver: AlertDialogDriver },
+  toast: { locator: byCssSelector('.astryx-toast'), driver: ToastDriver },
+} satisfies ScenePart;
+
+export class AdminSettingsDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  /** Apply a (partial) settings draft, switching tabs to reach each control. */
+  async setValue(value: Partial<SettingsModel>): Promise<void> {
+    if (value.orgName !== undefined || value.plan !== undefined || value.renewal !== undefined) {
+      await this.parts.tabs.selectTab('General');
+      if (value.orgName !== undefined) {
+        await this.parts.orgInput.setValue(value.orgName);
+      }
+      if (value.plan !== undefined) {
+        await this.parts.plan.setValue(value.plan);
+      }
+      if (value.renewal !== undefined) {
+        await this.parts.renewal.pickDate(value.renewal);
+      }
+    }
+
+    if (value.channels !== undefined) {
+      await this.parts.tabs.selectTab('Notifications');
+      const checked = await this.parts.channels.getCheckedLabels();
+      for (const label of checked) {
+        if (!value.channels.includes(label)) {
+          await this.parts.channels.uncheckItemByLabel(label);
+        }
+      }
+      for (const label of value.channels) {
+        await this.parts.channels.checkItemByLabel(label);
+      }
+    }
+
+    if (value.density !== undefined || value.beta !== undefined || value.model !== undefined) {
+      await this.parts.tabs.selectTab('Appearance');
+      if (value.density !== undefined) {
+        await this.parts.density.selectByValue(value.density);
+      }
+      if (value.beta !== undefined) {
+        await (value.beta ? this.parts.beta.turnOn() : this.parts.beta.turnOff());
+      }
+      if (value.model !== undefined) {
+        await this.parts.model.selectByLabel(value.model);
+      }
+    }
+  }
+
+  /** Read the form back, tab by tab. `renewal` is the displayed date string. */
+  async getValue(): Promise<AdminSettingsSnapshot> {
+    await this.parts.tabs.selectTab('General');
+    const orgName = await this.parts.orgInput.getValue();
+    const plan = await this.parts.plan.getValue();
+    const renewal = await this.parts.renewal.getValue();
+
+    await this.parts.tabs.selectTab('Notifications');
+    const channels = await this.parts.channels.getCheckedLabels();
+
+    await this.parts.tabs.selectTab('Appearance');
+    const density = await this.parts.density.getValue();
+    const beta = await this.parts.beta.isOn();
+    const model = await this.parts.model.getSelectedLabel();
+
+    return { orgName, plan, channels, density, beta, model, renewal };
+  }
+
+  async save(): Promise<void> {
+    await this.parts.save.click();
+  }
+
+  /** Whether the unsaved-changes banner is showing. */
+  async hasUnsavedBanner(): Promise<boolean> {
+    return this.interactor.exists(this.parts.unsavedBanner.locator);
+  }
+
+  /** The save-confirmation toast message, or `undefined` when no toast is shown. */
+  async getToastMessage(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(this.parts.toast.locator))) {
+      return undefined;
+    }
+    return this.parts.toast.getMessage();
+  }
+
+  async openDeleteDialog(): Promise<void> {
+    await this.parts.deleteTrigger.click();
+  }
+
+  /** Open the delete dialog and either confirm (action) or cancel. */
+  async deleteWorkspace(confirm: boolean): Promise<void> {
+    await this.openDeleteDialog();
+    await (confirm ? this.parts.deleteDialog.clickAction() : this.parts.deleteDialog.clickCancel());
+  }
+
+  get tabs(): TabListDriver {
+    return this.parts.tabs;
+  }
+
+  get orgField(): FieldDriver {
+    return this.parts.orgField;
+  }
+
+  get deleteDialog(): AlertDialogDriver {
+    return this.parts.deleteDialog;
+  }
+
+  get driverName(): string {
+    return 'AdminSettingsDriver';
+  }
+}

--- a/examples/example-astryx-workspace/src/testing/ChatPanelDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/ChatPanelDriver.ts
@@ -1,0 +1,100 @@
+import {
+  ChatComposerDriver,
+  ChatLayoutDriver,
+  ChatMessageListDriver,
+  ChatToolCallsDriver,
+  SelectorDriver,
+} from '@atomic-testing/component-driver-astryx';
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { ChatPanelDataTestId } from '../components/chatPanel/ChatPanelDataTestId';
+
+export interface ChatMessageView {
+  sender: Optional<string>;
+  text: Optional<string>;
+}
+
+/**
+ * Composes the shipped chat drivers (layout, message list, composer, model selector,
+ * tool-call group) into a single conversational page object, so a test reads like a
+ * person using the chat: `send('…')`, `getLastAssistantText()`, `selectModel('…')`.
+ */
+const parts = {
+  modelSelector: { locator: byDataTestId(ChatPanelDataTestId.modelSelector), driver: SelectorDriver },
+  layout: { locator: byDataTestId(ChatPanelDataTestId.layout), driver: ChatLayoutDriver },
+  messageList: { locator: byDataTestId(ChatPanelDataTestId.messageList), driver: ChatMessageListDriver },
+  composer: { locator: byDataTestId(ChatPanelDataTestId.composer), driver: ChatComposerDriver },
+  toolCalls: { locator: byDataTestId(ChatPanelDataTestId.toolCalls), driver: ChatToolCallsDriver },
+} satisfies ScenePart;
+
+export class ChatPanelDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  /** Whether the composer's send button is enabled (false when the input is empty). */
+  async canSend(): Promise<boolean> {
+    return this.parts.composer.canSend();
+  }
+
+  /** Type a message and send it. */
+  async send(text: string): Promise<void> {
+    await this.parts.composer.appendValue(text);
+    await this.parts.composer.submit();
+  }
+
+  async getMessageCount(): Promise<number> {
+    return this.parts.messageList.getMessageCount();
+  }
+
+  /** Every message as `{ sender, text }`, read through the shipped `ChatMessageDriver`. */
+  async getMessages(): Promise<ChatMessageView[]> {
+    const count = await this.parts.messageList.getMessageCount();
+    const views: ChatMessageView[] = [];
+    for (let index = 0; index < count; index++) {
+      const message = await this.parts.messageList.getItemByIndex(index);
+      if (message == null) {
+        continue;
+      }
+      views.push({ sender: await message.getSender(), text: await message.getBubbleText() });
+    }
+    return views;
+  }
+
+  async getLastAssistantText(): Promise<Optional<string>> {
+    const count = await this.parts.messageList.getMessageCount();
+    if (count === 0) {
+      return undefined;
+    }
+    const last = await this.parts.messageList.getItemByIndex(count - 1);
+    return last?.getBubbleText();
+  }
+
+  /** Number of tool calls in the latest assistant reply (0 when none is rendered). */
+  async getToolCallCount(): Promise<number> {
+    if (!(await this.interactor.exists(this.parts.toolCalls.locator))) {
+      return 0;
+    }
+    return this.parts.toolCalls.getCallCount();
+  }
+
+  async selectModel(label: string): Promise<boolean> {
+    return this.parts.modelSelector.selectByLabel(label);
+  }
+
+  async getSelectedModel(): Promise<Optional<string>> {
+    return this.parts.modelSelector.getSelectedLabel();
+  }
+
+  get driverName(): string {
+    return 'ChatPanelDriver';
+  }
+}

--- a/examples/example-astryx-workspace/src/testing/CommandBarDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/CommandBarDriver.ts
@@ -1,0 +1,68 @@
+import { ButtonDriver, CommandPaletteDriver } from '@atomic-testing/component-driver-astryx';
+import {
+  byCssSelector,
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { COMMAND_PALETTE_LABEL, CommandBarDataTestId } from '../components/commandBar/CommandBarDataTestId';
+
+/**
+ * Wraps the shipped `CommandPaletteDriver` with its ⌘K trigger button. The palette
+ * renders a native `<dialog aria-label="…">` that forwards no testid, so it is anchored
+ * by that accessible label (matching the shipped CommandPalette suite).
+ */
+const parts = {
+  trigger: { locator: byDataTestId(CommandBarDataTestId.trigger), driver: ButtonDriver },
+  palette: {
+    locator: byCssSelector(`dialog[aria-label="${COMMAND_PALETTE_LABEL}"]`),
+    driver: CommandPaletteDriver,
+  },
+} satisfies ScenePart;
+
+export class CommandBarDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async isOpen(): Promise<boolean> {
+    return this.parts.palette.isOpen();
+  }
+
+  /** Open the palette via its trigger (no-op if already open). */
+  async open(): Promise<void> {
+    if (await this.parts.palette.isOpen()) {
+      return;
+    }
+    await this.parts.trigger.click();
+  }
+
+  /** The available command labels. */
+  async getCommands(): Promise<readonly string[]> {
+    await this.open();
+    return this.parts.palette.getOptionLabels();
+  }
+
+  /** Open the palette and run the command with the given label. */
+  async run(label: string): Promise<boolean> {
+    await this.open();
+    if (await this.parts.palette.selectByLabel(label)) {
+      return true;
+    }
+    // Fall back to searching first, in case the source does not bootstrap every item.
+    await this.parts.palette.search(label);
+    return this.parts.palette.selectByLabel(label);
+  }
+
+  async close(): Promise<void> {
+    await this.parts.palette.closeByEscape();
+  }
+
+  get driverName(): string {
+    return 'CommandBarDriver';
+  }
+}

--- a/examples/example-astryx-workspace/src/testing/WorkspaceDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/WorkspaceDriver.ts
@@ -1,0 +1,66 @@
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { AppDataTestId } from '../AppDataTestId';
+import { AdminSettingsDriver } from './AdminSettingsDriver';
+import { ChatPanelDriver } from './ChatPanelDriver';
+import { CommandBarDriver } from './CommandBarDriver';
+import { WorkspaceSection, WorkspaceShellDriver } from './WorkspaceShellDriver';
+
+/**
+ * The top-level page object: the shell + chat + admin + command bar composed into one,
+ * so an entire flow reads through a single object — `workspace.gotoAdmin()`,
+ * `workspace.chat.send('…')`, `workspace.commandBar.run('Open settings')`. This driver
+ * (and {@link workspaceParts}) is imported verbatim by both the Vitest DOM specs and the
+ * Playwright E2E specs; only the engine construction differs.
+ */
+const parts = {
+  shell: { locator: byDataTestId(AppDataTestId.shell), driver: WorkspaceShellDriver },
+  chat: { locator: byDataTestId(AppDataTestId.chatSection), driver: ChatPanelDriver },
+  admin: { locator: byDataTestId(AppDataTestId.adminSection), driver: AdminSettingsDriver },
+  commandBar: { locator: byDataTestId(AppDataTestId.commandBar), driver: CommandBarDriver },
+} satisfies ScenePart;
+
+export class WorkspaceDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async gotoChat(): Promise<void> {
+    await this.parts.shell.gotoChat();
+  }
+
+  async gotoAdmin(): Promise<void> {
+    await this.parts.shell.gotoAdmin();
+  }
+
+  async getCurrentSection(): Promise<WorkspaceSection | undefined> {
+    return this.parts.shell.getCurrentSection();
+  }
+
+  get shell(): WorkspaceShellDriver {
+    return this.parts.shell;
+  }
+
+  get chat(): ChatPanelDriver {
+    return this.parts.chat;
+  }
+
+  get admin(): AdminSettingsDriver {
+    return this.parts.admin;
+  }
+
+  get commandBar(): CommandBarDriver {
+    return this.parts.commandBar;
+  }
+
+  get driverName(): string {
+    return 'WorkspaceDriver';
+  }
+}

--- a/examples/example-astryx-workspace/src/testing/WorkspaceShellDriver.ts
+++ b/examples/example-astryx-workspace/src/testing/WorkspaceShellDriver.ts
@@ -1,0 +1,65 @@
+import { AppShellDriver, SideNavDriver, SideNavItemDriver } from '@atomic-testing/component-driver-astryx';
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { AppDataTestId } from '../AppDataTestId';
+import { WorkspaceShellDataTestId } from '../components/workspaceShell/WorkspaceShellDataTestId';
+
+export type WorkspaceSection = 'chat' | 'admin';
+
+/**
+ * Composes the shipped `AppShellDriver` + `SideNavDriver` + per-item `SideNavItemDriver`s
+ * into a navigation page object. The AppShell sub-part targets the *same* element this
+ * driver is anchored on (`'Same'`), since the shell root carries the testid.
+ */
+const parts = {
+  appShell: { locator: byDataTestId(AppDataTestId.shell, 'Same'), driver: AppShellDriver },
+  sideNav: { locator: byDataTestId(WorkspaceShellDataTestId.sideNav), driver: SideNavDriver },
+  chatNav: { locator: byDataTestId(WorkspaceShellDataTestId.chatNav), driver: SideNavItemDriver },
+  adminNav: { locator: byDataTestId(WorkspaceShellDataTestId.adminNav), driver: SideNavItemDriver },
+} satisfies ScenePart;
+
+export class WorkspaceShellDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  /** Click the Chat nav item — navigates to the chat section. */
+  async gotoChat(): Promise<void> {
+    await this.interactor.click(this.parts.chatNav.locator);
+  }
+
+  /** Click the Admin nav item — navigates to the admin settings section. */
+  async gotoAdmin(): Promise<void> {
+    await this.interactor.click(this.parts.adminNav.locator);
+  }
+
+  /** Which section the side nav currently marks as selected. */
+  async getCurrentSection(): Promise<WorkspaceSection | undefined> {
+    if (await this.parts.adminNav.isSelected()) {
+      return 'admin';
+    }
+    if (await this.parts.chatNav.isSelected()) {
+      return 'chat';
+    }
+    return undefined;
+  }
+
+  get appShell(): AppShellDriver {
+    return this.parts.appShell;
+  }
+
+  get sideNav(): SideNavDriver {
+    return this.parts.sideNav;
+  }
+
+  get driverName(): string {
+    return 'WorkspaceShellDriver';
+  }
+}

--- a/examples/example-astryx-workspace/src/testing/workspaceParts.ts
+++ b/examples/example-astryx-workspace/src/testing/workspaceParts.ts
@@ -1,0 +1,14 @@
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+import { AppDataTestId } from '../AppDataTestId';
+import { WorkspaceDriver } from './WorkspaceDriver';
+
+/**
+ * The single scene map shared by the DOM and E2E specs. Both resolve the whole app
+ * through one `WorkspaceDriver`, anchored on the root testid — this is the dedup story:
+ * the parts + composed drivers are imported by both runners unchanged; only the engine
+ * (React vs. Playwright) differs.
+ */
+export const workspaceParts = {
+  workspace: { locator: byDataTestId(AppDataTestId.root), driver: WorkspaceDriver },
+} satisfies ScenePart;

--- a/examples/example-astryx-workspace/src/vite-env.d.ts
+++ b/examples/example-astryx-workspace/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/example-astryx-workspace/tsconfig.json
+++ b/examples/example-astryx-workspace/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "e2e"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/example-astryx-workspace/tsconfig.node.json
+++ b/examples/example-astryx-workspace/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts", "vitest.setup.ts", "playwright.config.ts"]
+}

--- a/examples/example-astryx-workspace/vite.config.ts
+++ b/examples/example-astryx-workspace/vite.config.ts
@@ -1,10 +1,11 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-// Defaults to Vite's 5173; override with PORT for CI/parallel runs. `strictPort` makes
-// a busy port fail fast instead of silently drifting to another one (which would let the
-// Playwright `webServer` run against the wrong app).
-const port = Number(process.env.PORT) || 5173;
+// A dedicated port (8088) that no other app in this monorepo uses, so every example and
+// package-test app can run side by side without collision. Override with PORT for
+// CI/parallel runs. `strictPort` makes a busy port fail fast instead of silently drifting
+// to another one (which would let the Playwright `webServer` run against the wrong app).
+const port = Number(process.env.PORT) || 8088;
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/examples/example-astryx-workspace/vite.config.ts
+++ b/examples/example-astryx-workspace/vite.config.ts
@@ -1,0 +1,14 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// Defaults to Vite's 5173; override with PORT for CI/parallel runs. `strictPort` makes
+// a busy port fail fast instead of silently drifting to another one (which would let the
+// Playwright `webServer` run against the wrong app).
+const port = Number(process.env.PORT) || 5173;
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  server: { port, strictPort: true },
+});

--- a/examples/example-astryx-workspace/vitest.config.ts
+++ b/examples/example-astryx-workspace/vitest.config.ts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+// https://vitest.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    // Only the atomic-testing component tests. Playwright specs under /e2e are
+    // intentionally excluded — they run through the Playwright runner instead.
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+    testTimeout: 30000,
+  },
+});

--- a/examples/example-astryx-workspace/vitest.setup.ts
+++ b/examples/example-astryx-workspace/vitest.setup.ts
@@ -1,0 +1,84 @@
+// Tells React 19 it is running inside an act()-aware test environment, which the
+// atomic-testing ReactInteractor relies on to flush state updates during tests.
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// --- jsdom polyfills for Astryx overlay chrome ---------------------------------
+// jsdom implements none of the browser APIs the Astryx components reach for on
+// mount/focus/open. Without these stubs, merely rendering a Selector, CommandPalette,
+// AlertDialog, Toast, or DateInput popover throws and tears down the React subtree.
+// Drivers read state from ARIA/data attributes, so inert stubs are sufficient under
+// jsdom; the real open/close/layout behaviour is exercised by the Playwright E2E run.
+// Mirrors package-tests/component-driver-astryx-test/jest.setup.ts.
+
+// Native HTML Popover API (Selector/Tooltip/Popover surfaces).
+const elementProto = globalThis.HTMLElement?.prototype as unknown as {
+  showPopover?: () => void;
+  hidePopover?: () => void;
+  togglePopover?: () => boolean;
+};
+if (elementProto != null && typeof elementProto.showPopover !== 'function') {
+  elementProto.showPopover = () => {};
+  elementProto.hidePopover = () => {};
+  elementProto.togglePopover = () => false;
+}
+
+// <dialog> modal methods (CommandPalette/AlertDialog). Reflect the `open` attribute
+// the drivers read.
+const dialogProto = globalThis.HTMLDialogElement?.prototype as unknown as {
+  show?: () => void;
+  showModal?: () => void;
+  close?: (returnValue?: string) => void;
+};
+if (dialogProto != null && typeof dialogProto.showModal !== 'function') {
+  function openDialog(this: HTMLDialogElement): void {
+    this.open = true;
+  }
+  dialogProto.show = openDialog;
+  dialogProto.showModal = openDialog;
+  dialogProto.close = function close(this: HTMLDialogElement): void {
+    this.open = false;
+    this.dispatchEvent(new Event('close'));
+  };
+}
+
+// ResizeObserver / IntersectionObserver (scroll-aware chrome constructs these on mount).
+const g = globalThis as unknown as { ResizeObserver?: unknown; IntersectionObserver?: unknown };
+if (typeof g.ResizeObserver !== 'function') {
+  g.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+if (typeof g.IntersectionObserver !== 'function') {
+  g.IntersectionObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): [] {
+      return [];
+    }
+  };
+}
+
+// window.matchMedia (Toast reads the theme via useMediaQuery) and a no-op scrollTo
+// (dialog scroll-lock calls it on open).
+const win = globalThis.window as unknown as {
+  matchMedia?: (q: string) => unknown;
+  scrollTo?: () => void;
+};
+if (win != null && typeof win.matchMedia !== 'function') {
+  win.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+if (win != null) {
+  win.scrollTo = () => {};
+}


### PR DESCRIPTION
Closes #986.

A standalone example under `examples/example-astryx-workspace/` built on the **Astryx design system** (`@astryxdesign/core`, React 19), tested with **Vitest** (jsdom) + **Playwright** (chromium/firefox/webkit). Sibling to `example-mui-signup-form`; consumes `@atomic-testing/*` (`^0.89.0`) and `@astryxdesign/*` from npm like a real consumer.

## What it demonstrates

- **Driver composability** — shipped Astryx drivers composed into page-object drivers (`WorkspaceShellDriver`, `ChatPanelDriver`, `CommandBarDriver`, `AdminSettingsDriver`), composed again into one top-level `WorkspaceDriver`.
- **DOM/E2E dedup** — the Vitest DOM spec (`src/__tests__/workspace.test.tsx`) and the Playwright E2E spec (`e2e/workspace.spec.ts`) import the **same** `workspaceParts` scene + composed drivers; only the engine construction differs (`createTestEngine(<App/>, parts)` from `@atomic-testing/react-19` vs `createTestEngine(page, parts)` from `@atomic-testing/playwright`).
- **Readability** — tests read like a person using the app: open the command palette, jump to settings, toggle beta features, save, expect a toast.

## The app

One `AppShell` whose `SideNav` switches between two co-equal sections (`react-router-dom@7`):

- **Chat** (`/`) — a `ChatLayout` message log with a docked `ChatComposer` and a deterministic client-side mock reply (including a tool-call group), a model `Selector`, and a ⌘K `CommandPalette` ("New chat" / "Clear chat" / "Open settings").
- **Admin** (`/admin`) — a `TabList` settings console over `Field` / `TextInput` / `SegmentedControl` / `CheckboxList` / `RadioList` / `Switch` / `Selector` / `DateInput`, an unsaved-changes `Banner`, Save → `Toast`, and Delete → `AlertDialog`.

## Driver-gap protocol

The Astryx driver surface was **gap-free** — every action these scenarios need is a shipped driver method, so no monorepo `component-driver-astryx` change or publish was required (the gap protocol / `AskUserQuestion` was not triggered).

## Verification

- `pnpm check:type` ✓
- `pnpm test:dom` — 5/5 ✓
- `pnpm test:e2e` — 15/15 across chromium, firefox, webkit ✓

> Note on ports: the dev server / Playwright `webServer` default to `5173` and honor a `PORT` override (verified locally on a free port). `vitest.setup.ts` polyfills the browser overlay APIs jsdom lacks (Popover, `<dialog>` modal methods, `ResizeObserver`/`IntersectionObserver`, `matchMedia`); real overlay behaviour is covered by the Playwright run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
