### PR TITLE
docs: make the first unit test reachable from the docs

### DIFF
--- a/docs/docs/getting-started-tutorial.mdx
+++ b/docs/docs/getting-started-tutorial.mdx
@@ -4,153 +4,241 @@ title: 'Step-by-Step Tutorial'
 sidebar_position: 5
 ---
 
-import loginFormDriver from '!!raw-loader!./snippets/login-form-driver';
+import loginFormDriver from '!!raw-loader!./snippets/login-form-driver-html';
 import signupE2e from '!!raw-loader!./snippets/signup-form-e2e.spec';
 import CodeBlock from '@theme/CodeBlock';
 
-This tutorial walks you through the [example-mui-signup-form](https://github.com/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form) found in the [examples](https://github.com/atomic-testing/atomic-testing/tree/main/examples) folder. You may run and see it live in [Codesandbox](https://codesandbox.io/p/sandbox/github/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form). It demonstrates how to run the example application and introduces the basic **Atomic Testing** APIs for writing tests. Component drivers work the same in isolated unit tests or full browser tests so the code you see here applies to both environments.
+This tutorial builds one complete, runnable **Atomic Testing** test from scratch using the canonical stack — `@atomic-testing/react-19` + `@atomic-testing/component-driver-html` + Jest — the same stack introduced in [Quick Start](./quick-start.mdx). Component drivers work the same way in isolated unit tests or full browser tests, so everything you see here applies to both.
+
+Once you have a green test, the tutorial shows how to wrap a component library like Material UI, compose drivers for reuse, and reuse the same scene in a Playwright E2E test. An **optional** section at the end walks through the full [example-mui-signup-form](https://github.com/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form) app if you want to see a larger, real-world codebase.
 
 ## 1. Install dependencies
 
-From the repository root run:
+```bash
+pnpm add -D @atomic-testing/core @atomic-testing/react-19 @atomic-testing/component-driver-html
+pnpm add -D jest jest-environment-jsdom @swc/jest @types/jest
+```
+
+(Already have a runner configured? Skip to [step 2](#2-configure-jest). See [Configure your test runner](./setup.mdx#configure-your-test-runner) for the Vitest equivalent.)
+
+## 2. Configure Jest
+
+```js title="jest.config.js"
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': ['@swc/jest', { jsc: { transform: { react: { runtime: 'automatic' } } } }],
+  },
+  // ReactInteractor wraps every interaction in React's act(); this flag stops
+  // React from logging spurious "not wrapped in act(...)" warnings.
+  globals: { IS_REACT_ACT_ENVIRONMENT: true },
+};
+```
+
+## 3. Write the component under test
+
+```tsx title="LoginForm.tsx"
+import { useState } from 'react';
+
+export function LoginForm({ onSubmit }: { onSubmit: (username: string) => void }) {
+  const [username, setUsername] = useState('');
+
+  return (
+    <form
+      data-testid='login-form'
+      onSubmit={e => {
+        e.preventDefault();
+        onSubmit(username);
+      }}
+    >
+      <input data-testid='username' value={username} onChange={e => setUsername(e.target.value)} />
+      <button data-testid='submit' disabled={username.length === 0}>
+        Log in
+      </button>
+    </form>
+  );
+}
+```
+
+## 4. Declare a ScenePart
+
+A ScenePart maps each `data-testid` to a locator and the driver that knows how to interact with it:
+
+```ts title="LoginForm.scene.ts"
+import { HTMLButtonDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+export const loginFormScene = {
+  username: { locator: byDataTestId('username'), driver: HTMLTextInputDriver },
+  submit: { locator: byDataTestId('submit'), driver: HTMLButtonDriver },
+} satisfies ScenePart;
+```
+
+## 5. Render, interact, assert, clean up
+
+```tsx title="LoginForm.test.tsx"
+import { TestEngine } from '@atomic-testing/core';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { LoginForm } from './LoginForm';
+import { loginFormScene } from './LoginForm.scene';
+
+describe('LoginForm', () => {
+  let engine: TestEngine<typeof loginFormScene>;
+  let onSubmit: jest.Mock;
+
+  beforeEach(() => {
+    onSubmit = jest.fn();
+    engine = createTestEngine(<LoginForm onSubmit={onSubmit} />, loginFormScene);
+  });
+
+  afterEach(async () => {
+    await engine.cleanUp();
+  });
+
+  it('enables submit once a username is entered', async () => {
+    expect(await engine.parts.submit.isDisabled()).toBe(true);
+
+    await engine.parts.username.setValue('ada');
+    expect(await engine.parts.submit.isDisabled()).toBe(false);
+
+    await engine.parts.submit.click();
+    expect(onSubmit).toHaveBeenCalledWith('ada');
+  });
+});
+```
+
+## 6. Run it
+
+```bash
+npx jest
+```
+
+You should see one passing test. That's the whole loop: **install → configure → render → interact → assert → clean up.**
+
+## 7. Compose a driver for reuse
+
+For larger forms it's convenient to wrap the individual inputs in a driver of your own, exposing a high-level action instead of making tests poke at each field. Below is a driver for the `LoginForm` above, combining `HTMLTextInputDriver` and `HTMLButtonDriver`:
+
+<CodeBlock language='ts'>{loginFormDriver}</CodeBlock>
+
+Use it in place of the raw scene parts:
+
+```ts title="LoginForm.test.tsx (with a composed driver)"
+const parts = {
+  form: { locator: byDataTestId('login-form'), driver: LoginFormDriver },
+} satisfies ScenePart;
+
+const engine = createTestEngine(<LoginForm onSubmit={onSubmit} />, parts);
+await engine.parts.form.login({ username: 'ada' });
+```
+
+With the `login()` helper, tests stay declarative and don't depend on the form's markup. If the implementation changes, update only `LoginFormDriver`.
+
+## 8. Same scene, now in Playwright (E2E)
+
+Because drivers depend only on the `Interactor` abstraction, the exact same `loginFormScene` from step 4 works against a real browser page — you just create the engine with `@atomic-testing/playwright`'s `createTestEngine(page, ...)` instead of React's. As covered in the [Playwright notes on Quick Start](./quick-start.mdx), this requires an actual page served by your app (Playwright drives a real browser, not jsdom) — configure `webServer`/`baseURL` in `playwright.config.ts` to point at it:
+
+```ts title="login.e2e.spec.ts"
+import { createTestEngine } from '@atomic-testing/playwright';
+import { test, expect } from '@playwright/test';
+
+import { loginFormScene } from './LoginForm.scene';
+
+test('enables submit once a username is entered', async ({ page }) => {
+  await page.goto('/login'); // a route your app actually serves
+  const engine = createTestEngine(page, loginFormScene);
+
+  expect(await engine.parts.submit.isDisabled()).toBe(true);
+  await engine.parts.username.setValue('ada');
+  expect(await engine.parts.submit.isDisabled()).toBe(false);
+
+  await engine.cleanUp();
+});
+```
+
+## Testing a component library (e.g. MUI)
+
+Component libraries like Material UI often need a context provider — a `ThemeProvider`, a router, etc. — to render correctly. `createTestEngine` has no knowledge of your app's providers, so wrap the component yourself before passing it in.
+
+The [example-mui-signup-form](https://github.com/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form) app does exactly this with a small local helper. It is **not** a package export — you write the equivalent for your own app:
+
+```tsx title="testUtil.tsx (example-local helper, not a package export)"
+import { createTestEngine } from '@atomic-testing/react-19';
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
+import { ReactNode } from 'react';
+
+import { theme } from './theme';
+
+const ComponentWrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    {children}
+  </ThemeProvider>
+);
+
+export const createTestEngineForComponent: typeof createTestEngine = (node, partDefinitions, option) =>
+  createTestEngine(<ComponentWrapper>{node}</ComponentWrapper>, partDefinitions, option);
+```
+
+Once you have that wrapper, use it exactly like `createTestEngine`, and reach for a component-library driver package instead of the HTML drivers — for example `@atomic-testing/component-driver-mui-v7` (see the [Package Guide](./framework-guide.mdx) for which MUI version matches your app):
+
+```ts
+import { ButtonDriver, TextFieldDriver } from '@atomic-testing/component-driver-mui-v7';
+import { byDataTestId, ScenePart } from '@atomic-testing/core';
+
+const parts = {
+  username: { locator: byDataTestId('username'), driver: TextFieldDriver },
+  submit: { locator: byDataTestId('submit'), driver: ButtonDriver },
+} satisfies ScenePart;
+
+const engine = createTestEngineForComponent(<CredentialForm />, parts);
+```
+
+## Optional: explore the full example app
+
+The rest of this section tours [example-mui-signup-form](https://github.com/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form), a larger multi-step signup form in the monorepo's [examples](https://github.com/atomic-testing/atomic-testing/tree/main/examples) folder, built with the `createTestEngineForComponent` wrapper from the previous section. You may also run it live in [Codesandbox](https://codesandbox.io/p/sandbox/github/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form) without installing anything locally.
+
+### Install and run it
+
+From the repository root:
 
 ```bash
 pnpm install
-```
-
-The example project has its own dependencies so install them as well:
-
-```bash
 cd examples/example-mui-signup-form
 pnpm install
-```
-
-## 2. Start the example application
-
-Run the app locally to see the signup form in action:
-
-```bash
 pnpm dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) in your browser to interact with the multi‑step form.
+Open [http://localhost:5173](http://localhost:5173) to interact with the multi-step form.
 
-## 3. Run the component tests
-
-Unit tests for each form step live under their respective `__tests__` directories. Execute them with:
+### Run its tests
 
 ```bash
-pnpm test:dom
+pnpm test:dom          # Unit tests for each form step
+pnpm test:e2e:chrome   # e2e/success.spec.ts in Chrome (add --ui to watch it)
 ```
 
-## 4. Run the end‑to‑end test
+### Explore Storybook (optional)
 
-The example also includes an end‑to‑end scenario located in `e2e/success.spec.ts`. Launch it in Chrome with:
-
-```bash
-pnpm test:e2e:chrome
-```
-
-Add the `--ui` flag to open Playwright in UI mode if you want to watch the interactions.
-
-## 5. Explore Storybook (optional)
-
-Some components contain Storybook stories with interaction tests. To view them, run:
+Some components contain Storybook stories with interaction tests:
 
 ```bash
 pnpm storybook
 ```
 
-## 6. Write your first Atomic test
+### Write an end-to-end test
 
-The signup form example includes unit tests written with **Atomic Testing**. The steps below outline the main pieces required to create a test.
-
-### Declare `data-testid`
-
-Assign the `data-testid` attribute on components that you need to interact with. This example shows the markup for the credential form:
-
-```tsx title="CredentialForm.tsx"
-<form data-testid={DataTestId.form}>
-  <TextField data-testid={DataTestId.emailInput} label='Email' />
-  <TextField data-testid={DataTestId.passwordInput} label='Password' />
-  <WizardButton data-testid={DataTestId.navigation} onNextStep={onNextStep} />
-</form>
-```
-
-### Define a ScenePart
-
-Create a ScenePart describing how to locate each component and which driver to use:
-
-```ts title="credentialScenePart.ts"
-const parts = {
-  form: {
-    locator: byDataTestId(DataTestId.form),
-    driver: CredentialFormDriver,
-  },
-} satisfies ScenePart;
-```
-
-### Instantiate the Test Engine and write a test
-
-```ts title="CredentialForm.test.tsx"
-import { afterEach, beforeEach, expect, test, vi, type Mock } from 'vitest';
-
-let testEngine: TestEngine<typeof parts>;
-let onNext: Mock;
-
-beforeEach(() => {
-  onNext = vi.fn();
-  testEngine = createTestEngineForComponent(
-    <CredentialForm data-testid={DataTestId.form} onNextStep={onNext} />,
-    parts
-  );
-});
-
-afterEach(async () => {
-  await testEngine.cleanUp();
-});
-
-test('submits valid data', async () => {
-  await testEngine.parts.form.setValue({
-    email: 'john@example.com',
-    password: 'secret123',
-    confirmPassword: 'secret123',
-    birthday: '1990-01-01',
-  });
-  await testEngine.parts.form.next();
-  expect(onNext).toHaveBeenCalled();
-});
-```
-
-The test engine renders the component, exposes the parts defined in the `ScenePart`, and provides helper methods from the driver to interact with the component. Always call `cleanUp()` after each test to unmount the component and release resources.
-
-## 7. Build a form driver
-
-For larger forms it is convenient to create a driver that wraps the individual inputs. Below is a simplified driver for a login form.
-
-<CodeBlock language='ts'>{loginFormDriver}</CodeBlock>
-
-Use it in a test:
-
-```ts title="LoginForm.test.tsx"
-const parts = {
-  form: { locator: byDataTestId('login-form'), driver: LoginFormDriver },
-} satisfies ScenePart;
-
-const engine = createTestEngineForComponent(<LoginForm />, parts);
-await engine.parts.form.login({ username: 'admin', password: 'secret' });
-```
-
-With the `login()` helper tests stay declarative and don't depend on the form's markup. If the implementation changes, update only `LoginFormDriver`.
-
-## 8. Write an end-to-end test
-
-Drivers work the same way in browser-based tests. The snippet below shows a Playwright test that reuses the drivers from the unit tests.
+The example's `e2e/success.spec.ts` reuses the same drivers as its unit tests — this is the pattern from [step 8](#8-same-scene-now-in-playwright-e2e) above, applied to the full signup flow:
 
 <CodeBlock language='ts'>{signupE2e}</CodeBlock>
 
-Because the driver encapsulates how to fill in the form, the test logic is short and can run in any browser supported by Playwright.
+## What to try next
 
-## Next steps
-
-Browse the example source code to see how scene parts, drivers and the test engine are set up. Then refer back to the [Setup](./setup.mdx) and [Core Concepts](./core-concepts.mdx) pages for more details on creating your own tests.
+- [Core Concepts](./core-concepts.mdx) — the vocabulary behind ScenePart, Locator, and TestEngine
+- [Best Practices](./best-practices.mdx) — patterns for keeping tests portable and maintainable
+- [Package Guide](./framework-guide.mdx) — which driver and framework packages to install for your stack
+- [Build Component Driver](./advanced-concepts/build-component-driver.mdx) — write a driver for a custom or unsupported component
+- [API Reference](./api-overview.mdx) — the full list of locators, drivers, and interactor methods

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -19,15 +19,14 @@ import Tabs from '@theme/Tabs';
 ## Installation
 
 ```bash
-# For React 19 with MUI v7
-pnpm add @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/react-19 @atomic-testing/component-driver-mui-v7
-
-# For React 18 with MUI v6
-pnpm add @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/react-18 @atomic-testing/component-driver-mui-v6
-
-# For React 17 or earlier with MUI v5
-pnpm add @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/react-legacy @atomic-testing/component-driver-mui-v5
+pnpm add @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/react-19
 ```
+
+On React 18 or React 17, swap in `@atomic-testing/react-18` or `@atomic-testing/react-legacy` — see the [Package Guide](./framework-guide.mdx) for the full matrix. Testing Material UI or another component library instead of plain HTML elements? See [Testing a component library](./getting-started-tutorial.mdx#testing-a-component-library-eg-mui).
+
+:::info Before you run this
+This test needs a jsdom-based runner (Jest or Vitest) with `IS_REACT_ACT_ENVIRONMENT` set. See [Configure your test runner](./setup.mdx#configure-your-test-runner) — one-time setup, applies to every example on this page.
+:::
 
 ## Your First Test
 
@@ -82,6 +81,20 @@ it('should welcome the user when clicked', async () => {
 ```bash
 pnpm add @atomic-testing/vue-3 @atomic-testing/component-driver-html
 ```
+
+:::info Before you run this
+Vue tests run under [Vitest](https://vitest.dev) with the `jsdom` environment:
+
+```ts title="vitest.config.ts"
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { environment: 'jsdom' },
+});
+```
+
+Unlike the React setup, no `IS_REACT_ACT_ENVIRONMENT` flag is needed — `VueInteractor` calls Vue's own `nextTick()` internally. See [Configure your test runner](./setup.mdx#configure-your-test-runner) for the Jest equivalent if you're testing React elsewhere in the same repo.
+:::
 
 ## Your First Test
 
@@ -142,6 +155,25 @@ it('should welcome the user when clicked', async () => {
 pnpm add @atomic-testing/playwright @atomic-testing/component-driver-html
 ```
 
+:::info DOM tests vs. Playwright tests
+The React and Vue tabs above render components directly into an in-memory jsdom document — nothing is served over HTTP. Playwright is different: `page.goto('/welcome')` drives a **real browser against a page your app actually serves**. The snippet below is illustrative — it only turns green once you have an app running that serves a `/welcome` route rendering the equivalent of the `WelcomeButton` component from the React tab (same `data-testid`s). Point Playwright at that server with `webServer`/`baseURL` in `playwright.config.ts`:
+
+```ts title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'pnpm dev', // starts your app's dev server
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+:::
+
 ## Your First Test
 
 ```typescript
@@ -156,8 +188,11 @@ const welcomeScene = {
   button: { locator: byDataTestId('welcome-btn'), driver: HTMLButtonDriver },
 };
 
+// Assumes a served page at "/welcome" that renders a WelcomeButton with
+// name="Alice" (see the caveat above) — this is illustrative, not copy-paste
+// runnable against an empty project.
 test('should welcome the user when clicked', async ({ page }) => {
-  // Navigate to your app
+  // Navigate to your app (driven by baseURL from playwright.config.ts)
   await page.goto('/welcome');
 
   // Create test engine with same scene
@@ -181,7 +216,7 @@ Notice how the test logic is **identical across frameworks**:
 
 1. **Same Scene Definition**: `welcomeScene` works everywhere
 2. **Same Test Code**: `engine.parts.button.click()` works everywhere
-3. **Same Component Drivers**: HTML/MUI drivers work everywhere
+3. **Same Component Drivers**: `component-driver-html` (or a component-library driver package, if you use one) works everywhere
 
 **This means**: Learn once, test everywhere. Your testing knowledge transfers completely between frameworks.
 

--- a/docs/docs/setup.mdx
+++ b/docs/docs/setup.mdx
@@ -3,7 +3,79 @@ id: setup
 sidebar_position: 3
 ---
 
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 # Setup
+
+## Configure your test runner
+
+Atomic Testing renders your component through your framework's real reconciler (React's `act()`, Vue's `nextTick()`), so before writing any test you need a runner that gives you a DOM to render into and compiles TSX. The configs below are the same ones used by this repo's own test suites (see [`package-tests/component-driver-html-test`](https://github.com/atomic-testing/atomic-testing/tree/main/package-tests/component-driver-html-test)).
+
+<Tabs>
+<TabItem value="jest" label="Jest">
+
+```bash
+pnpm add -D jest jest-environment-jsdom @swc/jest @types/jest
+```
+
+```js title="jest.config.js"
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': [
+      '@swc/jest',
+      { jsc: { transform: { react: { runtime: 'automatic' } } } },
+    ],
+  },
+  // ReactInteractor wraps every interaction in React's act(). Without this flag,
+  // React 18+ logs "not wrapped in act(...)" warnings even though it is.
+  globals: {
+    IS_REACT_ACT_ENVIRONMENT: true,
+  },
+};
+```
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "jest"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="vitest" label="Vitest">
+
+```bash
+pnpm add -D vitest jsdom
+```
+
+```ts title="vitest.config.ts"
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});
+```
+
+```ts title="vitest.setup.ts"
+// Same act()-environment flag as the Jest config above — required whenever
+// you're testing React components through `@atomic-testing/react-19` (or
+// react-18 / react-legacy).
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+```
+
+</TabItem>
+</Tabs>
+
+:::tip Testing Vue instead?
+Skip the `IS_REACT_ACT_ENVIRONMENT` flag — `VueInteractor` calls Vue's own `nextTick()` and doesn't need it. The `jsdom` environment is still required. See the Vue notes on the [Quick Start](./quick-start.mdx) page.
+:::
 
 ## Steps to create a test
 
@@ -15,17 +87,17 @@ Mark the key components with a `data-testid` attribute. These elements are the o
 
 ```tsx
 // Use data-testid on the span for easily retrieving the displayed name.
-<Typography variant="h1">
+<h1>
   Hello <span data-testid="person-name">{name}</span>
-</Typography>
+</h1>
 
-// Annotate the AutoComplete component to set its selection.
-<AutoComplete data-testid="favorite-color-value" choices={choices} />
+// Annotate the text input so a driver can read and set its value.
+<input data-testid="favorite-color-input" value={color} onChange={(e) => setColor(e.target.value)} />
 
-// A MUI button can be probed for its state (e.g., "disabled") or clicked.
-<MuiButton data-testid="submit" disabled={disabled}>
+// A button can be probed for its state (e.g., "disabled") or clicked.
+<button data-testid="submit" disabled={disabled}>
   Submit
-</MuiButton>
+</button>
 ```
 
 ---
@@ -35,8 +107,7 @@ Mark the key components with a `data-testid` attribute. These elements are the o
 A **ScenePart** describes how to locate a key component and which driver to use for interacting with it. For instance, the example above can be mapped as follows:
 
 ```ts
-import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
-import { ButtonDriver, AutoCompleteDriver } from '@atomic-testing/component-driver-mui-v6';
+import { HTMLButtonDriver, HTMLElementDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import { byDataTestId, ScenePart } from '@atomic-testing/core';
 
 const parts = {
@@ -45,15 +116,19 @@ const parts = {
     driver: HTMLElementDriver,
   },
   favoriteColorInput: {
-    locator: byDataTestId('favorite-color-value'),
-    driver: AutoCompleteDriver,
+    locator: byDataTestId('favorite-color-input'),
+    driver: HTMLTextInputDriver,
   },
   submitButton: {
     locator: byDataTestId('submit'),
-    driver: ButtonDriver,
+    driver: HTMLButtonDriver,
   },
 } satisfies ScenePart; // Using "satisfies ScenePart" improves TypeScript type-checking.
 ```
+
+:::info Testing a component library instead of plain HTML?
+Swap in the matching driver package (e.g. `@atomic-testing/component-driver-mui-v7` for Material UI) — see [Testing a component library](./getting-started-tutorial.mdx#testing-a-component-library-eg-mui) in the tutorial.
+:::
 
 ---
 
@@ -76,13 +151,13 @@ afterEach(async () => {
 });
 ```
 
-After instantiation, you can access your declared parts through the engine’s `parts` property:
+After instantiation, you can access your declared parts through the engine's `parts` property:
 
 ```ts
 await testEngine.parts.personDisplay.getText(); // Retrieves plain text from the personDisplay part.
 
 await testEngine.parts.favoriteColorInput.setValue('Black');
-// Sets the auto-complete component to "Black" using the AutoCompleteDriver's method.
+// Sets the text input to "Black" using HTMLTextInputDriver's setValue method.
 
 await testEngine.parts.submitButton.isDisabled(); // Checks if the submit button is disabled.
 
@@ -93,7 +168,7 @@ await testEngine.parts.submitButton.click(); // Simulates a click on the submit 
 
 ### 4. Writing Your Tests
 
-Write tests as you normally would, keeping in mind that most UI interactions are asynchronous. Here’s an example of how a test flow might look:
+Write tests as you normally would, keeping in mind that most UI interactions are asynchronous. Here's an example of how a test flow might look:
 
 ```ts
 it(`should display the person's name as "John Doe"`, async () => {
@@ -108,7 +183,7 @@ it(`should enable the submit button once a color is chosen`, async () => {
 
 ## Demo
 
-The following demo illustrates the complete setup of a login form using Atomic Testing. It includes the test setup, component rendering, and interaction with the UI elements.
+The following demo illustrates the complete setup of a login form using Atomic Testing, including a Material UI provider wrapper (see [Testing a component library](./getting-started-tutorial.mdx#testing-a-component-library-eg-mui) for why that's needed).
 
 - [Sample Login Form on Codesandbox](https://codesandbox.io/p/sandbox/github/atomic-testing/atomic-testing/tree/main/examples/example-mui-signup-form)
-- Follow the [Step-by-Step Tutorial](./getting-started-tutorial.mdx) which walks you through the sample form and how tests are written
+- Follow the [Step-by-Step Tutorial](./getting-started-tutorial.mdx) which builds a test from scratch and then walks through this sample form

--- a/docs/docs/snippets/login-form-driver-html.ts
+++ b/docs/docs/snippets/login-form-driver-html.ts
@@ -1,0 +1,39 @@
+import { HTMLButtonDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import {
+  ComponentDriver,
+  Interactor,
+  IComponentDriverOption,
+  IInputDriver,
+  PartLocator,
+  ScenePart,
+  byDataTestId,
+} from '@atomic-testing/core';
+
+const parts = {
+  username: { locator: byDataTestId('username'), driver: HTMLTextInputDriver },
+  submit: { locator: byDataTestId('submit'), driver: HTMLButtonDriver },
+} satisfies ScenePart;
+
+export interface LoginCredential {
+  username: string;
+}
+
+export class LoginFormDriver extends ComponentDriver<typeof parts> implements IInputDriver<LoginCredential> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, { ...option, parts });
+  }
+
+  async setValue(value: LoginCredential): Promise<boolean> {
+    await this.parts.username.setValue(value.username);
+    return true;
+  }
+
+  async login(value: LoginCredential): Promise<void> {
+    await this.setValue(value);
+    await this.parts.submit.click();
+  }
+
+  get driverName(): string {
+    return 'LoginFormDriver';
+  }
+}

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'quick-start', // NEW: Choose your framework + 5-minute example
+        'setup', // EXISTING: Runner config + step-by-step setup (must precede tutorial)
         'framework-guide', // NEW: React vs Vue vs Playwright decision guide
         'why-atomic-testing', // NEW: Long-term value demonstration
         'tutorial', // EXISTING: Detailed tutorial
@@ -34,7 +35,6 @@ const sidebars = {
       items: [
         'intro', // EXISTING: Introduction (moved here)
         'concepts', // EXISTING: Component drivers, locators, etc.
-        'setup', // EXISTING: Step-by-step setup
       ],
     },
 


### PR DESCRIPTION
## Summary
- Adopt one canonical newcomer stack (`react-19` + `component-driver-html` + Jest) across quick-start/setup/tutorial instead of three inconsistent recipes
- Add the missing "Configure your test runner" section to Setup (Jest + Vitest, jsdom, `IS_REACT_ACT_ENVIRONMENT`)
- Rewrite the tutorial to build one self-contained runnable test from scratch first, then demote the example-app tour to an optional section
- Make `createTestEngineForComponent` explicit as an example-local `ThemeProvider` wrapper rather than an unexplained import
- Spell out the DOM-vs-E2E boundary for the Playwright quick-start example and add `webServer`/`baseURL` config
- Move `setup` ahead of `tutorial` in the sidebar

## Findings addressed
D2-02, D2-03 (both critical), D2-04, D2-06, D2-07, D2-09, D2-08. (D2-01 and D2-05 were already resolved by #939 and an earlier partial fix, respectively — verified and left untouched.)

## Test plan
- [x] `node docs/scripts/check-doc-accuracy.mjs` passes (all `@atomic-testing/*` imports resolve to real exports)
- [x] `cd docs && pnpm build` succeeds (exit 0); the one broken-link warning it surfaces (`framework-guide` → `getting-started-tutorial`) is pre-existing and out of scope — tracked in #943

Closes #940

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVYo7JxzQFSqy8xyFsBRYA)_