### PR TITLE
docs: information architecture — nav/links, Diátaxis, API-reference bridge

### DIFF
--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Check doc accuracy (imports match real package exports)
         run: node docs/scripts/check-doc-accuracy.mjs
 
+      - name: Check doc/driver sync (excluded packages are EOL-flagged, not presented as normal options)
+        run: node docs/scripts/check-doc-driver-sync.mjs
+
       - name: Build packages
         run: ./publish.sh --build-only
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ report per package (`etc/<package>.api.md`), and governed by a documented
 deprecation lifecycle. Anything else — every `@atomic-testing/internal-*` package
 and every export tagged `@internal` — is not covered by the guarantee.
 Full policy, including the framework/Playwright/Node support matrix:
-[ADR-006](agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+[ADR-006](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
 
 ### MUI driver majors
 
 Material UI moves fast and each major has a distinct rendered DOM, so this
 project ships one driver package per MUI major (see
-[ADR-003](agent-docs/adr/003-version-specific-packages.md)). To keep the
+[ADR-003](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/003-version-specific-packages.md)). To keep the
 maintained surface focused, older majors reach **end of support** once newer
 ones are stable.
 
@@ -58,7 +58,7 @@ ones are stable.
 they remain installable at that version but receive no fixes, new drivers, or
 CI/e2e coverage, and their test suites no longer run. New work targets v6/v7/v9
 (MUI-X also v8 and v9). Rationale and migration notes:
-[ADR-005](agent-docs/adr/005-drop-mui-5-support.md).
+[ADR-005](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md).
 
 > Note: MUI Core has **no v8** — it jumped `7.3.11 → 9.0.0` to unify versioning
 > with MUI X, so `@atomic-testing/component-driver-mui-v9` is the successor to v7

--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -8,6 +8,28 @@ import Tabs from '@theme/Tabs';
 
 # API overview
 
+This page is the hand-authored entry point into the generated API reference
+(the **API Documentation** section in the sidebar below this page, produced
+from the TSDoc comments in each package's source). Read this page first.
+
+## How to read the API reference
+
+The generated reference is organized **by package** — one section per
+`@atomic-testing/*` package, mirroring the `packages/` directory. Locators and
+framework adapters (React, Vue, Playwright) each get one section; the Material
+UI driver packages get one section **per MUI major version**
+(`component-driver-mui-v6`, `-v7`, `-v9`, and the MUI-X equivalents).
+
+Driver **behavior** is consistent across those MUI-version sections — the same
+driver names and methods exist in each, because they document the same
+component-driver API surface. What differs is the underlying MUI major version's
+DOM, which is why each major has its own package and its own generated section.
+In practice this means: **pick the section that matches the MUI major version
+your project has installed, and skip the rest** rather than reading every MUI
+version's pages. If you're not sure which major you're on, see the
+[Framework Guide](./framework-guide.mdx#-component-driver-libraries) for how to
+choose.
+
 ## Locator
 
 In a nutshell, locators represent a way to find element on a page or within a test element.
@@ -59,8 +81,15 @@ Package: [@atomic-testing/component-driver-html](https://github.com/atomic-testi
 
 ### [MUI V5](https://mui.com/material-ui/getting-started/overview/) components
 
+:::warning ⚠️ EOL — see ADR-005
+MUI 5 reached end of support on 2026-06-27. `component-driver-mui-v5` is frozen
+at `0.81.0`: it stays installable but receives no fixes, new drivers, or CI/e2e
+coverage. Migrate to `component-driver-mui-v6` or `-v7` instead. Rationale:
+[ADR-005](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md).
+:::
+
 <details>
-  <summary>Component list</summary>
+  <summary>Component list (frozen, EOL — see warning above)</summary>
 
 Package: [@atomic-testing/component-driver-mui-v5](https://github.com/atomic-testing/atomic-testing/tree/main/packages/component-driver-mui-v5/src/components)
 
@@ -262,8 +291,17 @@ for the full list; the net-new drivers are:
 </details>
 ### [MUI X V5](https://mui.com/x/) components
 
+:::warning ⚠️ EOL — see ADR-005
+MUI-X 5 reached end of support on 2026-06-27. `component-driver-mui-x-v5` is
+frozen at `0.81.0`: it stays installable but receives no fixes, new drivers, or
+CI/e2e coverage. For DataGrid, migrate to `-x-v6`/`-x-v7`/`-x-v8`/`-x-v9`. Note
+that the date/time **picker** drivers ship only in this v5 package and were
+never carried forward to a supported major. Rationale:
+[ADR-005](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md).
+:::
+
 <details>
-  <summary>Component list</summary>
+  <summary>Component list (frozen, EOL — see warning above)</summary>
 
 Package: [@atomic-testing/component-driver-mui-x-v5](https://github.com/atomic-testing/atomic-testing/tree/main/packages/component-driver-mui-x-v5/src)
 

--- a/docs/docs/cheat-sheets.mdx
+++ b/docs/docs/cheat-sheets.mdx
@@ -1,6 +1,6 @@
 ---
 id: cheat-sheets
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Cheat Sheets

--- a/docs/docs/core-concepts.mdx
+++ b/docs/docs/core-concepts.mdx
@@ -29,6 +29,12 @@ The use of the data-testid attribute is recommended for locating components on a
 
 :::
 
+By default, a child part's locator is resolved as a descendant of its parent
+driver's element. Dialogs, menus, and other overlays commonly break that
+assumption by rendering outside their trigger's subtree — see
+[Testing portals & overlays](./guides/portal-and-overlays.md) for the recipe
+component drivers use to locate that content anyway.
+
 ## ScenePart
 
 A ScenePart is a map describing all components of interest (part) within a scene (a page or a rich UI component). Each entry in a ScenePart outlines the part name, the component locator, and the component driver.
@@ -116,3 +122,15 @@ await testEngine.parts.submit.click();
 const error = await testEngine.parts.error.getText();
 expect(error).toEqual('Password is required'); // Jest assertion, but any assertion library can be used
 ```
+
+## Going deeper
+
+Once these core concepts feel familiar, the "🔧 Advanced" section covers the
+next layer of detail:
+
+- [Architecture](./advanced-concepts/architecture.mdx) — how the TestEngine,
+  ComponentDriver, Interactor, and PartLocator layers fit together.
+- [The Interactor](./advanced-concepts/interactor.mdx) — the environment-adapter
+  layer underneath every component driver, and how it differs per framework.
+- [Atomic Testing vs. React Testing Library](./advanced-concepts/atomic-testing-vs-rtl.mdx) —
+  how the component-driver pattern compares to RTL's query-based approach.

--- a/docs/docs/framework-guide.mdx
+++ b/docs/docs/framework-guide.mdx
@@ -202,11 +202,18 @@ pnpm add @atomic-testing/component-driver-mui-v6
 
 <TabItem value="mui-v5" label="MUI v5">
 
+:::warning ⚠️ EOL — see ADR-005
+MUI 5 reached end of support on 2026-06-27. `component-driver-mui-v5` is frozen
+at `0.81.0`: it stays installable but receives no fixes, new drivers, or CI/e2e
+coverage. Migrate to `component-driver-mui-v6` or `-v7` instead. Rationale:
+[ADR-005](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/005-drop-mui-5-support.md).
+:::
+
 ```bash
 pnpm add @atomic-testing/component-driver-mui-v5
 ```
 
-**Supports**: Legacy MUI v5 components (consider upgrading)
+**Supports**: Legacy, frozen MUI v5 components — EOL, not recommended for new work
 
 </TabItem>
 </Tabs>
@@ -258,7 +265,7 @@ You can always add more packages later. HTML drivers work with any components.
     </div>
     <div className='card__body'>
       <p>Now that you know which packages to install, let's build a complete test together.</p>
-      <Link to='../getting-started-tutorial' className='button button--primary'>
+      <Link to='../tutorial' className='button button--primary'>
         Start Tutorial →
       </Link>
     </div>

--- a/docs/docs/why-atomic-testing.mdx
+++ b/docs/docs/why-atomic-testing.mdx
@@ -194,7 +194,7 @@ await engine.parts.submit.click();
 ### **Month 3**: "Wait, this is actually easier..."
 
 Once your scene grows a multi-field form, compose a driver method for it — the same pattern
-[`LoginFormDriver.login()`](../tutorial#7-build-a-form-driver) uses in the tutorial:
+[`LoginFormDriver.login()`](../tutorial#7-compose-a-driver-for-reuse) uses in the tutorial:
 
 ```typescript
 import { ComponentDriver } from '@atomic-testing/core';

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -61,7 +61,7 @@ const config: Config = {
   projectName: 'atomic-testing', // Usually your repo name.
   deploymentBranch: 'gh-pages', // Branch that GitHub pages will deploy from.
 
-  onBrokenLinks: 'warn',
+  onBrokenLinks: 'throw',
 
   trailingSlash: true,
 
@@ -137,7 +137,7 @@ const config: Config = {
         },
         {
           type: 'doc',
-          docId: 'intro',
+          docId: 'concepts',
           position: 'left',
           label: 'Core Concepts',
         },
@@ -163,6 +163,10 @@ const config: Config = {
             {
               label: 'Getting started',
               to: '/docs/intro',
+            },
+            {
+              label: 'Why Atomic Testing?',
+              to: '/docs/why-atomic-testing',
             },
             {
               label: 'Concepts',

--- a/docs/scripts/check-doc-driver-sync.mjs
+++ b/docs/scripts/check-doc-driver-sync.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Doc/driver-package sync gate for the Atomic Testing docs site.
+//
+// WHY: docusaurus.config.ts excludes frozen/EOL packages (MUI 5 / MUI-X 5, see
+// ADR-005) from the generated API reference, because they're no longer built and
+// TypeDoc can't resolve their cross-package types. The hand-authored narrative
+// docs (api-overview.mdx, framework-guide.mdx) are not generated, so nothing
+// stops them from silently presenting an excluded package as an ordinary,
+// first-class option — which is exactly what happened before #943. This script
+// makes that drift fail CI instead of shipping to readers.
+//
+// WHAT it checks:
+//   For every package excluded from the generated API reference (read the same
+//   way docusaurus.config.ts's getPackageNames()/EXCLUDED_FROM_DOCS do), every
+//   markdown section of api-overview.mdx / framework-guide.mdx that mentions the
+//   package must also carry an EOL marker ("EOL" or "ADR-005") in that same
+//   section. A mention with no nearby EOL marker means the package reads as a
+//   normal, supported option, which is the bug this gate exists to catch.
+//
+// Run from anywhere: `node docs/scripts/check-doc-driver-sync.mjs`
+// Exit code 0 = clean, 1 = an excluded package is presented without an EOL marker.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const docsRoot = path.join(repoRoot, 'docs');
+const packagesRoot = path.join(repoRoot, 'packages');
+const configFile = path.join(docsRoot, 'docusaurus.config.ts');
+
+// ---------- read the excluded-package set straight from docusaurus.config.ts ----------
+// Parsing the live config (instead of re-declaring the set here) keeps this script
+// and the API-reference build from drifting out of sync with each other.
+function readExcludedPackageNames() {
+  const configSrc = fs.readFileSync(configFile, 'utf8');
+  const match = configSrc.match(/EXCLUDED_FROM_DOCS\s*=\s*new Set\(\s*\[([\s\S]*?)]\s*\)/);
+  if (!match) {
+    throw new Error(
+      `Could not find EXCLUDED_FROM_DOCS in ${path.relative(repoRoot, configFile)} — has it been renamed?`
+    );
+  }
+  return [...match[1].matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1]);
+}
+
+// Mirrors docusaurus.config.ts's getPackageNames(): every directory under
+// packages/ except internal-* helpers and the excluded (EOL) set.
+function readRealPackageNames() {
+  const excluded = new Set(readExcludedPackageNames());
+  return fs
+    .readdirSync(packagesRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('internal-'))
+    .map(entry => entry.name)
+    .filter(name => !excluded.has(name));
+}
+
+// ---------- section-scoped scan of the narrative docs ----------
+// A "section" is the text between one `###` heading and the next (or EOF) — the
+// same granularity the docs use to give each package/driver family its own
+// subsection, so an EOL marker anywhere in a section covers every mention in it.
+function splitIntoSections(text) {
+  const headingRe = /^###\s.*$/gm;
+  const starts = [...text.matchAll(headingRe)].map(m => m.index);
+  if (starts.length === 0) return [{ heading: '(no ### heading)', body: text }];
+  return starts.map((start, i) => {
+    const end = i + 1 < starts.length ? starts[i + 1] : text.length;
+    const body = text.slice(start, end);
+    return { heading: body.split('\n', 1)[0].trim(), body };
+  });
+}
+
+const EOL_MARKER_RE = /\bEOL\b|ADR-005/;
+
+const CHECKED_DOCS = ['api-overview.mdx', 'framework-guide.mdx'];
+
+function findUnflaggedMentions(excludedPackages) {
+  const problems = [];
+
+  for (const docName of CHECKED_DOCS) {
+    const docPath = path.join(docsRoot, 'docs', docName);
+    const text = fs.readFileSync(docPath, 'utf8');
+    const sections = splitIntoSections(text);
+
+    for (const pkg of excludedPackages) {
+      const scopedName = `@atomic-testing/${pkg}`;
+      for (const section of sections) {
+        if (!section.body.includes(pkg)) continue;
+        if (EOL_MARKER_RE.test(section.body)) continue;
+        problems.push(
+          `${docName} — section "${section.heading}" mentions ${scopedName} (excluded/EOL package) ` +
+            `without an "EOL" or "ADR-005" marker in that section`
+        );
+      }
+    }
+  }
+
+  return problems;
+}
+
+// ---------- main ----------
+const excludedPackages = readExcludedPackageNames();
+const realPackageNames = readRealPackageNames();
+
+if (excludedPackages.length === 0) {
+  console.log('doc-driver-sync: no excluded packages configured — nothing to check.');
+  process.exit(0);
+}
+
+const problems = findUnflaggedMentions(excludedPackages);
+
+if (problems.length) {
+  console.error(`doc-driver-sync: FAILED — ${problems.length} issue(s) found:\n`);
+  for (const p of problems) console.error(`  ✗ ${p}`);
+  console.error(
+    '\nExcluded/EOL packages must be presented behind a clear EOL admonition (see ADR-005), not as a normal option.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `doc-driver-sync: OK — ${excludedPackages.length} excluded package(s) [${excludedPackages.join(', ')}] are ` +
+    `either absent or clearly EOL-flagged in ${CHECKED_DOCS.join(', ')}; ${realPackageNames.length} supported package(s) unaffected.`
+);

--- a/packages/component-driver-html/README.md
+++ b/packages/component-driver-html/README.md
@@ -15,8 +15,8 @@ For usage examples see the [documentation](https://atomic-testing.dev/).
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/component-driver-html.api.md`](etc/component-driver-html.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/component-driver-html.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/component-driver-html/etc/component-driver-html.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
 
 ## Capability interfaces
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -52,5 +52,5 @@ and more examples. A complete signup form example can be found under
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/core.api.md`](etc/core.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/core.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/core/etc/core.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -32,9 +32,9 @@ import type { PressKeyOption } from './PressKeyOption';
  * 1.0 contract is therefore deliberately scoped to **DOM environments addressed
  * by CSS**: there is no seam for a non-DOM target, and a computed ARIA accessible
  * name (`aria-labelledby` / `<label>` / text — not CSS-expressible) is out of
- * scope. See [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md);
+ * scope. See [ADR-008](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/008-css-dom-only-locator-boundary.md);
  * the deferred name-aware resolution is tracked in #923. Post-1.0 the interface
- * grows additively per [ADR-007](../../../../agent-docs/adr/007-interactor-evolution-and-composition.md).
+ * grows additively per [ADR-007](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/007-interactor-evolution-and-composition.md).
  */
 export interface Interactor {
   //#region Potentially DOM mutative interactions

--- a/packages/core/src/locators/PartLocator.ts
+++ b/packages/core/src/locators/PartLocator.ts
@@ -12,6 +12,6 @@ export type CssLocatorChain = CssLocator[];
  * …) emits a CSS fragment, same-element matchers compose via {@link CssLocator.and},
  * and `byCssSelector` is the raw-CSS escape hatch. XPath, text, and computed-ARIA
  * -name engines are out of scope — see
- * [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md).
+ * [ADR-008](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/008-css-dom-only-locator-boundary.md).
  */
 export type PartLocator = CssLocator | CssLocatorChain;

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -69,7 +69,7 @@ async function getEffectiveLocator(locator: PartLocator, interactor: Interactor)
  * Reduce a {@link PartLocator} to the single CSS selector the interactor runs
  * against the DOM. This is the one locator-resolution seam in the system, and it
  * is **CSS-only by design** for 1.0 — every locator must express itself as CSS
- * here (see [ADR-008](../../../../agent-docs/adr/008-css-dom-only-locator-boundary.md)).
+ * here (see [ADR-008](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/008-css-dom-only-locator-boundary.md)).
  */
 export async function toCssSelector(locator: PartLocator, interactor: Interactor): Promise<string> {
   const effectiveLocator = await getEffectiveLocator(locator, interactor);

--- a/packages/dom-core/README.md
+++ b/packages/dom-core/README.md
@@ -15,5 +15,5 @@ See the [documentation](https://atomic-testing.dev/) for usage examples.
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/dom-core.api.md`](etc/dom-core.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/dom-core.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/dom-core/etc/dom-core.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -17,5 +17,5 @@ See the [docs](https://atomic-testing.dev/) for configuration and usage details.
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/playwright.api.md`](etc/playwright.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/playwright.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/playwright/etc/playwright.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/react-18/README.md
+++ b/packages/react-18/README.md
@@ -94,5 +94,5 @@ For more in‑depth information, visit
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/react-18.api.md`](etc/react-18.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/react-18.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/react-18/etc/react-18.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/react-19/README.md
+++ b/packages/react-19/README.md
@@ -94,5 +94,5 @@ For more in‑depth information, visit
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/react-19.api.md`](etc/react-19.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/react-19.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/react-19/etc/react-19.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -6,5 +6,5 @@ Shared React utilities used by Atomic Testing React packages.
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/react-core.api.md`](etc/react-core.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/react-core.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/react-core/etc/react-core.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/react-legacy/README.md
+++ b/packages/react-legacy/README.md
@@ -94,5 +94,5 @@ For more in‑depth information, visit
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/react-legacy.api.md`](etc/react-legacy.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/react-legacy.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/react-legacy/etc/react-legacy.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/vue-3/README.md
+++ b/packages/vue-3/README.md
@@ -169,5 +169,5 @@ const engine = createTestEngine<Component>(MyVueComponent, sceneParts);
 
 The stable surface of this package is its `.` barrel exports, frozen under
 SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
-report at [`etc/vue-3.api.md`](etc/vue-3.api.md). Exports tagged `@internal` are
-not part of that guarantee. See the [1.0 API freeze & evolution policy](../../agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
+report at [`etc/vue-3.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/vue-3/etc/vue-3.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).


### PR DESCRIPTION
## Summary
- Fix the broken tutorial link (`framework-guide.mdx` used a stale file-path link; standardize on the doc-id link `../tutorial` used elsewhere) and enable `onBrokenLinks: 'throw'`
- While investigating broken-link warnings under strict mode, found and fixed the real cause of a class of generated-API-doc warnings: `typedoc-plugin-markdown` hardcodes relative links into an unroutable `_media/` folder, so TSDoc `@see` comments and package READMEs pointing at ADR files were permanently broken regardless of path correctness. Swapped those for absolute GitHub URLs (also more robust for npm-rendered READMEs) across 3 TSDoc comments and 10 READMEs
- Also found and fixed a second broken anchor surfaced by strict mode: `why-atomic-testing.mdx` linked to a tutorial heading that #940 renamed — updated the anchor to match
- Wrap the EOL MUI v5 / MUI-X v5 sections in `api-overview.mdx` and `framework-guide.mdx` in an "EOL — see ADR-005" admonition (verified the date/frozen-version claims against the real ADR text) instead of presenting them as normal options
- Add `docs/scripts/check-doc-driver-sync.mjs`, a new CI gate that fails if an EOL/excluded package is ever presented in those two docs without an EOL marker (reads the excluded-package set live from `docusaurus.config.ts` to avoid drift), wired into `doc-ci.yml`
- Add a "How to read the API reference" preamble to `api-overview.mdx` bridging the hand-authored docs to the generated per-package TypeDoc reference
- Add a "Going deeper" section to `core-concepts.mdx` cross-linking to Architecture, Interactor, and Atomic-Testing-vs-RTL, plus a contextual inbound link to the previously-orphaned `portal-and-overlays.md` guide
- Add a footer link to `why-atomic-testing.mdx` (the navbar/footer half of the fix shared with #942, which handled the homepage CTA half)
- Fix the navbar's "Core Concepts" item to point at the actual concepts doc instead of the introduction page, and resolve a `sidebar_position` collision between `best-practices.mdx` and `cheat-sheets.mdx`

## Findings addressed
D4-01, D4-02, D4-03 (all high), D4-04, D4-06 (medium), D4-05, D4-07 (low). (D4-08's orphaned-PNG decision is owned by #941 and left untouched; the Getting-Started sidebar ordering and homepage CTA are owned by #940/#942, already merged.)

## Test plan
- [x] `node docs/scripts/check-doc-accuracy.mjs` passes
- [x] `node docs/scripts/check-doc-driver-sync.mjs` passes (and was verified to actually fail when the EOL admonition is reverted)
- [x] `cd docs && pnpm build` succeeds with `onBrokenLinks: 'throw'` — zero broken links, zero broken anchors
- [x] `pnpm run check:lint` clean
- [x] This branch was merged with current `main` (after #940/#942 landed) before opening this PR, so the diff reflects only this issue's changes

Closes #943

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVYo7JxzQFSqy8xyFsBRYA)_