### PR TITLE
feat(examples): MUI 9 + MUI-X 9 ticket triage console + upstream MUI-X driver gaps (#985)

### DIFF
--- a/examples/example-mui-ticket-console/.gitignore
+++ b/examples/example-mui-ticket-console/.gitignore
@@ -1,0 +1,23 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.sw?
+
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/examples/example-mui-ticket-console/README.md
+++ b/examples/example-mui-ticket-console/README.md
@@ -1,0 +1,94 @@
+# Example: MUI 9 + MUI-X 9 ticket triage console
+
+A data-dense **support ticket triage console** built on **MUI Material v9 + MUI-X v9** and **React 19**, tested with **Vitest** (jsdom) and **Playwright** (3 browsers) through [atomic-testing](https://github.com/atomic-testing/atomic-testing) component drivers.
+
+It is a sibling to [`example-mui-signup-form`](../example-mui-signup-form), and exists to show three things the library is for:
+
+1. **Driver composability** — small shipped drivers compose into page-object drivers (`FilterBarDriver`, `TicketGridDriver`, `TicketEditorDriver`, `TeamNavDriver`), which compose again into one top-level `TicketConsoleDriver`.
+2. **DOM/E2E dedup** — the *same* composed drivers, the *same* `parts` scene, and the *same* scenario flows are imported by both the Vitest DOM tests and the Playwright E2E specs. The only thing that differs is how the `TestEngine` is built.
+3. **Readability** — a test reads like a person triaging tickets: *filter to Open due this week, open the first ticket, reassign it to me, save, expect a success toast.*
+
+## The scenario
+
+```
+┌─ Tickets ───────────────────────────────────────┐
+│ [🔎 search] [Assignee ▾] [Status ▾] [Due ▭–▭]   │  ← FilterBar
+│ [ All | Mine | Overdue ]  (Tabs)                 │
+├──────────────┬──────────────────────────────────┤
+│ ▾ Web        │  # │ Title    │ Assignee │ Due │⋯ │
+│   Bugs       │ 12 │ Login... │ Ana      │ Mon │⋯ │  ← MUI-X DataGrid
+│   Features   │ 13 │ Crash... │ Bo       │ Tue │⋯ │
+│ ▾ Mobile     │ 14 │ Slow...  │ —        │ Wed │⋯ │
+│   Crashes    │                       11 tickets   │
+│   Triage     │  row / row-menu → Dialog → Snackbar│
+│ (TreeView)   │                                    │
+└──────────────┴──────────────────────────────────┘
+```
+
+- **Team / queue sidebar** — a MUI-X `SimpleTreeView`; selecting a queue filters the grid.
+- **Filter bar** — free-text search (`TextField`), assignee (`Autocomplete`), status (`Select`), and a due-date range (two `DesktopDatePicker`s).
+- **Views** — `Tabs`: All / Mine / Overdue.
+- **Grid** — the **community** MUI-X `DataGrid` of tickets, with a per-row action `Menu` (Edit / Assign to me / Close).
+- **Editor** — a `Dialog` with title `TextField` (required), status + priority `Select`s, assignee `Autocomplete`, label `Chip`s, a "watching" `Switch`, and a due-date `DatePicker`.
+- **Feedback** — a `Snackbar` on save.
+
+All state is client-side. The seed (`src/data`) is a small fixed fixture and the app uses a **fixed reference "today"** (`2026-06-15`), so "Due this week" / "Overdue" and every assertion are deterministic across the DOM and E2E runs.
+
+## The dedup story (the headline)
+
+The DOM test and the E2E spec are thin adapters around shared modules:
+
+| | DOM (`src/__tests__/ticketConsole.test.tsx`) | E2E (`e2e/ticketConsole.spec.ts`) |
+| --- | --- | --- |
+| Engine | `createTestEngine(<App/>, consoleParts)` from `@atomic-testing/react-19` | `createTestEngine(page, consoleParts)` from `@atomic-testing/playwright` |
+| Scene | `consoleParts` (imported) | `consoleParts` (imported) |
+| Flows | `triageFlow`, `emptyQueueFlow`, … (imported) | the same functions (imported) |
+
+Each scenario in [`src/testing/scenarios.ts`](src/testing/scenarios.ts) is written **once** as a flow over `TicketConsoleDriver`. For example:
+
+```ts
+export async function triageFlow(console: TicketConsoleDriver, assert: Assert) {
+  await console.waitUntilReady();
+  await console.filterBar.filterByStatus('Open');
+  await console.filterBar.setDueRange(week.from, week.to);
+  await console.grid.openRow(0);
+  await console.editor.setValue({ assignee: 'Me', priority: 'High' });
+  await console.editor.save();
+  assert.includes(await console.toast.getLabel(), 'saved');
+  assert.equal(await console.grid.getAssignee(0), 'Me');
+}
+```
+
+The composed drivers live next to the components they drive, in `src/components/<feature>/<Feature>Driver.ts`.
+
+## Running it
+
+```bash
+pnpm install            # standalone install (its own lockfile; see "Dependency wiring")
+pnpm dev                # manual smoke at http://localhost:8090
+pnpm test:dom           # Vitest (jsdom)
+pnpm test:e2e:chrome    # Playwright, Chromium only (fast iteration)
+pnpm test:e2e           # Playwright on chromium + firefox + webkit (webServer auto-starts vite)
+pnpm check:type         # tsc --noEmit
+```
+
+## Notes for driver authors
+
+### Two driver gaps were filled upstream
+
+This scenario needs to *set* a date picker and *select* a tree item — capabilities the shipped MUI-X v9 drivers did not have. They were added to the monorepo as general, reusable driver methods (not example-local workarounds):
+
+- `DesktopDatePickerDriver.setValue(date)` / `pickDate('yyyy-mm-dd')` — operates the calendar popup (open → page to the month → click the day), the one write path that behaves identically in jsdom and in real browsers.
+- `SimpleTreeViewDriver.selectItem(itemId)` — clicks the item's content row to select it.
+
+Because this example consumes those methods, it depends on `@atomic-testing/*@^0.90.0`. See *Dependency wiring* for how it runs before that version is published.
+
+### Community vs. premium DataGrid
+
+The example uses the **community** `@mui/x-data-grid` (no license watermark). The shipped `DataGridPremiumDriver` drives it unchanged — Premium, Pro, and Community render the same grid DOM (`role="row"`/`"gridcell"`, `data-rowindex`/`data-field`). Virtualization is disabled and the page size is larger than the seed, so the grid renders every row in jsdom exactly as in a browser and `getRowCount` matches across both.
+
+## Dependency wiring
+
+This example is a **standalone pnpm workspace** (its own `pnpm-lock.yaml`, intentionally not a member of the monorepo's root workspace), mirroring a real consumer install.
+
+It pins `@atomic-testing/*@^0.90.0`. Until 0.90.0 is published to npm, [`pnpm-workspace.yaml`](pnpm-workspace.yaml) carries an `overrides` block that resolves every atomic-testing dependency — direct and the packages' own transitive `workspace:*` deps — to the in-repo builds, so the example runs against the exact driver code the 0.90.0 release adds. **Once 0.90.0 is on npm, delete that overrides block** and the `^0.90.0` ranges resolve straight from the registry.

--- a/examples/example-mui-ticket-console/e2e/ticketConsole.spec.ts
+++ b/examples/example-mui-ticket-console/e2e/ticketConsole.spec.ts
@@ -1,0 +1,42 @@
+import { createTestEngine } from '@atomic-testing/playwright';
+import { expect, test } from '@playwright/test';
+
+import { consoleParts } from '../src/testing/consoleParts';
+import { type Assert, emptyQueueFlow, tabSwitchFlow, triageFlow, validationFlow } from '../src/testing/scenarios';
+
+// E2E adapter: build the engine from a real browser `page`. The scene (`consoleParts`) and the
+// scenario flows are the SAME modules the DOM test imports — only this engine construction differs.
+const assert: Assert = {
+  // The scenarios compare primitives (counts, cell text), so `toBe` is the right matcher and is the
+  // one Playwright surfaces on a generic value (its typed `toEqual` is narrowed for object asserts).
+  equal: (actual, expected) => expect(actual).toBe(expected),
+  isTrue: value => expect(value).toBe(true),
+  match: (actual, pattern) => expect(actual ?? '').toMatch(pattern),
+  includes: (haystack, needle) => expect(haystack ?? '').toContain(needle),
+};
+
+test.describe('Ticket triage console (E2E)', () => {
+  test('triage flow: filter, reassign, save, see it reflected', async ({ page }) => {
+    await page.goto('/');
+    const engine = createTestEngine(page, consoleParts);
+    await triageFlow(engine.parts.console, assert);
+  });
+
+  test('empty state: a queue with no tickets', async ({ page }) => {
+    await page.goto('/');
+    const engine = createTestEngine(page, consoleParts);
+    await emptyQueueFlow(engine.parts.console, assert);
+  });
+
+  test('tab switch: All -> Overdue', async ({ page }) => {
+    await page.goto('/');
+    const engine = createTestEngine(page, consoleParts);
+    await tabSwitchFlow(engine.parts.console, assert);
+  });
+
+  test('validation: clearing the required title blocks save', async ({ page }) => {
+    await page.goto('/');
+    const engine = createTestEngine(page, consoleParts);
+    await validationFlow(engine.parts.console, assert);
+  });
+});

--- a/examples/example-mui-ticket-console/index.html
+++ b/examples/example-mui-ticket-console/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic testing example - MUI 9 ticket triage console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/example-mui-ticket-console/package.json
+++ b/examples/example-mui-ticket-console/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "example-mui9-ticket-console",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check:type": "tsc --noEmit",
+    "test:dom": "vitest run",
+    "test:dom:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:chrome": "playwright test --project=chromium"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
+    "@mui/x-data-grid": "^9.7.0",
+    "@mui/x-date-pickers": "^9.7.0",
+    "@mui/x-tree-view": "^9.7.0",
+    "date-fns": "^4.1.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@atomic-testing/component-driver-html": "^0.90.0",
+    "@atomic-testing/component-driver-mui-v9": "^0.90.0",
+    "@atomic-testing/component-driver-mui-x-v9": "^0.90.0",
+    "@atomic-testing/core": "^0.90.0",
+    "@atomic-testing/dom-core": "^0.90.0",
+    "@atomic-testing/playwright": "^0.90.0",
+    "@atomic-testing/react-19": "^0.90.0",
+    "@playwright/test": "^1.61.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/example-mui-ticket-console/playwright.config.ts
+++ b/examples/example-mui-ticket-console/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Matches vite.config.ts — defaults to this example's dedicated port 8090, override with PORT.
+const port = process.env.PORT ?? '8090';
+const baseURL = `http://localhost:${port}`;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* 30s tolerates Vite's cold first-compile (the DataGrid bundle is large) and cross-browser CI variance. */
+  timeout: 30 * 1000,
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  /* Start the Vite dev server before the tests (auto-starts so agents/CI need no manual step). */
+  webServer: {
+    command: 'pnpm dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/examples/example-mui-ticket-console/pnpm-lock.yaml
+++ b/examples/example-mui-ticket-console/pnpm-lock.yaml
@@ -1,0 +1,2215 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  '@atomic-testing/core': link:../../packages/core
+  '@atomic-testing/dom-core': link:../../packages/dom-core
+  '@atomic-testing/react-core': link:../../packages/react-core
+  '@atomic-testing/react-18': link:../../packages/react-18
+  '@atomic-testing/react-19': link:../../packages/react-19
+  '@atomic-testing/playwright': link:../../packages/playwright
+  '@atomic-testing/component-driver-html': link:../../packages/component-driver-html
+  '@atomic-testing/component-driver-mui-v9': link:../../packages/component-driver-mui-v9
+  '@atomic-testing/component-driver-mui-x-v9': link:../../packages/component-driver-mui-x-v9
+
+importers:
+
+  .:
+    dependencies:
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled':
+        specifier: ^11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/icons-material':
+        specifier: ^9.0.0
+        version: 9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material':
+        specifier: ^9.0.0
+        version: 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-tree-view':
+        specifier: ^9.7.0
+        version: 9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.4.0
+      react:
+        specifier: ^19.2.3
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@atomic-testing/component-driver-html':
+        specifier: link:../../packages/component-driver-html
+        version: link:../../packages/component-driver-html
+      '@atomic-testing/component-driver-mui-v9':
+        specifier: link:../../packages/component-driver-mui-v9
+        version: link:../../packages/component-driver-mui-v9
+      '@atomic-testing/component-driver-mui-x-v9':
+        specifier: link:../../packages/component-driver-mui-x-v9
+        version: link:../../packages/component-driver-mui-x-v9
+      '@atomic-testing/core':
+        specifier: link:../../packages/core
+        version: link:../../packages/core
+      '@atomic-testing/dom-core':
+        specifier: link:../../packages/dom-core
+        version: link:../../packages/dom-core
+      '@atomic-testing/playwright':
+        specifier: link:../../packages/playwright
+        version: link:../../packages/playwright
+      '@atomic-testing/react-19':
+        specifier: link:../../packages/react-19
+        version: link:../../packages/react-19
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.3(vite@8.1.1)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.1
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(jsdom@29.1.1)(vite@8.1.1)
+
+packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/styled@11.14.1':
+    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mui/core-downloads-tracker@9.1.2':
+    resolution: {integrity: sha512-ZMufoA/YFOEVp48lskcAOTlQYwpdBk4Z++4yUgPDEfuLHIpxBx9g+urGmIBKOtr+7M0ZlYfCxSvrJpEE/S32sg==}
+
+  '@mui/icons-material@9.1.1':
+    resolution: {integrity: sha512-OXhm9DajemStb58AumM06DuPhHTa3XD36TFD4yf6WtJyNRO5DfEZbbnHlBg/US2Y2oOXwM/XurMTBOD6L/YYZw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^9.1.1
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/material@9.1.2':
+    resolution: {integrity: sha512-CN2U1etAL+6qZT2XjJR1Ibv7nyE2wBN3/28b5XpXjQFMtBKNlD45wQupODfJrm9PLanJ1DefocHWIQZ5PkSipQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^9.1.1
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/private-theming@9.1.1':
+    resolution: {integrity: sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/styled-engine@9.1.1':
+    resolution: {integrity: sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/system@9.1.2':
+    resolution: {integrity: sha512-oJxyyummOR6nV8ODF/yugasJ//pSsQxxfYCE9q9RU2Hef0f5RRzJ75M9zr5NvHDhzhGgrPstkaNrJtmcuz/Pdg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/types@9.1.1':
+    resolution: {integrity: sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@9.1.1':
+    resolution: {integrity: sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/x-data-grid@9.7.0':
+    resolution: {integrity: sha512-VqcYklIlhK1GSvHdsBzk6NxqQguzquqSyxL+yNEUwZpJgLIDJp16/kxV1wTaFJN8uRhUSo8SOnsVIsBr6zZwVg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-date-pickers@9.7.0':
+    resolution: {integrity: sha512-gW/tz5LKhuwl5/naP/gv4jT3e3Fcf9gXEemvsWX6gVnO4IkO/GUJ55UbPQVooLCaJRAR/WBwMXgen7nIrBTBMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
+        optional: true
+
+  '@mui/x-internals@9.7.0':
+    resolution: {integrity: sha512-fdBwh96L78QFZXB1oS2v8y33gXap3A6Tc0+AJYxYzLsRwx05WnaWhtHEwNV2x7zLXLaZ4ux0CCAJIgZ6kTP4FA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@mui/x-tree-view@9.7.0':
+    resolution: {integrity: sha512-kQjElE7Sx5STTW3DHxv4bHdvYRLzLdLziD7Her0F4+snIZ3k7QMAUfRsm3Oed9rvzU3MbvqRRlFRfvFKdM9kmw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-virtualizer@0.5.0':
+    resolution: {integrity: sha512-L87mSQnUtPGoAX8AZstQEr2I2/8hy41FWOQoL3g6iG/UzvF+VP8zJ9pF07qiEg+sH+iwnAxShLRlCrqEBS1qSw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react-transition-group@4.4.12':
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-js-pure@3.49.0:
+    resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  rolldown@1.1.3:
+    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.5:
+    resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
+
+  tldts@7.4.5:
+    resolution: {integrity: sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@8.1.1:
+    resolution: {integrity: sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
+
+snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.7)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.2.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.7)
+      '@emotion/utils': 1.4.2
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
+
+  '@exodus/bytes@1.15.1': {}
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mui/core-downloads-tracker@9.1.2': {}
+
+  '@mui/icons-material@9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/core-downloads-tracker': 9.1.2
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@types/react': 19.2.17
+
+  '@mui/private-theming@9.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/styled-engine@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+
+  '@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/private-theming': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/styled-engine': 9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@types/react': 19.2.17
+
+  '@mui/types@9.1.1(@types/react@19.2.17)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/utils@9.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-is: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/x-data-grid@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-virtualizer': 0.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-date-pickers@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      date-fns: 4.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internals@9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      core-js-pure: 3.49.0
+      react: 19.2.7
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+
+  '@mui/x-tree-view@9.7.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-virtualizer@0.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.137.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
+  '@popperjs/core@2.11.8': {}
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/parse-json@4.0.2': {}
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react-transition-group@4.4.12(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.1)':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.1
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.1)':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.1
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      cosmiconfig: 7.1.0
+      resolve: 1.22.12
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  callsites@3.1.0: {}
+
+  chai@6.2.2: {}
+
+  clsx@2.1.1: {}
+
+  convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  core-js-pure@3.49.0: {}
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.3
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  date-fns@4.4.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+
+  entities@8.0.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  find-root@1.1.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@11.5.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  object-assign@4.1.1: {}
+
+  obug@2.1.3: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  path-parse@1.0.7: {}
+
+  path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-is@19.2.7: {}
+
+  react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  react@19.2.7: {}
+
+  require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  rolldown@1.1.3:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.3
+      '@rolldown/binding-darwin-arm64': 1.1.3
+      '@rolldown/binding-darwin-x64': 1.1.3
+      '@rolldown/binding-freebsd-x64': 1.1.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
+      '@rolldown/binding-linux-arm64-gnu': 1.1.3
+      '@rolldown/binding-linux-arm64-musl': 1.1.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
+      '@rolldown/binding-linux-s390x-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-musl': 1.1.3
+      '@rolldown/binding-openharmony-arm64': 1.1.3
+      '@rolldown/binding-wasm32-wasi': 1.1.3
+      '@rolldown/binding-win32-arm64-msvc': 1.1.3
+      '@rolldown/binding-win32-x64-msvc': 1.1.3
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.5.7: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  stylis@4.2.0: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.5: {}
+
+  tldts@7.4.5:
+    dependencies:
+      tldts-core: 7.4.5
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.5
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  undici@7.28.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  vite@8.1.1:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.1.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.9(jsdom@29.1.1)(vite@8.1.1):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.1)
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.2.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.1
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yaml@1.10.3: {}

--- a/examples/example-mui-ticket-console/pnpm-workspace.yaml
+++ b/examples/example-mui-ticket-console/pnpm-workspace.yaml
@@ -1,0 +1,19 @@
+# Marks this example as its OWN pnpm workspace root so it installs standalone (its own lockfile,
+# isolated from the monorepo's root workspace — it is intentionally NOT a member of that one).
+#
+# The atomic-testing dependencies are declared at ^0.90.0 (the release that adds
+# DesktopDatePickerDriver.pickDate / setValue and SimpleTreeViewDriver.selectItem). Until 0.90.0 is
+# published to npm, these `overrides` resolve every atomic-testing dependency — direct AND the
+# packages' own transitive `workspace:*` deps — to the in-repo builds, so the example runs against
+# the exact driver code its tests rely on. Once 0.90.0 is on npm, delete this overrides block and
+# the ^0.90.0 ranges resolve straight from the registry, mirroring a real consumer install.
+overrides:
+  '@atomic-testing/core': link:../../packages/core
+  '@atomic-testing/dom-core': link:../../packages/dom-core
+  '@atomic-testing/react-core': link:../../packages/react-core
+  '@atomic-testing/react-18': link:../../packages/react-18
+  '@atomic-testing/react-19': link:../../packages/react-19
+  '@atomic-testing/playwright': link:../../packages/playwright
+  '@atomic-testing/component-driver-html': link:../../packages/component-driver-html
+  '@atomic-testing/component-driver-mui-v9': link:../../packages/component-driver-mui-v9
+  '@atomic-testing/component-driver-mui-x-v9': link:../../packages/component-driver-mui-x-v9

--- a/examples/example-mui-ticket-console/src/App.tsx
+++ b/examples/example-mui-ticket-console/src/App.tsx
@@ -1,0 +1,74 @@
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import { ThemeProvider } from '@mui/material/styles';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Typography from '@mui/material/Typography';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+
+import { AppDataTestId } from './AppDataTestId';
+import { FilterBar } from './components/filterBar/FilterBar';
+import { TeamNav } from './components/teamNav/TeamNav';
+import { TicketEditor } from './components/ticketEditor/TicketEditor';
+import { TicketGrid } from './components/ticketGrid/TicketGrid';
+import { type TabView } from './data/filterTickets';
+import { useTicketConsole } from './hooks/useTicketConsole';
+import { theme } from './themes/theme';
+
+const TABS: readonly TabView[] = ['All', 'Mine', 'Overdue'];
+
+export function App() {
+  const vm = useTicketConsole();
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <Box sx={{ p: 2 }}>
+          <Typography variant='h5' sx={{ mb: 2 }}>
+            Ticket triage console
+          </Typography>
+          <Box data-testid={AppDataTestId.console} sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+            <Paper variant='outlined' sx={{ width: 220, p: 1, flexShrink: 0 }}>
+              <TeamNav selectedQueue={vm.selectedQueue} onSelectQueue={vm.selectQueue} />
+            </Paper>
+
+            <Paper variant='outlined' sx={{ flex: 1, minWidth: 0 }}>
+              <FilterBar filters={vm.filters} onChange={vm.updateFilters} />
+              <Tabs
+                data-testid={AppDataTestId.tabs}
+                value={vm.tab}
+                onChange={(_event, value: TabView) => vm.selectTab(value)}
+                sx={{ px: 2, borderBottom: 1, borderColor: 'divider' }}>
+                {TABS.map(tab => (
+                  <Tab key={tab} label={tab} value={tab} />
+                ))}
+              </Tabs>
+              <Box sx={{ p: 2 }}>
+                <TicketGrid
+                  rows={vm.visible}
+                  onOpen={vm.openEditor}
+                  onAssignToMe={vm.assignToMe}
+                  onClose={vm.closeTicket}
+                />
+              </Box>
+            </Paper>
+          </Box>
+        </Box>
+
+        <TicketEditor ticket={vm.editingTicket} onSave={vm.save} onCancel={vm.closeEditor} />
+
+        <Snackbar
+          data-testid={AppDataTestId.toast}
+          open={vm.snackbar != null}
+          message={vm.snackbar ?? ''}
+          autoHideDuration={null}
+          onClose={vm.dismissSnackbar}
+        />
+      </LocalizationProvider>
+    </ThemeProvider>
+  );
+}

--- a/examples/example-mui-ticket-console/src/AppDataTestId.ts
+++ b/examples/example-mui-ticket-console/src/AppDataTestId.ts
@@ -1,0 +1,6 @@
+// App-shell test ids. Feature-level ids live next to each feature (e.g. FilterBarDataTestId).
+export const AppDataTestId = {
+  console: 'ticket-console',
+  tabs: 'view-tabs',
+  toast: 'save-toast',
+} as const;

--- a/examples/example-mui-ticket-console/src/__tests__/ticketConsole.test.tsx
+++ b/examples/example-mui-ticket-console/src/__tests__/ticketConsole.test.tsx
@@ -1,0 +1,29 @@
+import { createTestEngine } from '@atomic-testing/react-19';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { App } from '../App';
+import { consoleParts } from '../testing/consoleParts';
+import { type Assert, emptyQueueFlow, tabSwitchFlow, triageFlow, validationFlow } from '../testing/scenarios';
+
+// DOM adapter: build the engine by rendering <App/> with React 19. Everything else — the scene and
+// the scenario flows — is imported, unchanged, from the same modules the E2E spec uses.
+const assert: Assert = {
+  equal: (actual, expected, message) => expect(actual, message).toEqual(expected),
+  isTrue: (value, message) => expect(value, message).toBe(true),
+  match: (actual, pattern, message) => expect(actual ?? '', message).toMatch(pattern),
+  includes: (haystack, needle, message) => expect(haystack ?? '', message).toContain(needle),
+};
+
+describe('Ticket triage console (DOM)', () => {
+  let engine: ReturnType<typeof createTestEngine<typeof consoleParts>>;
+
+  beforeEach(() => {
+    engine = createTestEngine(<App />, consoleParts);
+  });
+  afterEach(() => engine.cleanUp());
+
+  test('triage flow: filter, reassign, save, see it reflected', () => triageFlow(engine.parts.console, assert));
+  test('empty state: a queue with no tickets', () => emptyQueueFlow(engine.parts.console, assert));
+  test('tab switch: All -> Overdue', () => tabSwitchFlow(engine.parts.console, assert));
+  test('validation: clearing the required title blocks save', () => validationFlow(engine.parts.console, assert));
+});

--- a/examples/example-mui-ticket-console/src/components/filterBar/FilterBar.tsx
+++ b/examples/example-mui-ticket-console/src/components/filterBar/FilterBar.tsx
@@ -1,0 +1,91 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+
+import { type Filters } from '../../data/filterTickets';
+import { parseCalendarDate, TODAY, toIso } from '../../data/today';
+import { ASSIGNEES, type Assignee, STATUSES, type Status } from '../../models/Ticket';
+import { FilterBarDataTestId } from './FilterBarDataTestId';
+
+const ANY_STATUS = 'Any status';
+
+// `referenceDate` makes an empty picker open on the seed's month, so date entry is deterministic
+// and the calendar never opens on the wall-clock month.
+const referenceDate = parseCalendarDate(TODAY);
+
+export interface FilterBarProps {
+  'data-testid'?: string;
+  filters: Filters;
+  onChange: (filters: Filters) => void;
+}
+
+export function FilterBar({ filters, onChange, ...rest }: FilterBarProps) {
+  const patch = (partial: Partial<Filters>) => onChange({ ...filters, ...partial });
+
+  return (
+    <Stack
+      data-testid={rest['data-testid'] ?? FilterBarDataTestId.root}
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={2}
+      sx={{ p: 2, alignItems: { md: 'center' } }}>
+      <TextField
+        data-testid={FilterBarDataTestId.search}
+        label='Search'
+        size='small'
+        value={filters.search}
+        onChange={event => patch({ search: event.target.value })}
+      />
+
+      <Autocomplete
+        data-testid={FilterBarDataTestId.assignee}
+        sx={{ minWidth: 180 }}
+        options={ASSIGNEES as readonly Assignee[]}
+        value={filters.assignee}
+        onChange={(_event, value) => patch({ assignee: value })}
+        renderInput={params => <TextField {...params} label='Assignee' size='small' />}
+      />
+
+      <FormControl size='small' sx={{ minWidth: 160 }}>
+        <InputLabel id='filter-status-label'>Status</InputLabel>
+        <Select
+          data-testid={FilterBarDataTestId.status}
+          labelId='filter-status-label'
+          label='Status'
+          value={filters.status ?? ''}
+          onChange={event => patch({ status: (event.target.value as Status) || null })}>
+          <MenuItem value=''>{ANY_STATUS}</MenuItem>
+          {STATUSES.map(status => (
+            <MenuItem key={status} value={status}>
+              {status}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <div data-testid={FilterBarDataTestId.dueFrom}>
+        <DesktopDatePicker
+          label='Due from'
+          slotProps={{ textField: { size: 'small' } }}
+          referenceDate={referenceDate}
+          value={filters.dueFrom != null ? parseCalendarDate(filters.dueFrom) : null}
+          onChange={date => patch({ dueFrom: date != null ? toIso(date) : null })}
+        />
+      </div>
+
+      <div data-testid={FilterBarDataTestId.dueTo}>
+        <DesktopDatePicker
+          label='Due to'
+          slotProps={{ textField: { size: 'small' } }}
+          referenceDate={referenceDate}
+          value={filters.dueTo != null ? parseCalendarDate(filters.dueTo) : null}
+          onChange={date => patch({ dueTo: date != null ? toIso(date) : null })}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/examples/example-mui-ticket-console/src/components/filterBar/FilterBarDataTestId.ts
+++ b/examples/example-mui-ticket-console/src/components/filterBar/FilterBarDataTestId.ts
@@ -1,0 +1,8 @@
+export const FilterBarDataTestId = {
+  root: 'filter-bar',
+  search: 'filter-search',
+  assignee: 'filter-assignee',
+  status: 'filter-status',
+  dueFrom: 'filter-due-from',
+  dueTo: 'filter-due-to',
+} as const;

--- a/examples/example-mui-ticket-console/src/components/filterBar/FilterBarDriver.ts
+++ b/examples/example-mui-ticket-console/src/components/filterBar/FilterBarDriver.ts
@@ -1,0 +1,69 @@
+import { AutoCompleteDriver, SelectDriver, TextFieldDriver } from '@atomic-testing/component-driver-mui-v9';
+import { DesktopDatePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { FilterBarDataTestId } from './FilterBarDataTestId';
+
+const parts = {
+  search: { locator: byDataTestId(FilterBarDataTestId.search), driver: TextFieldDriver },
+  assignee: { locator: byDataTestId(FilterBarDataTestId.assignee), driver: AutoCompleteDriver },
+  status: { locator: byDataTestId(FilterBarDataTestId.status), driver: SelectDriver },
+  dueFrom: { locator: byDataTestId(FilterBarDataTestId.dueFrom), driver: DesktopDatePickerDriver },
+  dueTo: { locator: byDataTestId(FilterBarDataTestId.dueTo), driver: DesktopDatePickerDriver },
+} satisfies ScenePart;
+
+export interface ActiveFilters {
+  search: string;
+  assignee: string | null;
+  status: string | null;
+  dueFrom: string | undefined;
+  dueTo: string | undefined;
+}
+
+// Page-object driver for the filter bar. Composes the shipped text/autocomplete/select/date-picker
+// drivers — including the new DesktopDatePicker `pickDate` — behind triage-oriented method names.
+export class FilterBarDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async search(text: string): Promise<void> {
+    await this.parts.search.setValue(text);
+  }
+
+  async filterByAssignee(name: string): Promise<void> {
+    await this.parts.assignee.setValue(name);
+  }
+
+  async filterByStatus(label: string): Promise<void> {
+    await this.parts.status.selectByLabel(label);
+  }
+
+  /** Set the due-date range by operating both desktop date pickers. Dates are `yyyy-mm-dd`. */
+  async setDueRange(fromIso: string, toIso: string): Promise<void> {
+    await this.parts.dueFrom.pickDate(fromIso);
+    await this.parts.dueTo.pickDate(toIso);
+  }
+
+  async getActiveFilters(): Promise<ActiveFilters> {
+    const [search, assignee, status, dueFrom, dueTo] = await Promise.all([
+      this.parts.search.getValue(),
+      this.parts.assignee.getValue(),
+      this.parts.status.getSelectedLabel(),
+      this.parts.dueFrom.getValueText(),
+      this.parts.dueTo.getValueText(),
+    ]);
+    return { search: search ?? '', assignee, status, dueFrom, dueTo };
+  }
+
+  override get driverName(): string {
+    return 'FilterBarDriver';
+  }
+}

--- a/examples/example-mui-ticket-console/src/components/teamNav/TeamNav.tsx
+++ b/examples/example-mui-ticket-console/src/components/teamNav/TeamNav.tsx
@@ -1,0 +1,39 @@
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+
+import { TEAMS } from '../../data/seed';
+import { TEAM_TREE_ID, TeamNavDataTestId } from './TeamNavDataTestId';
+
+const QUEUE_IDS = new Set(TEAMS.flatMap(team => team.queues.map(queue => queue.id)));
+
+export interface TeamNavProps {
+  'data-testid'?: string;
+  selectedQueue: string | null;
+  onSelectQueue: (queueId: string | null) => void;
+}
+
+// Team -> queue sidebar. Selecting a queue (a leaf) filters the grid; selecting a team (a branch)
+// only expands/collapses it. State is controlled by the console hook.
+export function TeamNav({ selectedQueue, onSelectQueue, ...rest }: TeamNavProps) {
+  return (
+    <div data-testid={rest['data-testid'] ?? TeamNavDataTestId.root}>
+      <SimpleTreeView
+        id={TEAM_TREE_ID}
+        defaultExpandedItems={TEAMS.map(team => team.id)}
+        selectedItems={selectedQueue}
+        onSelectedItemsChange={(_event, itemId) => {
+          if (itemId != null && QUEUE_IDS.has(itemId)) {
+            onSelectQueue(itemId);
+          }
+        }}>
+        {TEAMS.map(team => (
+          <TreeItem key={team.id} itemId={team.id} label={team.label}>
+            {team.queues.map(queue => (
+              <TreeItem key={queue.id} itemId={queue.id} label={queue.label} />
+            ))}
+          </TreeItem>
+        ))}
+      </SimpleTreeView>
+    </div>
+  );
+}

--- a/examples/example-mui-ticket-console/src/components/teamNav/TeamNavDataTestId.ts
+++ b/examples/example-mui-ticket-console/src/components/teamNav/TeamNavDataTestId.ts
@@ -1,0 +1,8 @@
+export const TeamNavDataTestId = {
+  root: 'team-nav',
+} as const;
+
+// The SimpleTreeView's explicit DOM id, so tree item element ids are the deterministic
+// `${TEAM_TREE_ID}-${itemId}` the driver targets (instead of MUI's environment-dependent
+// auto-generated prefix).
+export const TEAM_TREE_ID = 'team-tree';

--- a/examples/example-mui-ticket-console/src/components/teamNav/TeamNavDriver.ts
+++ b/examples/example-mui-ticket-console/src/components/teamNav/TeamNavDriver.ts
@@ -1,0 +1,59 @@
+import { SimpleTreeViewDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import {
+  byCssSelector,
+  byRole,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  locatorUtil,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { TEAM_TREE_ID } from './TeamNavDataTestId';
+
+const parts = {
+  tree: {
+    locator: byRole('tree'),
+    driver: SimpleTreeViewDriver,
+  },
+} satisfies ScenePart;
+
+// Page-object driver for the team/queue sidebar. Wraps the shipped SimpleTreeViewDriver — including
+// its new `selectItem` action — behind queue-oriented method names.
+export class TeamNavDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async expandTeam(teamId: string): Promise<void> {
+    await this.parts.tree.expandItem(teamId);
+  }
+
+  async collapseTeam(teamId: string): Promise<void> {
+    await this.parts.tree.collapseItem(teamId);
+  }
+
+  /** Select a queue (tree leaf), which filters the grid to that queue. */
+  async selectQueue(queueId: string): Promise<void> {
+    await this.parts.tree.selectItem(queueId);
+  }
+
+  async isQueueSelected(queueId: string): Promise<boolean> {
+    return this.parts.tree.isSelected(queueId);
+  }
+
+  /** The labels of the queues under a team, in document order. Expands the team first if needed. */
+  async getQueues(teamId: string): Promise<string[]> {
+    await this.parts.tree.expandItem(teamId);
+    const childItems = locatorUtil.append(this.locator, byCssSelector(`[id$="-${teamId}"] [role=treeitem]`));
+    const ids = await this.interactor.getAttribute(childItems, 'id', true);
+    const queueIds = ids.map(id => id.replace(`${TEAM_TREE_ID}-`, ''));
+    const labels = await Promise.all(queueIds.map(queueId => this.parts.tree.getItemLabel(queueId)));
+    return labels.filter((label): label is string => label != null);
+  }
+
+  override get driverName(): string {
+    return 'TeamNavDriver';
+  }
+}

--- a/examples/example-mui-ticket-console/src/components/ticketConsole/TicketConsoleDriver.ts
+++ b/examples/example-mui-ticket-console/src/components/ticketConsole/TicketConsoleDriver.ts
@@ -1,0 +1,71 @@
+import { SnackbarDriver, TabsDriver } from '@atomic-testing/component-driver-mui-v9';
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { AppDataTestId } from '../../AppDataTestId';
+import { FilterBarDataTestId } from '../filterBar/FilterBarDataTestId';
+import { FilterBarDriver } from '../filterBar/FilterBarDriver';
+import { TeamNavDataTestId } from '../teamNav/TeamNavDataTestId';
+import { TeamNavDriver } from '../teamNav/TeamNavDriver';
+import { TicketEditorDataTestId } from '../ticketEditor/TicketEditorDataTestId';
+import { TicketEditorDriver } from '../ticketEditor/TicketEditorDriver';
+import { TicketGridDataTestId } from '../ticketGrid/TicketGridDataTestId';
+import { TicketGridDriver } from '../ticketGrid/TicketGridDriver';
+
+const parts = {
+  teamNav: { locator: byDataTestId(TeamNavDataTestId.root), driver: TeamNavDriver },
+  filterBar: { locator: byDataTestId(FilterBarDataTestId.root), driver: FilterBarDriver },
+  grid: { locator: byDataTestId(TicketGridDataTestId.root), driver: TicketGridDriver },
+  tabs: { locator: byDataTestId(AppDataTestId.tabs), driver: TabsDriver },
+  // The editor dialog and save toast portal to <body>, so they are addressed from the document Root.
+  editor: { locator: byDataTestId(TicketEditorDataTestId.root, 'Root'), driver: TicketEditorDriver },
+  toast: { locator: byDataTestId(AppDataTestId.toast, 'Root'), driver: SnackbarDriver },
+} satisfies ScenePart;
+
+// The top-level page object: one object a test reads end-to-end through. It composes the four
+// feature page objects plus the view tabs and the save toast, so a scenario reads like a person
+// triaging tickets.
+export class TicketConsoleDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  get teamNav(): TeamNavDriver {
+    return this.parts.teamNav;
+  }
+
+  get filterBar(): FilterBarDriver {
+    return this.parts.filterBar;
+  }
+
+  get grid(): TicketGridDriver {
+    return this.parts.grid;
+  }
+
+  get tabs(): TabsDriver {
+    return this.parts.tabs;
+  }
+
+  get editor(): TicketEditorDriver {
+    return this.parts.editor;
+  }
+
+  get toast(): SnackbarDriver {
+    return this.parts.toast;
+  }
+
+  /** Wait for the grid to finish its first render before a scenario starts reading rows. */
+  async waitUntilReady(timeoutMs: number = 10000): Promise<void> {
+    await this.grid.waitForLoad(timeoutMs);
+  }
+
+  override get driverName(): string {
+    return 'TicketConsoleDriver';
+  }
+}

--- a/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditor.tsx
+++ b/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditor.tsx
@@ -1,0 +1,176 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { useState } from 'react';
+
+import { parseCalendarDate, TODAY, toIso } from '../../data/today';
+import {
+  ASSIGNEES,
+  type Assignee,
+  PRIORITIES,
+  type Priority,
+  STATUSES,
+  type Status,
+  type Ticket,
+  type TicketEdit,
+  toEdit,
+} from '../../models/Ticket';
+import { labelChipTestId, TicketEditorDataTestId as TID } from './TicketEditorDataTestId';
+
+export interface TicketEditorProps {
+  'data-testid'?: string;
+  ticket: Ticket | null;
+  onSave: (edit: TicketEdit) => void;
+  onCancel: () => void;
+}
+
+// The editor dialog. Open state is driven by `ticket` (open when non-null); the inner form is keyed
+// by ticket id so its draft state resets cleanly each time a different ticket is opened.
+export function TicketEditor({ ticket, onSave, onCancel, ...rest }: TicketEditorProps) {
+  return (
+    <Dialog
+      data-testid={rest['data-testid'] ?? TID.root}
+      open={ticket != null}
+      onClose={onCancel}
+      fullWidth
+      maxWidth='sm'>
+      {ticket != null && <TicketEditorForm key={ticket.id} ticket={ticket} onSave={onSave} onCancel={onCancel} />}
+    </Dialog>
+  );
+}
+
+function TicketEditorForm({
+  ticket,
+  onSave,
+  onCancel,
+}: {
+  ticket: Ticket;
+  onSave: (edit: TicketEdit) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState<TicketEdit>(() => toEdit(ticket));
+  const [titleError, setTitleError] = useState<string | undefined>(undefined);
+
+  const patch = (partial: Partial<TicketEdit>) => setDraft(prev => ({ ...prev, ...partial }));
+
+  const save = () => {
+    if (draft.title.trim().length === 0) {
+      setTitleError('Title is required');
+      return;
+    }
+    onSave(draft);
+  };
+
+  return (
+    <>
+      <DialogTitle>Edit ticket #{ticket.id}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            data-testid={TID.title}
+            label='Title'
+            value={draft.title}
+            error={titleError != null}
+            helperText={titleError}
+            onChange={event => {
+              patch({ title: event.target.value });
+              setTitleError(undefined);
+            }}
+          />
+
+          <FormControl fullWidth>
+            <InputLabel id='editor-status-label'>Status</InputLabel>
+            <Select
+              data-testid={TID.status}
+              labelId='editor-status-label'
+              label='Status'
+              value={draft.status}
+              onChange={event => patch({ status: event.target.value as Status })}>
+              {STATUSES.map(status => (
+                <MenuItem key={status} value={status}>
+                  {status}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth>
+            <InputLabel id='editor-priority-label'>Priority</InputLabel>
+            <Select
+              data-testid={TID.priority}
+              labelId='editor-priority-label'
+              label='Priority'
+              value={draft.priority}
+              onChange={event => patch({ priority: event.target.value as Priority })}>
+              {PRIORITIES.map(priority => (
+                <MenuItem key={priority} value={priority}>
+                  {priority}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Autocomplete
+            data-testid={TID.assignee}
+            options={ASSIGNEES as readonly Assignee[]}
+            value={draft.assignee}
+            onChange={(_event, value) => patch({ assignee: value })}
+            renderInput={params => <TextField {...params} label='Assignee' />}
+          />
+
+          <Stack direction='row' spacing={1} sx={{ flexWrap: 'wrap' }}>
+            {draft.labels.map(label => (
+              <Chip
+                key={label}
+                data-testid={labelChipTestId(label)}
+                label={label}
+                onDelete={() => patch({ labels: draft.labels.filter(other => other !== label) })}
+              />
+            ))}
+          </Stack>
+
+          <FormControlLabel
+            control={
+              <Switch
+                data-testid={TID.watching}
+                checked={draft.watching}
+                onChange={event => patch({ watching: event.target.checked })}
+              />
+            }
+            label='Watching'
+          />
+
+          <div data-testid={TID.due}>
+            <DesktopDatePicker
+              label='Due'
+              referenceDate={parseCalendarDate(TODAY)}
+              value={parseCalendarDate(draft.due)}
+              onChange={date => date != null && patch({ due: toIso(date) })}
+            />
+          </div>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button data-testid={TID.cancel} onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button data-testid={TID.save} variant='contained' onClick={save}>
+          Save
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditorDataTestId.ts
+++ b/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditorDataTestId.ts
@@ -1,0 +1,13 @@
+export const TicketEditorDataTestId = {
+  root: 'ticket-editor',
+  title: 'editor-title',
+  status: 'editor-status',
+  priority: 'editor-priority',
+  assignee: 'editor-assignee',
+  watching: 'editor-watching',
+  due: 'editor-due',
+  save: 'editor-save',
+  cancel: 'editor-cancel',
+} as const;
+
+export const labelChipTestId = (label: string): string => `editor-label-${label}`;

--- a/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditorDriver.ts
+++ b/examples/example-mui-ticket-console/src/components/ticketEditor/TicketEditorDriver.ts
@@ -1,0 +1,126 @@
+import {
+  AutoCompleteDriver,
+  ButtonDriver,
+  ChipDriver,
+  SelectDriver,
+  SwitchDriver,
+  TextFieldDriver,
+} from '@atomic-testing/component-driver-mui-v9';
+import { DesktopDatePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import {
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import type { TicketEdit } from '../../models/Ticket';
+import { labelChipTestId, TicketEditorDataTestId as TID } from './TicketEditorDataTestId';
+
+const parts = {
+  title: { locator: byDataTestId(TID.title), driver: TextFieldDriver },
+  status: { locator: byDataTestId(TID.status), driver: SelectDriver },
+  priority: { locator: byDataTestId(TID.priority), driver: SelectDriver },
+  assignee: { locator: byDataTestId(TID.assignee), driver: AutoCompleteDriver },
+  watching: { locator: byDataTestId(TID.watching), driver: SwitchDriver },
+  due: { locator: byDataTestId(TID.due), driver: DesktopDatePickerDriver },
+  save: { locator: byDataTestId(TID.save), driver: ButtonDriver },
+  cancel: { locator: byDataTestId(TID.cancel), driver: ButtonDriver },
+} satisfies ScenePart;
+
+export interface EditorValue {
+  title: string;
+  status: string | null;
+  priority: string | null;
+  assignee: string | null;
+  watching: boolean;
+  due: Optional<string>;
+}
+
+// Page-object driver for the editor dialog. Its locator is the (portaled) dialog root; the field
+// drivers compose under it. Reads "open" from the dialog's presence — MUI unmounts a closed dialog.
+export class TicketEditorDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async isOpen(): Promise<boolean> {
+    return this.interactor.exists(this.locator);
+  }
+
+  async waitForOpen(timeoutMs: number = 5000): Promise<void> {
+    await this.waitUntil({ probeFn: () => this.isOpen(), terminateCondition: true, timeoutMs });
+  }
+
+  async waitForClose(timeoutMs: number = 5000): Promise<void> {
+    await this.waitUntil({ probeFn: () => this.isOpen(), terminateCondition: false, timeoutMs });
+  }
+
+  /** Apply the provided fields. Omitted fields are left untouched. */
+  async setValue(edit: Partial<TicketEdit>): Promise<void> {
+    if (edit.title !== undefined) {
+      await this.parts.title.setValue(edit.title);
+    }
+    if (edit.status !== undefined) {
+      await this.parts.status.selectByLabel(edit.status);
+    }
+    if (edit.priority !== undefined) {
+      await this.parts.priority.selectByLabel(edit.priority);
+    }
+    if (edit.assignee !== undefined) {
+      await this.parts.assignee.setValue(edit.assignee);
+    }
+    if (edit.watching !== undefined) {
+      await this.parts.watching.setSelected(edit.watching);
+    }
+    if (edit.due !== undefined) {
+      await this.parts.due.pickDate(edit.due);
+    }
+  }
+
+  async getValue(): Promise<EditorValue> {
+    const [title, status, priority, assignee, watching, due] = await Promise.all([
+      this.parts.title.getValue(),
+      this.parts.status.getSelectedLabel(),
+      this.parts.priority.getSelectedLabel(),
+      this.parts.assignee.getValue(),
+      this.parts.watching.isSelected(),
+      this.parts.due.getValueText(),
+    ]);
+    return { title: title ?? '', status, priority, assignee, watching, due };
+  }
+
+  /** The title field's validation message, e.g. after attempting to save an empty title. */
+  async getError(): Promise<Optional<string>> {
+    return this.parts.title.getHelperText();
+  }
+
+  /** A ChipDriver for one label chip, addressed by the label text. */
+  getLabelChip(label: string): ChipDriver {
+    return new ChipDriver(
+      locatorUtil.append(this.locator, byDataTestId(labelChipTestId(label))),
+      this.interactor,
+      this.commutableOption
+    );
+  }
+
+  async removeLabel(label: string): Promise<void> {
+    await this.getLabelChip(label).clickRemove();
+  }
+
+  async save(): Promise<void> {
+    await this.parts.save.click();
+  }
+
+  async cancel(): Promise<void> {
+    await this.parts.cancel.click();
+  }
+
+  override get driverName(): string {
+    return 'TicketEditorDriver';
+  }
+}

--- a/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGrid.tsx
+++ b/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGrid.tsx
@@ -1,0 +1,104 @@
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useState } from 'react';
+
+import { type Ticket } from '../../models/Ticket';
+import { RowMenuAction, TicketGridDataTestId } from './TicketGridDataTestId';
+
+export interface TicketGridProps {
+  'data-testid'?: string;
+  rows: readonly Ticket[];
+  onOpen: (ticketId: number) => void;
+  onAssignToMe: (ticketId: number) => void;
+  onClose: (ticketId: number) => void;
+}
+
+interface MenuState {
+  anchorEl: HTMLElement;
+  ticketId: number;
+}
+
+export function TicketGrid({ rows, onOpen, onAssignToMe, onClose, ...rest }: TicketGridProps) {
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const closeMenu = () => setMenu(null);
+  const runAndClose = (fn: (id: number) => void) => () => {
+    if (menu != null) {
+      fn(menu.ticketId);
+    }
+    closeMenu();
+  };
+
+  const columns: GridColDef<Ticket>[] = [
+    { field: 'id', headerName: '#', width: 70 },
+    {
+      field: 'title',
+      headerName: 'Title',
+      flex: 1,
+      minWidth: 200,
+      // A button (not row-click) makes opening a row a plain, deterministic click in every engine.
+      renderCell: params => (
+        <Link component='button' type='button' underline='hover' onClick={() => onOpen(params.row.id)}>
+          {params.row.title}
+        </Link>
+      ),
+    },
+    {
+      field: 'assignee',
+      headerName: 'Assignee',
+      width: 120,
+      valueGetter: (value: Ticket['assignee']) => value ?? '—',
+    },
+    { field: 'status', headerName: 'Status', width: 130 },
+    { field: 'priority', headerName: 'Priority', width: 110 },
+    { field: 'due', headerName: 'Due', width: 130 },
+    {
+      field: 'actions',
+      headerName: '',
+      width: 60,
+      sortable: false,
+      filterable: false,
+      renderCell: params => (
+        <IconButton
+          aria-label={`Actions for ticket ${params.row.id}`}
+          size='small'
+          onClick={event => setMenu({ anchorEl: event.currentTarget, ticketId: params.row.id })}>
+          <MoreVertIcon fontSize='small' />
+        </IconButton>
+      ),
+    },
+  ];
+
+  return (
+    <div data-testid={rest['data-testid'] ?? TicketGridDataTestId.root}>
+      <div data-testid={TicketGridDataTestId.count}>{rows.length} tickets</div>
+      <div style={{ height: 460, width: '100%' }}>
+        <DataGrid
+          rows={rows as Ticket[]}
+          columns={columns}
+          getRowId={row => row.id}
+          disableColumnMenu
+          // The seed is small; a page large enough to hold it keeps row counts pagination-free, and
+          // disabling virtualization makes every row render in jsdom (no layout) exactly as it does
+          // in a real browser — so DOM and E2E read the same getRowCount.
+          disableVirtualization
+          initialState={{ pagination: { paginationModel: { pageSize: 25, page: 0 } } }}
+          pageSizeOptions={[25, 50]}
+        />
+      </div>
+
+      <Menu
+        data-testid={TicketGridDataTestId.rowMenu}
+        anchorEl={menu?.anchorEl ?? null}
+        open={menu != null}
+        onClose={closeMenu}>
+        <MenuItem onClick={runAndClose(onOpen)}>{RowMenuAction.edit}</MenuItem>
+        <MenuItem onClick={runAndClose(onAssignToMe)}>{RowMenuAction.assignToMe}</MenuItem>
+        <MenuItem onClick={runAndClose(onClose)}>{RowMenuAction.close}</MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGridDataTestId.ts
+++ b/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGridDataTestId.ts
@@ -1,0 +1,12 @@
+export const TicketGridDataTestId = {
+  root: 'ticket-grid',
+  count: 'ticket-count',
+  rowMenu: 'ticket-row-menu',
+} as const;
+
+// The per-row action menu items (also the labels the MenuDriver selects by).
+export const RowMenuAction = {
+  edit: 'Edit',
+  assignToMe: 'Assign to me',
+  close: 'Close ticket',
+} as const;

--- a/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGridDriver.ts
+++ b/examples/example-mui-ticket-console/src/components/ticketGrid/TicketGridDriver.ts
@@ -1,0 +1,94 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { MenuDriver } from '@atomic-testing/component-driver-mui-v9';
+import { DataGridDataRowDriver, DataGridPremiumDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import {
+  byCssSelector,
+  byDataTestId,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { TicketGridDataTestId } from './TicketGridDataTestId';
+
+const parts = {
+  // The DataGrid root is the shipped driver's target; the example's `data-testid` sits on the
+  // wrapping element (this driver's own locator).
+  grid: { locator: byCssSelector('.MuiDataGrid-root'), driver: DataGridPremiumDriver },
+  count: { locator: byDataTestId(TicketGridDataTestId.count), driver: HTMLElementDriver },
+  // The row-action menu portals to <body>, so it is addressed from the document Root.
+  rowMenu: { locator: byDataTestId(TicketGridDataTestId.rowMenu, 'Root'), driver: MenuDriver },
+} satisfies ScenePart;
+
+function rowCellButtonLocator(rowIndex: number, field: string): PartLocator {
+  return byCssSelector(`[role=row][data-rowindex="${rowIndex}"] [data-field="${field}"] button`);
+}
+
+// Page-object driver over the ticket grid. Wraps the shipped community-grid driver
+// (DataGridPremiumDriver drives the community DataGrid — identical row/cell DOM) plus the per-row
+// action menu, behind ticket-oriented method names.
+export class TicketGridDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  /** Wait for the grid to finish its initial render/load before reading rows. */
+  async waitForLoad(timeoutMs: number = 10000): Promise<void> {
+    await this.parts.grid.waitForLoad(timeoutMs);
+  }
+
+  async getRowCount(): Promise<number> {
+    return this.parts.grid.getRowCount();
+  }
+
+  /** The "{n} tickets" summary text shown above the grid. */
+  async getRowCountText(): Promise<Optional<string>> {
+    return this.parts.count.getText();
+  }
+
+  /** The Title column text of every visible row, in display order. */
+  async getVisibleTitles(): Promise<string[]> {
+    const count = await this.getRowCount();
+    const titles: string[] = [];
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      titles.push(await this.parts.grid.getCellText({ rowIndex, columnField: 'title' }));
+    }
+    return titles;
+  }
+
+  /** The Assignee column text of a row (the grid shows `—` for unassigned). */
+  async getAssignee(rowIndex: number): Promise<string> {
+    return this.parts.grid.getCellText({ rowIndex, columnField: 'assignee' });
+  }
+
+  /** Open the editor for a row by clicking its title. */
+  async openRow(rowIndex: number): Promise<void> {
+    await this.interactor.click(locatorUtil.append(this.locator, rowCellButtonLocator(rowIndex, 'title')));
+  }
+
+  /** Open the per-row action menu (Edit / Assign to me / Close ticket). */
+  async openRowMenu(rowIndex: number): Promise<void> {
+    await this.interactor.click(locatorUtil.append(this.locator, rowCellButtonLocator(rowIndex, 'actions')));
+  }
+
+  /** Open a row's action menu and choose an item by its label. */
+  async chooseRowAction(rowIndex: number, actionLabel: string): Promise<void> {
+    await this.openRowMenu(rowIndex);
+    await this.parts.rowMenu.selectByLabel(actionLabel);
+  }
+
+  /** The data-row driver for the first row whose Title matches, or `null`. */
+  async getRowByTitle(title: string): Promise<DataGridDataRowDriver | null> {
+    const titles = await this.getVisibleTitles();
+    const index = titles.indexOf(title);
+    return index >= 0 ? this.parts.grid.getRow(index) : null;
+  }
+
+  override get driverName(): string {
+    return 'TicketGridDriver';
+  }
+}

--- a/examples/example-mui-ticket-console/src/data/filterTickets.ts
+++ b/examples/example-mui-ticket-console/src/data/filterTickets.ts
@@ -1,0 +1,77 @@
+import { CURRENT_USER, type Assignee, type Status, type Ticket } from '../models/Ticket';
+import { isOverdue, parseCalendarDate } from './today';
+
+export type TabView = 'All' | 'Mine' | 'Overdue';
+
+export interface Filters {
+  readonly search: string;
+  /** `null` means "any assignee". */
+  readonly assignee: Assignee | null;
+  /** `null` means "any status". */
+  readonly status: Status | null;
+  /** Inclusive `yyyy-mm-dd` lower bound, or `null` for unbounded. */
+  readonly dueFrom: string | null;
+  /** Inclusive `yyyy-mm-dd` upper bound, or `null` for unbounded. */
+  readonly dueTo: string | null;
+}
+
+export const emptyFilters: Filters = {
+  search: '',
+  assignee: null,
+  status: null,
+  dueFrom: null,
+  dueTo: null,
+};
+
+export interface TicketQuery {
+  readonly queueId: string | null;
+  readonly filters: Filters;
+  readonly tab: TabView;
+}
+
+function matchesTab(ticket: Ticket, tab: TabView): boolean {
+  switch (tab) {
+    case 'Mine':
+      return ticket.assignee === CURRENT_USER;
+    case 'Overdue':
+      return isOverdue(ticket.due) && ticket.status !== 'Closed';
+    case 'All':
+      return true;
+  }
+}
+
+function withinDueRange(due: string, from: string | null, to: string | null): boolean {
+  const dueMs = parseCalendarDate(due).getTime();
+  if (from != null && dueMs < parseCalendarDate(from).getTime()) {
+    return false;
+  }
+  if (to != null && dueMs > parseCalendarDate(to).getTime()) {
+    return false;
+  }
+  return true;
+}
+
+// Pure, deterministic projection of the seed tickets for a given sidebar/filter/tab state. Keeping
+// it free of component state lets the same logic back both the UI and any reasoning in tests.
+export function filterTickets(tickets: readonly Ticket[], query: TicketQuery): Ticket[] {
+  const { queueId, filters, tab } = query;
+  const needle = filters.search.trim().toLowerCase();
+  return tickets.filter(ticket => {
+    if (queueId != null && ticket.queueId !== queueId) {
+      return false;
+    }
+    if (needle.length > 0 && !ticket.title.toLowerCase().includes(needle)) {
+      return false;
+    }
+    if (filters.assignee != null && ticket.assignee !== filters.assignee) {
+      return false;
+    }
+    if (filters.status != null && ticket.status !== filters.status) {
+      return false;
+    }
+    if (!withinDueRange(ticket.due, filters.dueFrom, filters.dueTo)) {
+      return false;
+    }
+    return matchesTab(ticket, tab);
+  });
+}

--- a/examples/example-mui-ticket-console/src/data/seed.ts
+++ b/examples/example-mui-ticket-console/src/data/seed.ts
@@ -1,0 +1,159 @@
+import type { Ticket } from '../models/Ticket';
+
+// The team -> queue sidebar tree. `itemId`s are stable handles the TeamNav driver targets.
+export interface Queue {
+  readonly id: string;
+  readonly label: string;
+}
+export interface Team {
+  readonly id: string;
+  readonly label: string;
+  readonly queues: readonly Queue[];
+}
+
+export const TEAMS: readonly Team[] = [
+  {
+    id: 'web',
+    label: 'Web',
+    queues: [
+      { id: 'web-bugs', label: 'Bugs' },
+      { id: 'web-features', label: 'Features' },
+    ],
+  },
+  {
+    id: 'mobile',
+    label: 'Mobile',
+    queues: [
+      { id: 'mobile-crashes', label: 'Crashes' },
+      // Intentionally empty, to exercise the grid's no-rows empty state.
+      { id: 'mobile-triage', label: 'Triage' },
+    ],
+  },
+];
+
+// Deterministic ticket fixture. Due dates are positioned relative to TODAY (2026-06-15, a Monday):
+// some inside that week, some overdue, some in the future — so the "Due this week" and "Overdue"
+// views have a known, stable membership.
+export const TICKETS: readonly Ticket[] = [
+  {
+    id: 12,
+    title: 'Login fails on Safari',
+    assignee: 'Ana',
+    status: 'Open',
+    priority: 'High',
+    due: '2026-06-16',
+    labels: ['auth'],
+    watching: false,
+    queueId: 'web-bugs',
+  },
+  {
+    id: 13,
+    title: 'Crash on file upload',
+    assignee: 'Bo',
+    status: 'Open',
+    priority: 'Urgent',
+    due: '2026-06-18',
+    labels: ['crash'],
+    watching: true,
+    queueId: 'web-bugs',
+  },
+  {
+    id: 14,
+    title: 'Slow dashboard load',
+    assignee: null,
+    status: 'In Progress',
+    priority: 'Medium',
+    due: '2026-06-17',
+    labels: ['perf'],
+    watching: false,
+    queueId: 'web-bugs',
+  },
+  {
+    id: 15,
+    title: 'Typo in footer',
+    assignee: 'Mia',
+    status: 'Open',
+    priority: 'Low',
+    due: '2026-06-10',
+    labels: ['ui'],
+    watching: false,
+    queueId: 'web-bugs',
+  },
+  {
+    id: 16,
+    title: 'Broken pricing link',
+    assignee: 'Ana',
+    status: 'Closed',
+    priority: 'Low',
+    due: '2026-06-05',
+    labels: [],
+    watching: false,
+    queueId: 'web-bugs',
+  },
+  {
+    id: 17,
+    title: 'Dark mode toggle',
+    assignee: 'Bo',
+    status: 'Open',
+    priority: 'Medium',
+    due: '2026-06-20',
+    labels: ['ui'],
+    watching: false,
+    queueId: 'web-features',
+  },
+  {
+    id: 18,
+    title: 'Export to CSV',
+    assignee: 'Me',
+    status: 'In Progress',
+    priority: 'High',
+    due: '2026-06-25',
+    labels: ['export'],
+    watching: true,
+    queueId: 'web-features',
+  },
+  {
+    id: 19,
+    title: 'Bulk edit tickets',
+    assignee: 'Me',
+    status: 'Open',
+    priority: 'Medium',
+    due: '2026-06-12',
+    labels: [],
+    watching: false,
+    queueId: 'web-features',
+  },
+  {
+    id: 20,
+    title: 'ANR on cold start',
+    assignee: 'Ana',
+    status: 'Blocked',
+    priority: 'Urgent',
+    due: '2026-06-19',
+    labels: ['crash'],
+    watching: false,
+    queueId: 'mobile-crashes',
+  },
+  {
+    id: 21,
+    title: 'Memory leak in feed',
+    assignee: null,
+    status: 'Open',
+    priority: 'High',
+    due: '2026-06-30',
+    labels: ['perf'],
+    watching: false,
+    queueId: 'mobile-crashes',
+  },
+  {
+    id: 22,
+    title: 'Push token refresh error',
+    assignee: 'Me',
+    status: 'Open',
+    priority: 'Medium',
+    due: '2026-06-14',
+    labels: ['push'],
+    watching: false,
+    queueId: 'mobile-crashes',
+  },
+];

--- a/examples/example-mui-ticket-console/src/data/today.ts
+++ b/examples/example-mui-ticket-console/src/data/today.ts
@@ -1,0 +1,33 @@
+// A FIXED reference "today" so that the relative views ("Due this week", "Overdue") are
+// deterministic across the DOM and E2E runs. The app never reads the wall clock.
+// 2026-06-15 is a Monday, which makes the surrounding week boundaries easy to reason about.
+export const TODAY = '2026-06-15';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Parse a `yyyy-mm-dd` string as a local calendar date (midnight local), avoiding the UTC shift
+// `new Date('yyyy-mm-dd')` would introduce.
+export function parseCalendarDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function isOverdue(dueIso: string, today: string = TODAY): boolean {
+  return parseCalendarDate(dueIso).getTime() < parseCalendarDate(today).getTime();
+}
+
+// The Monday..Sunday week that contains `today`.
+export function weekRange(today: string = TODAY): { from: string; to: string } {
+  const date = parseCalendarDate(today);
+  const dayOfWeek = (date.getDay() + 6) % 7; // 0 = Monday
+  const monday = new Date(date.getTime() - dayOfWeek * MS_PER_DAY);
+  const sunday = new Date(monday.getTime() + 6 * MS_PER_DAY);
+  return { from: toIso(monday), to: toIso(sunday) };
+}
+
+export function toIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/examples/example-mui-ticket-console/src/hooks/useTicketConsole.ts
+++ b/examples/example-mui-ticket-console/src/hooks/useTicketConsole.ts
@@ -1,0 +1,52 @@
+import { useMemo, useState } from 'react';
+
+import { emptyFilters, type Filters, filterTickets, type TabView } from '../data/filterTickets';
+import { TICKETS } from '../data/seed';
+import { CURRENT_USER, type Ticket, type TicketEdit } from '../models/Ticket';
+
+// Owns all console state and derives the visible ticket set with the pure `filterTickets`. App and
+// the feature components stay presentational; this hook is the single source of truth.
+export function useTicketConsole() {
+  const [tickets, setTickets] = useState<readonly Ticket[]>(TICKETS);
+  const [selectedQueue, setSelectedQueue] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>(emptyFilters);
+  const [tab, setTab] = useState<TabView>('All');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [snackbar, setSnackbar] = useState<string | null>(null);
+
+  const visible = useMemo(
+    () => filterTickets(tickets, { queueId: selectedQueue, filters, tab }),
+    [tickets, selectedQueue, filters, tab]
+  );
+  const editingTicket = editingId != null ? (tickets.find(ticket => ticket.id === editingId) ?? null) : null;
+
+  const patchTicket = (id: number, partial: Partial<Ticket>, toast: string) => {
+    setTickets(prev => prev.map(ticket => (ticket.id === id ? { ...ticket, ...partial } : ticket)));
+    setSnackbar(toast);
+  };
+
+  return {
+    tickets,
+    visible,
+    selectedQueue,
+    filters,
+    tab,
+    editingTicket,
+    snackbar,
+    selectQueue: (queueId: string | null) => setSelectedQueue(queueId),
+    updateFilters: (next: Filters) => setFilters(next),
+    selectTab: (next: TabView) => setTab(next),
+    openEditor: (id: number) => setEditingId(id),
+    closeEditor: () => setEditingId(null),
+    save: (edit: TicketEdit) => {
+      const id = editingId;
+      if (id != null) {
+        patchTicket(id, edit, `Ticket #${id} saved`);
+      }
+      setEditingId(null);
+    },
+    assignToMe: (id: number) => patchTicket(id, { assignee: CURRENT_USER }, `Ticket #${id} saved`),
+    closeTicket: (id: number) => patchTicket(id, { status: 'Closed' }, `Ticket #${id} saved`),
+    dismissSnackbar: () => setSnackbar(null),
+  };
+}

--- a/examples/example-mui-ticket-console/src/main.tsx
+++ b/examples/example-mui-ticket-console/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/examples/example-mui-ticket-console/src/models/Ticket.ts
+++ b/examples/example-mui-ticket-console/src/models/Ticket.ts
@@ -1,0 +1,44 @@
+// Domain model for the ticket triage console. All state is client-side; the seed is deterministic
+// (see src/data) so the DOM and E2E assertions are identical and stable.
+
+export const STATUSES = ['Open', 'In Progress', 'Blocked', 'Closed'] as const;
+export type Status = (typeof STATUSES)[number];
+
+export const PRIORITIES = ['Low', 'Medium', 'High', 'Urgent'] as const;
+export type Priority = (typeof PRIORITIES)[number];
+
+// The signed-in user is "Me"; the "Mine" tab and "Assign to me" action key off this exact label.
+export const CURRENT_USER = 'Me';
+export const ASSIGNEES = [CURRENT_USER, 'Ana', 'Bo', 'Mia'] as const;
+export type Assignee = (typeof ASSIGNEES)[number];
+
+export interface Ticket {
+  readonly id: number;
+  readonly title: string;
+  /** `null` means unassigned. */
+  readonly assignee: Assignee | null;
+  readonly status: Status;
+  readonly priority: Priority;
+  /** Due date as a `yyyy-mm-dd` calendar date (no time / timezone). */
+  readonly due: string;
+  readonly labels: readonly string[];
+  readonly watching: boolean;
+  /** Id of the queue (tree leaf) this ticket belongs to. */
+  readonly queueId: string;
+}
+
+// The editable subset of a ticket, as the editor dialog reads/writes it.
+export interface TicketEdit {
+  readonly title: string;
+  readonly status: Status;
+  readonly priority: Priority;
+  readonly assignee: Assignee | null;
+  readonly due: string;
+  readonly labels: readonly string[];
+  readonly watching: boolean;
+}
+
+export function toEdit(ticket: Ticket): TicketEdit {
+  const { title, status, priority, assignee, due, labels, watching } = ticket;
+  return { title, status, priority, assignee, due, labels, watching };
+}

--- a/examples/example-mui-ticket-console/src/testing/consoleParts.ts
+++ b/examples/example-mui-ticket-console/src/testing/consoleParts.ts
@@ -1,0 +1,14 @@
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+import { AppDataTestId } from '../AppDataTestId';
+import { TicketConsoleDriver } from '../components/ticketConsole/TicketConsoleDriver';
+
+// The single scene shared by BOTH the Vitest DOM tests and the Playwright E2E specs. The only thing
+// that differs between the two runs is how the TestEngine is constructed (React render vs. a browser
+// page) — this `parts` map and the drivers it wires are imported, unchanged, by both.
+export const consoleParts = {
+  console: {
+    locator: byDataTestId(AppDataTestId.console),
+    driver: TicketConsoleDriver,
+  },
+} satisfies ScenePart;

--- a/examples/example-mui-ticket-console/src/testing/scenarios.ts
+++ b/examples/example-mui-ticket-console/src/testing/scenarios.ts
@@ -1,0 +1,74 @@
+import type { TicketConsoleDriver } from '../components/ticketConsole/TicketConsoleDriver';
+import { weekRange } from '../data/today';
+
+// A tiny assertion surface so each scenario is written once and run by both Vitest and Playwright,
+// which provide their own `expect`. Each test file adapts its `expect` into this shape.
+export interface Assert {
+  equal<T>(actual: T, expected: T, message?: string): void;
+  isTrue(value: boolean, message?: string): void;
+  match(actual: string | null | undefined, pattern: RegExp, message?: string): void;
+  includes(haystack: string | null | undefined, needle: string, message?: string): void;
+}
+
+// Scenario 1 — Triage flow: narrow to "Open, due this week", open the first ticket, reassign it to
+// me, save, expect a success toast, and see the grid reflect the new assignee.
+export async function triageFlow(console: TicketConsoleDriver, assert: Assert): Promise<void> {
+  await console.waitUntilReady();
+
+  await console.filterBar.filterByStatus('Open');
+  const week = weekRange();
+  await console.filterBar.setDueRange(week.from, week.to);
+  await console.grid.waitForLoad();
+
+  const titles = await console.grid.getVisibleTitles();
+  assert.equal(titles.length, 3, 'three Open tickets are due this week');
+  assert.includes(titles.join('|'), 'Login fails on Safari');
+
+  await console.grid.openRow(0);
+  await console.editor.waitForOpen();
+  await console.editor.setValue({ assignee: 'Me', priority: 'High' });
+  await console.editor.save();
+  await console.editor.waitForClose();
+
+  assert.includes(await console.toast.getLabel(), 'saved', 'a save toast appears');
+  assert.equal(await console.grid.getAssignee(0), 'Me', 'the grid row shows the new assignee');
+}
+
+// Scenario 2 — Empty state: a queue with no tickets shows zero rows.
+export async function emptyQueueFlow(console: TicketConsoleDriver, assert: Assert): Promise<void> {
+  await console.waitUntilReady();
+
+  await console.teamNav.selectQueue('mobile-triage');
+  await console.grid.waitForLoad();
+
+  assert.equal(await console.grid.getRowCount(), 0, 'the empty queue shows no rows');
+}
+
+// Scenario 3 — Tab switch: the Overdue view replaces the full list with only overdue tickets.
+export async function tabSwitchFlow(console: TicketConsoleDriver, assert: Assert): Promise<void> {
+  await console.waitUntilReady();
+
+  assert.equal(await console.grid.getRowCount(), 11, 'the All view shows every seeded ticket');
+
+  await console.tabs.selectByLabel('Overdue');
+  await console.grid.waitForLoad();
+
+  assert.equal(await console.grid.getRowCount(), 3, 'the Overdue view shows only overdue, open tickets');
+  const titles = await console.grid.getVisibleTitles();
+  assert.isTrue(titles.includes('Typo in footer'), 'an overdue ticket is listed');
+}
+
+// Scenario 4 — Validation: clearing the required title and saving surfaces a field error and keeps
+// the editor open.
+export async function validationFlow(console: TicketConsoleDriver, assert: Assert): Promise<void> {
+  await console.waitUntilReady();
+
+  await console.grid.openRow(0);
+  await console.editor.waitForOpen();
+
+  await console.editor.setValue({ title: '' });
+  await console.editor.save();
+
+  assert.match(await console.editor.getError(), /required/i, 'the title error mentions "required"');
+  assert.isTrue(await console.editor.isOpen(), 'the editor stays open on a validation error');
+}

--- a/examples/example-mui-ticket-console/src/themes/theme.ts
+++ b/examples/example-mui-ticket-console/src/themes/theme.ts
@@ -1,0 +1,10 @@
+import { createTheme } from '@mui/material/styles';
+
+// A light, compact theme — nothing the drivers depend on, just a pleasant default for the demo.
+export const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#3949ab' },
+  },
+  shape: { borderRadius: 8 },
+});

--- a/examples/example-mui-ticket-console/src/vite-env.d.ts
+++ b/examples/example-mui-ticket-console/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/example-mui-ticket-console/tsconfig.json
+++ b/examples/example-mui-ticket-console/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "e2e"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/example-mui-ticket-console/tsconfig.node.json
+++ b/examples/example-mui-ticket-console/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts", "vitest.setup.ts", "playwright.config.ts"]
+}

--- a/examples/example-mui-ticket-console/vite.config.ts
+++ b/examples/example-mui-ticket-console/vite.config.ts
@@ -1,0 +1,19 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// A dedicated port (8090) that no other app in this monorepo uses, so this example can run
+// alongside every other example/package-test app. Override with PORT for CI/parallel runs.
+// `strictPort` fails fast on a busy port instead of silently drifting to another one (which
+// would let the Playwright `webServer` run against the wrong app).
+const port = Number(process.env.PORT) || 8090;
+
+// The atomic-testing packages are linked from the monorepo (see package.json `pnpm.overrides`),
+// so React/Emotion can be resolved both from this app and from the linked packages. Dedupe them
+// to a single copy or MUI's emotion cache and React's hooks break at runtime.
+// https://vitejs.dev/config/
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  resolve: { dedupe: ['react', 'react-dom', '@emotion/react', '@emotion/styled'] },
+  server: { port, strictPort: true },
+});

--- a/examples/example-mui-ticket-console/vitest.config.ts
+++ b/examples/example-mui-ticket-console/vitest.config.ts
@@ -1,0 +1,23 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+// https://vitest.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  // The atomic-testing packages are symlinked monorepo builds; dedupe React/Emotion so the app
+  // and the linked ReactInteractor share one copy (act() flushing relies on a single React).
+  resolve: { dedupe: ['react', 'react-dom', '@emotion/react', '@emotion/styled'] },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    // Only the atomic-testing component tests. Playwright specs under /e2e run via Playwright.
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+    testTimeout: 30000,
+    // MUI-X v9 reaches `core-js-pure` through `@mui/x-internals` via an extensionless directory
+    // import that Node's native ESM resolver rejects. Inlining the whole `@mui/x-*` chain (and
+    // core-js-pure) routes those imports through Vite's resolver, which handles them, so the grid,
+    // pickers, and tree load under jsdom. `fallbackCJS` lets Vite fall back to a package's CJS build
+    // when its ESM entry is not resolvable.
+    server: { deps: { inline: [/@mui\/x-/, /core-js-pure/], fallbackCJS: true } },
+  },
+});

--- a/examples/example-mui-ticket-console/vitest.setup.ts
+++ b/examples/example-mui-ticket-console/vitest.setup.ts
@@ -1,0 +1,53 @@
+// Tells React 19 it is running inside an act()-aware test environment, which the atomic-testing
+// ReactInteractor relies on to flush state updates during tests.
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// --- jsdom polyfills for MUI v9 + MUI-X v9 -------------------------------------------------------
+// jsdom implements none of the layout/observer APIs that the DataGrid, pickers, and overlays reach
+// for on mount. Without these stubs, merely rendering them throws and tears down the React subtree.
+// Drivers read state from ARIA/DOM attributes, so inert stubs suffice under jsdom; real layout and
+// open/close behaviour is exercised by the Playwright E2E run.
+const g = globalThis as unknown as {
+  ResizeObserver?: unknown;
+  IntersectionObserver?: unknown;
+};
+
+if (typeof g.ResizeObserver !== 'function') {
+  g.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+
+if (typeof g.IntersectionObserver !== 'function') {
+  g.IntersectionObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): [] {
+      return [];
+    }
+  };
+}
+
+// MUI components read the theme/breakpoints via useMediaQuery, and scroll-lock calls scrollTo.
+const win = globalThis.window as unknown as {
+  matchMedia?: (q: string) => unknown;
+  scrollTo?: () => void;
+};
+if (win != null && typeof win.matchMedia !== 'function') {
+  win.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+if (win != null) {
+  win.scrollTo = () => {};
+}

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
@@ -47,5 +47,28 @@ export const desktopDatePickerTestSuite: TestSuiteInfo<typeof desktopDatePickerE
       assertEqual(second?.getMonth(), 0); // January
       assertEqual(second?.getDate(), 15);
     });
+
+    test('setValue selects a day in the currently shown month', async () => {
+      // Default value is June 2026, so the popup opens on the target month directly.
+      await engine().parts.picker.setValue(new Date(2026, 5, 30));
+      assertEqual(await engine().parts.picker.getValueText(), '06/30/2026');
+    });
+
+    test('pickDate pages forward across months', async () => {
+      await engine().parts.picker.pickDate('2026-09-14');
+      assertEqual(await engine().parts.picker.getValueText(), '09/14/2026');
+    });
+
+    test('pickDate pages backward across months', async () => {
+      await engine().parts.picker.pickDate('2026-02-03');
+      assertEqual(await engine().parts.picker.getValueText(), '02/03/2026');
+    });
+
+    test('pickDate operates each picker independently', async () => {
+      await engine().parts.secondPicker.pickDate('2020-01-20');
+      assertEqual(await engine().parts.secondPicker.getValueText(), '01/20/2020');
+      // The first picker is untouched.
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026');
+    });
   },
 };

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/treeview/SimpleTreeView.suite.ts
@@ -52,5 +52,14 @@ export const simpleTreeViewTestSuite: TestSuiteInfo<typeof simpleTreeViewExample
       // their removal would be environment-dependent.
       assertFalse(await engine().parts.tree.isExpanded('fruits'));
     });
+
+    test('selectItem selects a leaf and flips its selection state', async () => {
+      await engine().parts.tree.expandItem('fruits');
+      assertFalse(await engine().parts.tree.isSelected('apple'));
+      await engine().parts.tree.selectItem('apple');
+      assertTrue(await engine().parts.tree.isSelected('apple'));
+      // Selection is single by default, so a sibling stays unselected.
+      assertFalse(await engine().parts.tree.isSelected('banana'));
+    });
   },
 };

--- a/packages/component-driver-astryx/package.json
+++ b/packages/component-driver-astryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-astryx",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Component driver for Astryx (@astryxdesign/core)",
   "repository": {
     "type": "git",

--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "HTML component driver for atomic-testing",
   "keywords": [
     "e2e",

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v5",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "[DEPRECATED: MUI 5 end of support] Atomic Testing Component driver to help drive Material UI v5 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-v7/package.json
+++ b/packages/component-driver-mui-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v7",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Component driver for Material-UI v7",
   "repository": {
     "type": "git",

--- a/packages/component-driver-mui-v9/package.json
+++ b/packages/component-driver-mui-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v9",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Component driver for Material-UI v9",
   "repository": {
     "type": "git",

--- a/packages/component-driver-mui-x-v5/package.json
+++ b/packages/component-driver-mui-x-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v5",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "[DEPRECATED: MUI-X 5 end of support] Atomic Testing Component driver to help drive Material UI X v5 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v6/package.json
+++ b/packages/component-driver-mui-x-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v6",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v7/package.json
+++ b/packages/component-driver-mui-x-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v7",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V7 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v8/package.json
+++ b/packages/component-driver-mui-x-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v8",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V8 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v9/package.json
+++ b/packages/component-driver-mui-x-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v9",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V9 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
@@ -1,9 +1,11 @@
 import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import {
   byCssClass,
+  byCssSelector,
   ComponentDriver,
   IComponentDriverOption,
   Interactor,
+  locatorUtil,
   Optional,
   PartLocator,
   ScenePart,
@@ -15,13 +17,13 @@ import { DatePickerCharacteristic } from './types';
 // is a `PickersSectionList`: a `role="group"` of `contenteditable` `role="spinbutton"` section
 // spans (`.MuiPickersSectionList-sectionContent`, one per Month/Day/Year). A single hidden,
 // `aria-hidden` `<input class="MuiPickersInputBase-input">` mirrors the committed value as a
-// locale-formatted string for form submission — which is the stable, portable read path.
+// locale-formatted string for form submission — the stable, portable READ path.
 //
-// NOTE: This base is read-only. A portable `setValue` requires typing real keystrokes into a
-// section span; the DOM interactor types via `userEvent.type` (real keys, works) but the
-// Playwright interactor types via `locator.fill` (innerText replacement, which MUI ignores).
-// Setting a value portably therefore needs a new keystroke primitive on `Interactor`,
-// tracked as a follow-up.
+// The WRITE path goes through the calendar popup, not the section field: typing into a section
+// is not portable (the Playwright interactor's `fill` replaces innerText, which MUI ignores, and
+// the DOM interactor's `pressKey` dispatches only `keydown`/`keyup` with no `input` event), but a
+// mouse click behaves identically across engines. So `setValue` opens the popup, walks to the
+// target month, and clicks the day cell. See {@link DesktopDatePickerDriverBase.setValue}.
 const parts = {
   // The hidden input mirrors the committed value as a formatted string (e.g. "06/27/2026").
   valueInput: {
@@ -29,6 +31,49 @@ const parts = {
     driver: HTMLTextInputDriver,
   },
 } satisfies ScenePart;
+
+// The open ("Choose date") adornment button carries a stable, locale-independent marker attribute
+// (its `aria-label` interpolates the selected date, so it is not a reliable handle).
+const openButtonLocator = byCssSelector('[data-mui-picker-open-button="true"]');
+
+// The calendar popup is portaled to <body>, so its parts are addressed from the document Root, not
+// as descendants of the picker. Only one picker popup is open at a time, so the singular root is
+// unambiguous while open.
+const popupRoot = '.MuiPickerPopper-root';
+const popupLocator = byCssSelector(popupRoot, 'Root');
+const calendarHeaderLabelLocator = byCssSelector(`${popupRoot} .MuiPickersCalendarHeader-label`, 'Root');
+const previousMonthLocator = byCssSelector(`${popupRoot} .MuiPickersArrowSwitcher-previousIconButton`, 'Root');
+const nextMonthLocator = byCssSelector(`${popupRoot} .MuiPickersArrowSwitcher-nextIconButton`, 'Root');
+// In-month day cells are <button>s carrying a `data-timestamp`; out-of-month cells are filler
+// <div>s without one. Excluding `dayOutsideMonth` keeps the set to days 1..N even when a consumer
+// turns on `showDaysOutsideCurrentMonth`, so the buttons line up with day-of-month by position.
+const inMonthDayButtonsLocator = byCssSelector(
+  `${popupRoot} .MuiPickerDay-root[data-timestamp]:not(.MuiPickerDay-dayOutsideMonth)`,
+  'Root'
+);
+// While the month slide animates, MUI keeps the outgoing month grids mounted (marked
+// `slideExit`) alongside the incoming one, so the day-cell list briefly spans several months.
+// Waiting for no exiting grid to remain collapses the view back to a single month before any day
+// is read. (Under jsdom there is no animation, so this never matches and the wait is a no-op.)
+const exitingMonthGridLocator = byCssSelector(`${popupRoot} .MuiPickersSlideTransition-slideExit`, 'Root');
+
+function dayByTimestampLocator(timestamp: string): PartLocator {
+  return byCssSelector(`${popupRoot} .MuiPickerDay-root[data-timestamp="${timestamp}"]`, 'Root');
+}
+
+// Collapse a year+month to a single comparable ordinal so month deltas are a subtraction.
+function toMonthOrdinal(year: number, monthIndex: number): number {
+  return year * 12 + monthIndex;
+}
+
+// The header label (e.g. "June 2026") is parsed in the driver's own JS runtime — never in the
+// browser — so this `Date` parse runs on V8 in both the DOM and Playwright paths and needs no
+// cross-engine guarantee. Assumes the default (English) locale, matching this driver family's
+// other English defaults (e.g. the `mm/dd/yyyy` format fallback).
+function parseHeaderMonthOrdinal(label: string): number | null {
+  const parsed = new Date(label);
+  return Number.isNaN(parsed.getTime()) ? null : toMonthOrdinal(parsed.getFullYear(), parsed.getMonth());
+}
 
 export abstract class DesktopDatePickerDriverBase extends ComponentDriver<typeof parts> {
   constructor(
@@ -73,5 +118,117 @@ export abstract class DesktopDatePickerDriverBase extends ComponentDriver<typeof
    */
   async getFormat(defaultFormat: string = this.characteristic.defaultFormat): Promise<string> {
     return defaultFormat;
+  }
+
+  /**
+   * Set the picker's committed value to `value` by operating the calendar popup the way a user
+   * would: open it, page to the target month, and click the day cell. Returns `true` once the day
+   * is clicked.
+   *
+   * Only the year/month/day of `value` are used — any time component is ignored. Clearing (setting
+   * an empty value) is not handled here; the default desktop picker has no clear affordance.
+   *
+   * @param value The date to select.
+   * @param timeoutMs Budget for the popup to open and the day grid to render. Defaults to 10s.
+   */
+  async setValue(value: Date, timeoutMs: number = 10000): Promise<boolean> {
+    await this.openCalendar(timeoutMs);
+    await this.navigateToMonth(value.getFullYear(), value.getMonth(), timeoutMs);
+
+    // Day cells render in DOM order as days 1..N, so the day-of-month indexes straight into the
+    // timestamp list. Reading the timestamp from the DOM (rather than recomputing it) keeps the
+    // selection free of any timezone assumption about how the picker stamps each day.
+    const timestamps = await this.interactor.getAttribute(inMonthDayButtonsLocator, 'data-timestamp', true);
+    const targetTimestamp = timestamps[value.getDate() - 1];
+    if (targetTimestamp == null) {
+      throw new Error(
+        `${this.driverName}: day ${value.getDate()} is not available in the displayed month (found ${timestamps.length} days)`
+      );
+    }
+
+    await this.interactor.click(dayByTimestampLocator(targetTimestamp));
+    // Selecting a day closes the popup (closeOnSelect). Best-effort wait so a lingering popup does
+    // not overlay later interactions; the value is already committed by the click regardless.
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(popupLocator),
+      terminateCondition: false,
+      timeoutMs: 2000,
+    }).catch(() => undefined);
+    return true;
+  }
+
+  /**
+   * Convenience wrapper over {@link setValue} that accepts an ISO `yyyy-mm-dd` calendar date. The
+   * parts are read as a local date (no timezone shift), so the day clicked is exactly the one named.
+   *
+   * @param isoDate A `yyyy-mm-dd` string, e.g. `'2026-06-27'`.
+   */
+  async pickDate(isoDate: string): Promise<boolean> {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+    if (match == null) {
+      throw new Error(`${this.driverName}: pickDate expects a 'yyyy-mm-dd' date, received '${isoDate}'`);
+    }
+    const [, year, month, day] = match;
+    return this.setValue(new Date(Number(year), Number(month) - 1, Number(day)));
+  }
+
+  /**
+   * Open the calendar popup (no-op when already open) and wait until its day grid has rendered.
+   */
+  protected async openCalendar(timeoutMs: number = 10000): Promise<void> {
+    if (!(await this.interactor.exists(popupLocator))) {
+      await this.interactor.click(locatorUtil.append(this.locator, openButtonLocator));
+    }
+    // The day grid mounts a tick after the popup, so wait for an actual day cell, not just the popup.
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(inMonthDayButtonsLocator),
+      terminateCondition: true,
+      timeoutMs,
+    });
+  }
+
+  /**
+   * Page the open calendar to the given year/month by clicking the previous/next-month arrows. The
+   * displayed month is re-read from the header each step, so the walk converges regardless of arrow
+   * animation, and is bounded so an unreachable target (e.g. blocked by `minDate`/`maxDate`) fails
+   * fast instead of looping forever.
+   */
+  protected async navigateToMonth(year: number, monthIndex: number, timeoutMs: number = 10000): Promise<void> {
+    const target = toMonthOrdinal(year, monthIndex);
+    // A calendar spans at most a couple of decades of practical navigation; cap well above that.
+    const maxSteps = 24 * 30;
+    for (let step = 0; step < maxSteps; step++) {
+      const label = await this.interactor.getText(calendarHeaderLabelLocator);
+      const displayed = label != null ? parseHeaderMonthOrdinal(label) : null;
+      if (displayed == null) {
+        throw new Error(`${this.driverName}: could not read the calendar month from header "${label}"`);
+      }
+      if (displayed === target) {
+        // The header flips to the target immediately, but outgoing grids may still be sliding out;
+        // wait for them to leave so the caller reads day cells from the target month alone.
+        await this.waitForCalendarSettled(timeoutMs);
+        return;
+      }
+      await this.interactor.click(displayed < target ? nextMonthLocator : previousMonthLocator);
+      // Let the day grid for the new month mount before the next header read.
+      await this.waitUntil({
+        probeFn: () => this.interactor.exists(inMonthDayButtonsLocator),
+        terminateCondition: true,
+        timeoutMs,
+      });
+    }
+    throw new Error(`${this.driverName}: month ${year}-${String(monthIndex + 1).padStart(2, '0')} was not reachable`);
+  }
+
+  /**
+   * Wait until no month grid is mid-exit, i.e. the calendar shows a single settled month. No-op in
+   * non-animating environments (jsdom), where exiting grids never appear.
+   */
+  protected async waitForCalendarSettled(timeoutMs: number = 5000): Promise<void> {
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(exitingMonthGridLocator),
+      terminateCondition: false,
+      timeoutMs,
+    });
   }
 }

--- a/packages/component-driver-mui-x-v9/src/components/treeview/SimpleTreeViewDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/treeview/SimpleTreeViewDriver.ts
@@ -10,10 +10,13 @@ import {
 } from '@atomic-testing/core';
 
 // MUI X Tree View renders an accessible tree: a `[role=tree]` container whose items are
-// `<li role="treeitem">` carrying `aria-expanded` (expandable items only) and `aria-selected`
-// (when selection is enabled). Each item's own label lives in `.MuiTreeItem-label` inside its
-// `.MuiTreeItem-content`; child items live in a nested `<ul>` that is only rendered while the
-// parent is expanded (collapsed branches are absent from the DOM).
+// `<li role="treeitem">` carrying `aria-expanded` (expandable items only). Selection is reflected
+// on the item's `.MuiTreeItem-content` row via a `data-selected` marker (and the `<li>`'s
+// `aria-checked`), not the `aria-selected` older tree markup used — so selection is read from that
+// content marker, which holds across single/multi/checkbox selection modes. Each item's own label
+// lives in `.MuiTreeItem-label` inside its `.MuiTreeItem-content`; child items live in a nested
+// `<ul>` that is only rendered while the parent is expanded (collapsed branches are absent from the
+// DOM).
 //
 // Items are identified by the app-assigned `itemId`, which MUI emits as the suffix of the
 // element `id` (`mui-tree-view-<n>-<itemId>`). There is no dedicated `data-itemid`, so this
@@ -102,15 +105,11 @@ export class SimpleTreeViewDriver extends ComponentDriver {
   }
 
   /**
-   * Whether an item is selected. Reads `aria-selected`; only meaningful when the tree has
-   * selection enabled.
+   * Whether an item is selected. Reads the `data-selected` marker MUI X v9 places on the item's
+   * content row when it is selected; returns false for unselected or unrendered items.
    */
   async isSelected(itemId: string): Promise<boolean> {
-    const selected = await this.interactor.getAttribute(
-      locatorUtil.append(this.locator, itemLocator(itemId)),
-      'aria-selected'
-    );
-    return selected === 'true';
+    return this.interactor.hasAttribute(locatorUtil.append(this.locator, itemContentLocator(itemId)), 'data-selected');
   }
 
   /**
@@ -130,6 +129,20 @@ export class SimpleTreeViewDriver extends ComponentDriver {
     if (await this.isExpanded(itemId)) {
       await this.interactor.click(locatorUtil.append(this.locator, itemContentLocator(itemId)));
     }
+  }
+
+  /**
+   * Select the item identified by `itemId` by clicking its content row, the same row a user
+   * clicks to select. Selection must be enabled on the tree for this to register; verify with
+   * {@link isSelected}.
+   *
+   * Caveat: in a default tree the content row is also the expansion toggle, so selecting an
+   * EXPANDABLE item flips its expanded state as a side effect (MUI's own behavior). Leaf items
+   * — the common selection target — only select. Use {@link expandItem}/{@link collapseItem} to
+   * restore a parent's expansion state if both selection and a fixed expansion are needed.
+   */
+  async selectItem(itemId: string): Promise<void> {
+    await this.interactor.click(locatorUtil.append(this.locator, itemContentLocator(itemId)));
   }
 
   override get driverName(): string {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Core library for atomic-testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Core engine for HTML DOM testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/internal-mui-x-test-fixture/package.json
+++ b/packages/internal-mui-x-test-fixture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-mui-x-test-fixture",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "license": "MIT",
   "author": "Tianzhen Lin <tangent@usa.net>",

--- a/packages/internal-react-example/package.json
+++ b/packages/internal-react-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-react-example",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "description": "Shared example components for package tests",
   "license": "MIT",

--- a/packages/internal-test-runner-jest-adapter/package.json
+++ b/packages/internal-test-runner-jest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-jest-adapter",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "description": "Jest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner-playwright-adapter/package.json
+++ b/packages/internal-test-runner-playwright-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-playwright-adapter",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "description": "Playwright adapter for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/internal-test-runner-vitest-adapter/package.json
+++ b/packages/internal-test-runner-vitest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-vitest-adapter",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "description": "Vitest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner/package.json
+++ b/packages/internal-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "private": true,
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Atomic Testing Playwright Adapter",
   "keywords": [],
   "license": "MIT",

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-18",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-19/package.json
+++ b/packages/react-19/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-19",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-core",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Shared utilities for Atomic Testing React adapters",
   "keywords": [
     "react",

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-legacy",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Adapter for testing React 17 and earlier",
   "keywords": [
     "legacy",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/vue-3",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "The @atomic-testing/vue-3 package is a Vue 3 test adapter that extends Atomic Testing's component driver pattern to Vue applications. It enables testing Vue components using the same high-level semantic APIs used across React, Playwright, and DOM environments.",
   "keywords": [
     "integration",


### PR DESCRIPTION
Implements #985 — a standalone **MUI 9 + MUI-X 9 ticket triage console** example, plus the two upstream MUI-X v9 driver gaps it needs (built as general APIs, per the issue's driver-gap protocol).

## What changed

### Upstream drivers (built first, as reusable monorepo APIs)
- **`DesktopDatePickerDriver.setValue(date)` / `pickDate('yyyy-mm-dd')`** (#995). The portable write path is the **calendar popup** — the only path whose primitive is a plain click, behaving identically in jsdom and real browsers. Keystroke entry was rejected because Playwright's `fill` replaces innerText (MUI ignores it) and the DOM interactor's `pressKey` fires no `input` event, so digit entry would pass E2E but fail jsdom. The driver opens via `data-mui-picker-open-button`, pages months by reading the header label (parsed in the driver's JS runtime → no cross-browser parse risk) using the locale-free arrow classes, and picks the day from the in-month cells' `data-timestamp` array (**read from the DOM, never computed → timezone-proof**), waiting out the `slideExit` animation so stacked month grids don't corrupt the read.
- **`SimpleTreeViewDriver.selectItem(itemId)`** + a fix to **`isSelected`** (#996). Digging the real v9 DOM showed selection is reflected by `data-selected` / `aria-checked`, **not** `aria-selected` — so the shipped `isSelected` was silently broken (no existing test exercised selection). Both added/fixed.
- New tests in the shipped MUI-X v9 suites for both; the suites stay green. Monorepo versions bumped to **0.90.0**.

### The example — `examples/example-mui-ticket-console/`
Five composed page-object drivers (`FilterBarDriver`, `TicketGridDriver`, `TicketEditorDriver`, `TeamNavDriver`) compose into one `TicketConsoleDriver`. The **same** `consoleParts` scene and the **same** scenario flows (`src/testing/scenarios.ts`) are imported by both the Vitest DOM test and the Playwright spec — only the `TestEngine` construction differs (`createTestEngine(<App/>, …)` vs `createTestEngine(page, …)`). That's the headline dedup proof. Four scenarios: triage flow, empty state, tab switch, validation.

Grid uses the **community** `@mui/x-data-grid` (no license watermark) — `DataGridPremiumDriver` drives it unchanged.

## Decisions (from the issue's `AskUserQuestion` protocol)
| Question | Decision |
|---|---|
| Two driver gaps | **Build upstream** as general APIs (this PR) |
| DataGrid tier | **Community** `@mui/x-data-grid` |
| Track gaps | **File issues** → #995, #996 |

## Test results
- `pnpm test:dom` (Vitest/jsdom): **4/4**
- `pnpm test:e2e` (chromium + firefox + webkit): **12/12**
- `pnpm check:type`, oxlint, oxfmt: clean
- Upstream MUI-X v9 suites: 18 DOM + 39 E2E still green

## Reviewer notes
- **Dev port is 8090** (not the issue's 5173), matching the Astryx example's dedicated-port convention; `PORT`-overridable. Happy to switch to 5173 if preferred.
- **Wiring bridge:** the example is a standalone workspace pinning `@atomic-testing/*@^0.90.0`. Because 0.90.0 isn't published yet, its `pnpm-workspace.yaml` `overrides` link those deps (and their transitive `workspace:*`) to the in-repo builds so it runs today. **Once 0.90.0 ships, delete that overrides block** (documented in the example README) and it becomes a clean registry consumer.

Closes #995, closes #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
