### PR TITLE
docs: honest homepage claims, working demo code, wire in the why-funnel

### DIFF
--- a/docs/docs/why-atomic-testing.mdx
+++ b/docs/docs/why-atomic-testing.mdx
@@ -48,6 +48,12 @@ expect(await testEngine.parts.error.isVisible()).toBe(false);
 
 _The nightmare scenario that Atomic Testing makes trivial_
 
+> **To be clear:** the pain below isn't React Testing Library, Vue Test Utils, or Playwright themselves — each is a
+> solid tool for its own environment, and Atomic Testing actually
+> [builds on top of RTL](../advanced-concepts/atomic-testing-vs-rtl) for DOM testing rather than replacing it. The
+> pain is calling each framework's API **directly, per framework, with no shared layer** — so switching frameworks
+> means rewriting every test from scratch.
+
 <Tabs>
 <TabItem value="before" label="😱 Traditional Approach">
 
@@ -187,8 +193,24 @@ await engine.parts.submit.click();
 
 ### **Month 3**: "Wait, this is actually easier..."
 
+Once your scene grows a multi-field form, compose a driver method for it — the same pattern
+[`LoginFormDriver.login()`](../tutorial#7-build-a-form-driver) uses in the tutorial:
+
 ```typescript
-// Complex interactions become trivial
+import { ComponentDriver } from '@atomic-testing/core';
+
+// A driver method you write once — not a built-in API:
+class SignupFormDriver extends ComponentDriver<typeof parts> {
+  async fillAndSubmit(value: SignupValue): Promise<void> {
+    await this.parts.email.setValue(value.email);
+    await this.parts.password.setValue(value.password);
+    await this.parts.confirmPassword.setValue(value.confirmPassword);
+    await this.parts.agreeToTerms.setSelected(value.agreeToTerms);
+    await this.parts.submit.click();
+  }
+}
+
+// Your test stays declarative:
 await testEngine.parts.form.fillAndSubmit({
   email: 'user@example.com',
   password: 'secure123',

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -57,6 +57,22 @@ function Feature({ icon, iconVariant, title, description }: FeatureItem): JSX.El
   );
 }
 
+const PACKAGE_TESTS_URL = 'https://github.com/atomic-testing/atomic-testing/tree/main/package-tests';
+
+function ProofStrip(): JSX.Element {
+  return (
+    <p className={styles.proof}>
+      <span className={styles.proofBadge}>✓ verifiable</span>
+      Not just a claim: this repo&apos;s own <code className={styles.inlineCode}>*.suite.ts</code> test logic runs
+      unmodified under Jest <em>and</em> across Chromium, Firefox &amp; WebKit via Playwright — see{' '}
+      <a href={PACKAGE_TESTS_URL} target='_blank' rel='noopener noreferrer'>
+        package-tests/
+      </a>{' '}
+      in this monorepo.
+    </p>
+  );
+}
+
 export default function HomepageFeatures(): JSX.Element {
   return (
     <section className={styles.features}>
@@ -69,6 +85,7 @@ export default function HomepageFeatures(): JSX.Element {
             <Feature key={feature.title} {...feature} />
           ))}
         </div>
+        <ProofStrip />
       </div>
     </section>
   );

--- a/docs/src/components/HomepageFeatures/styles.module.css
+++ b/docs/src/components/HomepageFeatures/styles.module.css
@@ -90,6 +90,33 @@
   border: 0;
 }
 
+.proof {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  max-width: 760px;
+  margin: 40px auto 0;
+  text-align: center;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--at-text-muted);
+}
+
+.proofBadge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  background: var(--at-tip-bg);
+  border: 1px solid var(--at-tip-border);
+  color: var(--at-tip-ink);
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12.5px;
+}
+
 @media (max-width: 996px) {
   .grid {
     grid-template-columns: 1fr;

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -306,6 +306,21 @@
   color: var(--at-mint);
 }
 
+.heroWhyLink {
+  display: inline-flex;
+  margin-top: 18px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--at-text-muted);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--at-border);
+}
+.heroWhyLink:hover {
+  color: var(--at-blue);
+  text-decoration: none;
+  border-bottom-color: var(--at-blue);
+}
+
 /* ---------------- hero visual ---------------- */
 .heroVisual {
   position: relative;
@@ -799,6 +814,49 @@
   background: none;
   border: 0;
   padding: 0;
+}
+
+/* ============================ TRADEOFFS ============================ */
+.tradeoffs {
+  border-top: 1px solid var(--at-border);
+  border-bottom: 1px solid var(--at-border);
+  background: var(--at-bg);
+}
+.tradeoffsInner {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 24px;
+  text-align: center;
+}
+.tradeoffsTitle {
+  font-family: var(--at-font-display);
+  font-weight: 700;
+  font-size: 30px;
+  letter-spacing: -0.02em;
+  margin: 10px 0 0;
+  color: var(--at-text);
+}
+.tradeoffsSubtitle {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--at-text-muted);
+  margin: 16px 0 0;
+}
+.tradeoffsLinks {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px 28px;
+  margin-top: 26px;
+}
+.tradeoffsLink {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--at-blue);
+  text-decoration: none;
+}
+.tradeoffsLink:hover {
+  text-decoration: underline;
 }
 
 /* ============================ FINAL CTA ============================ */

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -170,7 +170,7 @@ function OrbitVisual(): JSX.Element {
       </div>
 
       <span className={clsx(styles.chip, styles.chipBlue, styles.chipTopLeft)}>byDataTestId()</span>
-      <span className={clsx(styles.chip, styles.chipTeal, styles.chipTopRight)}>MUIV8ButtonDriver</span>
+      <span className={clsx(styles.chip, styles.chipTeal, styles.chipTopRight)}>HTMLButtonDriver</span>
       <span className={clsx(styles.chip, styles.chipInk, styles.chipBottomLeft)}>engine.parts</span>
     </div>
   );
@@ -239,7 +239,7 @@ function HeroSection(): JSX.Element {
       <div className={styles.heroInner}>
         <div className={styles.heroCopy}>
           <div className={styles.badge}>
-            <span className={styles.badgeChip}>v3 · stable</span>
+            <span className={styles.badgeChip}>Pre-1.0</span>
             Portable UI testing for React · Vue · Playwright
           </div>
 
@@ -265,6 +265,10 @@ function HeroSection(): JSX.Element {
           </div>
 
           <InstallBox />
+
+          <Link className={styles.heroWhyLink} to='/docs/why-atomic-testing'>
+            Why Atomic Testing — and when NOT to use it →
+          </Link>
         </div>
 
         <div className={styles.heroVisual}>
@@ -352,7 +356,7 @@ const composeSteps: ComposeStep[] = [
   {
     eyebrow: 'Driver',
     eyebrowColor: '#38bdf8',
-    code: 'MUIV8ButtonDriver',
+    code: 'HTMLButtonDriver',
     text: (
       <>
         Semantic API — <span className={styles.bandHint}>.click()</span>,{' '}
@@ -472,6 +476,30 @@ function HowItWorksSection(): JSX.Element {
   );
 }
 
+function TradeoffsSection(): JSX.Element {
+  return (
+    <section className={styles.tradeoffs}>
+      <div className={styles.tradeoffsInner}>
+        <div className={clsx(styles.eyebrow, styles.eyebrowBlue)}>Is it for you?</div>
+        <h2 className={styles.tradeoffsTitle}>Honest tradeoffs</h2>
+        <p className={styles.tradeoffsSubtitle}>
+          Atomic Testing adds a driver layer on top of RTL, Vue Test Utils and Playwright — that&apos;s a learning curve
+          and a dependency, not a free lunch. It&apos;s a poor fit for a single throwaway component, a prototype
+          you&apos;ll never maintain, or a team unwilling to invest in the pattern up front.
+        </p>
+        <div className={styles.tradeoffsLinks}>
+          <Link className={styles.tradeoffsLink} to='/docs/why-atomic-testing'>
+            When NOT to use Atomic Testing →
+          </Link>
+          <Link className={styles.tradeoffsLink} to='/docs/advanced-concepts/atomic-testing-vs-rtl'>
+            How it compares to React Testing Library →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function FinalCtaSection(): JSX.Element {
   return (
     <section className={styles.ctaSection}>
@@ -506,6 +534,7 @@ export default function Home(): JSX.Element {
         <ComposableSection />
         <HomepageFeatures />
         <HowItWorksSection />
+        <TradeoffsSection />
         <FinalCtaSection />
       </main>
     </Layout>


### PR DESCRIPTION
## Summary
- Replace the fabricated `MUIV8ButtonDriver` chip (no such package exists) with the real `HTMLButtonDriver` export, consistent with the rest of the homepage's code samples
- Replace the "v3 · stable" badge (actual version is `0.90.0`, pre-1.0) with an honest "Pre-1.0" stability descriptor
- Replace the fabricated `fillAndSubmit()` built-in call in `why-atomic-testing.mdx` with a real composed-driver pattern (`SignupFormDriver` extending `ComponentDriver`, mirroring the tutorial's verified `LoginFormDriver.login()`)
- Add a homepage secondary CTA linking to `why-atomic-testing.mdx` (the strongest conversion asset was previously orphaned from the funnel)
- Add an honest, verifiable proof strip (this repo's own test suites run unmodified under Jest and across Chromium/Firefox/WebKit via Playwright — no fabricated stats)
- Add a "Honest tradeoffs" section linking to `why-atomic-testing.mdx` and `atomic-testing-vs-rtl.mdx`
- Clarify in `why-atomic-testing.mdx` that Atomic Testing builds on RTL rather than replacing it, resolving the mixed message against `atomic-testing-vs-rtl.mdx`

## Findings addressed
D3-02, D3-03, D3-04 (all high), D3-06, D3-07 (medium), D3-08, D3-09 (low). (D3-01 and D3-05 were already resolved by #939; D3-10's orphaned-PNG decision and navbar/footer changes are owned by #941/#943 respectively and left untouched.)

## Test plan
- [x] `node docs/scripts/check-doc-accuracy.mjs` passes (all `@atomic-testing/*` imports resolve to real exports)
- [x] `cd docs && pnpm build` succeeds (exit 0); no new broken links — the new `/docs/why-atomic-testing` and `/docs/advanced-concepts/atomic-testing-vs-rtl` links resolve cleanly. Remaining warnings are pre-existing and out of scope (generated API doc `_media` links, `framework-guide`→`tutorial` mismatch tracked in #943)

Closes #942

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVYo7JxzQFSqy8xyFsBRYA)_