### PR TITLE
chore(examples): drop ticket-console overrides bridge now that 0.90.0 is published

### DIFF
--- a/examples/example-mui-ticket-console/README.md
+++ b/examples/example-mui-ticket-console/README.md
@@ -81,7 +81,7 @@ This scenario needs to *set* a date picker and *select* a tree item — capabili
 - `DesktopDatePickerDriver.setValue(date)` / `pickDate('yyyy-mm-dd')` — operates the calendar popup (open → page to the month → click the day), the one write path that behaves identically in jsdom and in real browsers.
 - `SimpleTreeViewDriver.selectItem(itemId)` — clicks the item's content row to select it.
 
-Because this example consumes those methods, it depends on `@atomic-testing/*@^0.90.0`. See *Dependency wiring* for how it runs before that version is published.
+Because this example consumes those methods, it depends on `@atomic-testing/*@^0.90.0`.
 
 ### Community vs. premium DataGrid
 
@@ -91,4 +91,4 @@ The example uses the **community** `@mui/x-data-grid` (no license watermark). Th
 
 This example is a **standalone pnpm workspace** (its own `pnpm-lock.yaml`, intentionally not a member of the monorepo's root workspace), mirroring a real consumer install.
 
-It pins `@atomic-testing/*@^0.90.0`. Until 0.90.0 is published to npm, [`pnpm-workspace.yaml`](pnpm-workspace.yaml) carries an `overrides` block that resolves every atomic-testing dependency — direct and the packages' own transitive `workspace:*` deps — to the in-repo builds, so the example runs against the exact driver code the 0.90.0 release adds. **Once 0.90.0 is on npm, delete that overrides block** and the `^0.90.0` ranges resolve straight from the registry.
+It pins `@atomic-testing/*@^0.90.0`, resolved straight from the npm registry.

--- a/examples/example-mui-ticket-console/pnpm-lock.yaml
+++ b/examples/example-mui-ticket-console/pnpm-lock.yaml
@@ -4,17 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@atomic-testing/core': link:../../packages/core
-  '@atomic-testing/dom-core': link:../../packages/dom-core
-  '@atomic-testing/react-core': link:../../packages/react-core
-  '@atomic-testing/react-18': link:../../packages/react-18
-  '@atomic-testing/react-19': link:../../packages/react-19
-  '@atomic-testing/playwright': link:../../packages/playwright
-  '@atomic-testing/component-driver-html': link:../../packages/component-driver-html
-  '@atomic-testing/component-driver-mui-v9': link:../../packages/component-driver-mui-v9
-  '@atomic-testing/component-driver-mui-x-v9': link:../../packages/component-driver-mui-x-v9
-
 importers:
 
   .:
@@ -51,26 +40,26 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@atomic-testing/component-driver-html':
-        specifier: link:../../packages/component-driver-html
-        version: link:../../packages/component-driver-html
+        specifier: ^0.90.0
+        version: 0.90.0
       '@atomic-testing/component-driver-mui-v9':
-        specifier: link:../../packages/component-driver-mui-v9
-        version: link:../../packages/component-driver-mui-v9
+        specifier: ^0.90.0
+        version: 0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@atomic-testing/component-driver-mui-x-v9':
-        specifier: link:../../packages/component-driver-mui-x-v9
-        version: link:../../packages/component-driver-mui-x-v9
+        specifier: ^0.90.0
+        version: 0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@atomic-testing/core':
-        specifier: link:../../packages/core
-        version: link:../../packages/core
+        specifier: ^0.90.0
+        version: 0.90.0
       '@atomic-testing/dom-core':
-        specifier: link:../../packages/dom-core
-        version: link:../../packages/dom-core
+        specifier: ^0.90.0
+        version: 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
       '@atomic-testing/playwright':
-        specifier: link:../../packages/playwright
-        version: link:../../packages/playwright
+        specifier: ^0.90.0
+        version: 0.90.0(@playwright/test@1.61.1)
       '@atomic-testing/react-19':
-        specifier: link:../../packages/react-19
-        version: link:../../packages/react-19
+        specifier: ^0.90.0
+        version: 0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -82,7 +71,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.3(vite@8.1.1)
+        version: 6.0.3(vite@8.1.2)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -91,10 +80,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.16
-        version: 8.1.1
+        version: 8.1.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(jsdom@29.1.1)(vite@8.1.1)
+        version: 4.1.9(jsdom@29.1.1)(vite@8.1.2)
 
 packages:
 
@@ -112,6 +101,56 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@atomic-testing/component-driver-html@0.90.0':
+    resolution: {integrity: sha512-6kVWTkBmW0jsTFvWDVXhMBwEg3u6qZTU748laOMcgEchYC3ZHD9Fx4o6qSiYuiPLva8XGu9Xa+gDm2wHhEoLqA==}
+
+  '@atomic-testing/component-driver-mui-v9@0.90.0':
+    resolution: {integrity: sha512-DCZ7Jtwu90kGtPsB0kT71Ei06VPR6D2PE/1iPX+wKXOGif0G8uHqCnqatC4+BGTcSLzqxAo9MoxwJjGAeLqMwg==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@atomic-testing/component-driver-mui-x-v9@0.90.0':
+    resolution: {integrity: sha512-X8bfD+EL2pNk6U8pl3eWhJjBiAdf9Q3l24lZO5kgtYhVwGc9wRQvUlwbCuJOsYyduvsecPnZ8T6iRyQzeyFOSQ==}
+
+  '@atomic-testing/core@0.90.0':
+    resolution: {integrity: sha512-JpLIm4lZhxg9Duo0TZfyFo4YfSXjQxl0eV8lWxphPIJ0WFygJfen+n619BSntzKchDL4f2cb4qKMGE2pcaIHsQ==}
+
+  '@atomic-testing/dom-core@0.90.0':
+    resolution: {integrity: sha512-/nuVqz67w1k/C0vHGOyiWE55t7RCvvlk2QHN6En+Qa4xV3DqcJodHfkCv18nRnh1lg2MEaYSZc0vZbbPmmntug==}
+    peerDependencies:
+      '@testing-library/dom': '>=10.4.1'
+      '@testing-library/user-event': '>=14.0.0'
+
+  '@atomic-testing/playwright@0.90.0':
+    resolution: {integrity: sha512-AS8Ur5vkdfWFlB0WxAM8jkeF81dWffe2kIiT7sHVJSSH0bAdZLgBN++aWqov1Kh1fWTjKRx0H8bpFWTaO83C3A==}
+    peerDependencies:
+      '@playwright/test': '>=1.50.0'
+
+  '@atomic-testing/react-18@0.90.0':
+    resolution: {integrity: sha512-bCmLHwyMhWeFqdt+I78094lMb0/ldJKDlyXs0EryULjgWz7PHx3j9pkkynqeyRya9Thj5JGzLTPauy/Vjmb5tw==}
+    peerDependencies:
+      '@testing-library/dom': '>=10.4.1'
+      '@testing-library/react': '>=16.2.0'
+      '@testing-library/user-event': '>=14.0.0'
+      react: '>=18.0.0 <19.0.0'
+      react-dom: '>=18.0.0 <19.0.0'
+
+  '@atomic-testing/react-19@0.90.0':
+    resolution: {integrity: sha512-M0brDa8gJMeAOT9yE8XiEwLCWxp/jRSvuflTWUCUdyE9gVTmvkgCFjE2+rf3xjz48MBHi9wj953DqweBgueneQ==}
+    peerDependencies:
+      '@testing-library/dom': '>=10.2.0'
+      '@testing-library/react': '>=16.2.0'
+      '@testing-library/user-event': '>=14.0.0'
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+
+  '@atomic-testing/react-core@0.90.0':
+    resolution: {integrity: sha512-mDR0BFwlla2n6A3X5bBH1//JsR9ej6za6VhEFbiUB87AHXuhDIwunmBse2BN4iE5TQGBaI1+4kVFWrZM1Vkqcg==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -521,42 +560,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
     resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
@@ -587,8 +620,36 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -660,6 +721,17 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -722,9 +794,16 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -859,28 +938,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -908,6 +983,10 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -973,6 +1052,10 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -987,6 +1070,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
@@ -1103,8 +1189,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vite@8.1.1:
-    resolution: {integrity: sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==}
+  vite@8.1.2:
+    resolution: {integrity: sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1240,6 +1326,100 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@atomic-testing/component-driver-html@0.90.0':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+
+  '@atomic-testing/component-driver-mui-v9@0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/component-driver-html': 0.90.0
+      '@atomic-testing/core': 0.90.0
+      '@atomic-testing/dom-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@atomic-testing/react-18': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@mui/material-pigment-css'
+      - '@testing-library/dom'
+      - '@testing-library/react'
+      - '@testing-library/user-event'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  '@atomic-testing/component-driver-mui-x-v9@0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/component-driver-html': 0.90.0
+      '@atomic-testing/component-driver-mui-v9': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@atomic-testing/core': 0.90.0
+    transitivePeerDependencies:
+      - '@mui/material-pigment-css'
+      - '@testing-library/dom'
+      - '@testing-library/react'
+      - '@testing-library/user-event'
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - supports-color
+
+  '@atomic-testing/core@0.90.0': {}
+
+  '@atomic-testing/dom-core@0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+
+  '@atomic-testing/playwright@0.90.0(@playwright/test@1.61.1)':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+      '@playwright/test': 1.61.1
+
+  '@atomic-testing/react-18@0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+      '@atomic-testing/dom-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@atomic-testing/react-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@atomic-testing/react-19@0.90.0(@testing-library/dom@10.4.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+      '@atomic-testing/dom-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@atomic-testing/react-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@atomic-testing/react-core@0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@atomic-testing/core': 0.90.0
+      '@atomic-testing/dom-core': 0.90.0(@testing-library/dom@10.4.1)(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - '@testing-library/user-event'
+      - '@types/react'
+      - '@types/react-dom'
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -1692,10 +1872,37 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1722,10 +1929,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.1)':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.2)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.1
+      vite: 8.1.2
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -1736,13 +1943,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.1)':
+  '@vitest/mocker@4.1.9(vite@8.1.2)':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.1
+      vite: 8.1.2
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -1767,6 +1974,14 @@ snapshots:
       '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -1822,7 +2037,11 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -1977,6 +2196,8 @@ snapshots:
 
   lru-cache@11.5.1: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2030,6 +2251,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -2044,6 +2271,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@19.2.7: {}
 
@@ -2150,7 +2379,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  vite@8.1.1:
+  vite@8.1.2:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2160,10 +2389,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.9(jsdom@29.1.1)(vite@8.1.1):
+  vitest@4.1.9(jsdom@29.1.1)(vite@8.1.2):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.1)
+      '@vitest/mocker': 4.1.9(vite@8.1.2)
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -2180,7 +2409,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.1
+      vite: 8.1.2
       why-is-node-running: 2.3.0
     optionalDependencies:
       jsdom: 29.1.1

--- a/examples/example-mui-ticket-console/pnpm-workspace.yaml
+++ b/examples/example-mui-ticket-console/pnpm-workspace.yaml
@@ -2,18 +2,5 @@
 # isolated from the monorepo's root workspace — it is intentionally NOT a member of that one).
 #
 # The atomic-testing dependencies are declared at ^0.90.0 (the release that adds
-# DesktopDatePickerDriver.pickDate / setValue and SimpleTreeViewDriver.selectItem). Until 0.90.0 is
-# published to npm, these `overrides` resolve every atomic-testing dependency — direct AND the
-# packages' own transitive `workspace:*` deps — to the in-repo builds, so the example runs against
-# the exact driver code its tests rely on. Once 0.90.0 is on npm, delete this overrides block and
-# the ^0.90.0 ranges resolve straight from the registry, mirroring a real consumer install.
-overrides:
-  '@atomic-testing/core': link:../../packages/core
-  '@atomic-testing/dom-core': link:../../packages/dom-core
-  '@atomic-testing/react-core': link:../../packages/react-core
-  '@atomic-testing/react-18': link:../../packages/react-18
-  '@atomic-testing/react-19': link:../../packages/react-19
-  '@atomic-testing/playwright': link:../../packages/playwright
-  '@atomic-testing/component-driver-html': link:../../packages/component-driver-html
-  '@atomic-testing/component-driver-mui-v9': link:../../packages/component-driver-mui-v9
-  '@atomic-testing/component-driver-mui-x-v9': link:../../packages/component-driver-mui-x-v9
+# DesktopDatePickerDriver.pickDate / setValue and SimpleTreeViewDriver.selectItem) and resolve
+# straight from the npm registry, mirroring a real consumer install.


### PR DESCRIPTION
## Summary
- `examples/example-mui-ticket-console` shipped in #997 with a temporary `pnpm-workspace.yaml` `overrides` block pinning `@atomic-testing/*` to in-repo builds, since `0.90.0` wasn't on npm yet at merge time.
- `@atomic-testing/*@0.90.0` is now published (confirmed against the npm registry). This removes the overrides block and the matching README note, per the follow-up the README itself documented.
- Reinstalled with a fresh lockfile against the published package and reverified.

## Test plan
- [x] `pnpm install` resolves `@atomic-testing/*` at `0.90.0` straight from the registry (no `link:` overrides)
- [x] `pnpm test:dom` — 4/4 passed
- [x] `pnpm test:e2e` — 12/12 passed (chromium, firefox, webkit)
- [x] `pnpm check:type` — clean

Refs #985 (closed — implemented by #997; this closes out its last documented follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)