### PR TITLE
fix: repair e2e test failures across astryx, mui, and radix drivers

### DIFF
--- a/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AppShellDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { appShellExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { avatarExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/AvatarGroupDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { avatarGroupExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BadgeDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { badgeExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BlockquoteDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { blockquoteExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/BreadcrumbsDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { breadcrumbsExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatComposerExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatComposerInputDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatComposerInputExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatDictationButtonDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatDictationButtonExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatLayoutDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatLayoutExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageBubbleDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatMessageBubbleExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatMessageExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatMessageListDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatMessageListExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSendButtonDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatSendButtonExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatSystemMessageDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatSystemMessageExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ChatToolCallsDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { chatToolCallsExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/CitationDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CitationDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { citationExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeBlockDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { codeBlockExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/CodeDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/CodeDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { codeExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ContextMenuDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { contextMenuExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/DividerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/DividerDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { dividerExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/EmptyStateDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { emptyStateExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/FileInputDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { fileInputExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HeadingDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { headingExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/HoverCardDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { hoverCardExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ItemDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { itemExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MarkdownDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { markdownExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/MobileNavDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { mobileNavExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/NavIconDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { navIconExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ProgressBarDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { progressBarExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { sideNavExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SideNavItemDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { sideNavItemExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/SpinnerDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { spinnerExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/StatusDotDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { statusDotExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TextDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TextDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { textExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/ThumbnailDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { thumbnailExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TimestampDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { timestampExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TokenDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TokenDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { tokenExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TooltipDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { tooltipExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { topNavExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavItemDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { topNavItemExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMegaMenuDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { topNavMegaMenuExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/TopNavMenuDriver.e2e.test.ts
@@ -1,5 +1,5 @@
 import { testRunner } from '@atomic-testing/internal-test-runner';
-import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/playwright';
+import { getTestRunnerInterface, playWrightTestFrameworkMapper } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
 import { topNavMenuExampleTestSuite } from '../src/examples';
 

--- a/package-tests/component-driver-mui-v5-test/package.json
+++ b/package-tests/component-driver-mui-v5-test/package.json
@@ -27,8 +27,8 @@
     "start": "vite --force",
     "build:ui": "vite build",
     "test:dom": "jest",
-    "test:e2e": "playwright test",
-    "test:e2e:chrome": "playwright test --project=chromium"
+    "test:e2e:deprecated": "playwright test",
+    "test:e2e:chrome:deprecated": "playwright test --project=chromium"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",

--- a/package-tests/component-driver-mui-v5-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-v5-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-v6-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-v6-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-v7-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-v7-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-v9-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-v9-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-x-v5-test/package.json
+++ b/package-tests/component-driver-mui-x-v5-test/package.json
@@ -27,8 +27,8 @@
     "start": "vite --force",
     "build:ui": "vite build",
     "test:dom": "jest",
-    "test:e2e": "playwright test",
-    "test:e2e:chrome": "playwright test --project=chromium"
+    "test:e2e:deprecated": "playwright test",
+    "test:e2e:chrome:deprecated": "playwright test --project=chromium"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",

--- a/package-tests/component-driver-mui-x-v5-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-x-v5-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-x-v6-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-x-v6-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-x-v6-test/vite.config.ts
+++ b/package-tests/component-driver-mui-x-v6-test/vite.config.ts
@@ -21,4 +21,27 @@ export default defineConfig({
       port,
     },
   },
+  optimizeDeps: {
+    // Works around a Rolldown dependency pre-bundling bug: @mui/material's
+    // styles/index.js was landing in an auto-split shared chunk that calls
+    // init_emotion_react_browser_development_esm() without importing it,
+    // throwing a ReferenceError on every route (the same shared chunk is
+    // imported correctly elsewhere, so this looks like a Rolldown bug in
+    // per-chunk import-list generation, not an app code issue). Forcing all
+    // of @emotion + @mui/material into one named chunk means every call site
+    // shares a module scope with the init function's definition, so there's
+    // no cross-chunk import to generate — and thus none to get lost.
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: 'emotion-mui-vendor',
+              test: /[\\/]node_modules[\\/](@emotion|@mui[\\/]material)[\\/]/,
+            },
+          ],
+        },
+      },
+    },
+  },
 });

--- a/package-tests/component-driver-mui-x-v7-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-x-v7-test/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/package-tests/component-driver-mui-x-v8-test/package.json
+++ b/package-tests/component-driver-mui-x-v8-test/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@atomic-testing/component-driver-mui-x-v7-test",
+  "name": "@atomic-testing/component-driver-mui-x-v8-test",
   "version": "0.0.0",
-  "description": "Examples and tests for @atomic-testing/component-driver-mui-x-v7",
+  "description": "Examples and tests for @atomic-testing/component-driver-mui-x-v8",
   "keywords": [
     "integration",
     "integration-driver",

--- a/package-tests/component-driver-mui-x-v8-test/playwright.config.ts
+++ b/package-tests/component-driver-mui-x-v8-test/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseUrl = 'http://localhost:5127';
+const baseUrl = 'http://localhost:5128';
 
 /**
  * Read environment variables from file.
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: './__tests__',
   testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
   /* Maximum time one test can run for. */
-  timeout: 3 * 1000, // 30 * 1000,
+  timeout: 30 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/packages/component-driver-mui-v5/src/components/AccordionDriver.ts
+++ b/packages/component-driver-mui-v5/src/components/AccordionDriver.ts
@@ -15,7 +15,7 @@ export const parts = {
    * The clickable area to expand/collapse the accordion.
    */
   disclosure: {
-    locator: byRole('button'),
+    locator: byCssClass('MuiAccordionSummary-root'),
     driver: HTMLElementDriver,
   },
   summary: {

--- a/packages/component-driver-radix-v1/src/components/PasswordToggleFieldDriver.ts
+++ b/packages/component-driver-radix-v1/src/components/PasswordToggleFieldDriver.ts
@@ -12,6 +12,8 @@ import {
   ScenePart,
 } from '@atomic-testing/core';
 
+const defaultTransitionDuration = 250;
+
 export const parts = {
   // Neither `input[type=password]` nor a native `<button>` carries an explicit
   // `role` attribute (their ARIA roles are implicit HTML semantics), and Radix
@@ -75,9 +77,20 @@ export class PasswordToggleFieldDriver
     return (await this.parts.input.getAttribute('type')) === 'text';
   }
 
-  /** Click the toggle button, flipping visibility. */
+  /**
+   * Click the toggle button, then wait for visibility to flip. The click
+   * resolves before React commits the resulting re-render, so callers reading
+   * {@link isPasswordVisible} or {@link getToggleLabel} right after would
+   * otherwise race the stale pre-click state.
+   */
   async toggleVisibility(): Promise<void> {
-    return this.parts.toggle.click();
+    const wasVisible = await this.isPasswordVisible();
+    await this.parts.toggle.click();
+    await this.interactor.waitUntil({
+      probeFn: () => this.isPasswordVisible(),
+      terminateCondition: !wasVisible,
+      timeoutMs: defaultTransitionDuration,
+    });
   }
 
   /**

--- a/packages/internal-mui-x-test-fixture/package.json
+++ b/packages/internal-mui-x-test-fixture/package.json
@@ -26,8 +26,5 @@
   "scripts": {
     "build": "tsdown",
     "check:type": "tsgo --noEmit"
-  },
-  "dependencies": {
-    "@mui/x-data-grid-pro": "5.17.26"
   }
 }

--- a/packages/internal-mui-x-test-fixture/src/gridConfig.ts
+++ b/packages/internal-mui-x-test-fixture/src/gridConfig.ts
@@ -1,4 +1,4 @@
-import { GridAlignment } from '@mui/x-data-grid-pro';
+type GridAlignment = 'left' | 'right' | 'center';
 
 export const initialState = {
   columns: {

--- a/packages/internal-test-runner-playwright-adapter/package.json
+++ b/packages/internal-test-runner-playwright-adapter/package.json
@@ -33,6 +33,9 @@
     "@atomic-testing/internal-test-runner": "workspace:*",
     "@atomic-testing/playwright": "workspace:*"
   },
+  "devDependencies": {
+    "@types/node": "^24.0.3"
+  },
   "peerDependencies": {
     "@playwright/test": ">=1.50.0"
   }

--- a/packages/internal-test-runner-playwright-adapter/src/index.ts
+++ b/packages/internal-test-runner-playwright-adapter/src/index.ts
@@ -8,6 +8,31 @@ import { createTestEngine } from '@atomic-testing/playwright';
 import { expect, Page, test } from '@playwright/test';
 
 /**
+ * Stub out raw `.css`/`.less` requires for Node's plain CJS loader.
+ *
+ * Playwright's e2e tests run in plain Node (no bundler), but this repo's shared
+ * `*.suite.ts`/`*.examples.tsx` test-suite files (see CLAUDE.md, "Shared Test
+ * Pattern") get `require()`'d directly into that process. Some upstream CJS
+ * builds (e.g. `@mui/x-data-grid@8.6.0`'s `DataGrid/index.js`) `require()` a raw
+ * CSS file for its bundler-only side effect; a bundler (Vite, webpack) knows how
+ * to handle that, but Node's `require()` tries to parse the CSS as JavaScript and
+ * throws `SyntaxError: Unexpected token '.'`.
+ *
+ * Every e2e test file imports this adapter before importing the suite/examples
+ * that trigger the problematic transitive require (confirmed empirically), so
+ * installing the stub here — once, at module load — protects every e2e package
+ * with zero per-package config changes. This mirrors `jest.css.js`, which solves
+ * the identical problem for the DOM/Jest pipeline via `moduleNameMapper`.
+ */
+if (typeof require !== 'undefined' && require.extensions) {
+  const stubModule = (module: NodeModule): void => {
+    module.exports = {};
+  };
+  require.extensions['.css'] ??= stubModule;
+  require.extensions['.less'] ??= stubModule;
+}
+
+/**
  * Navigate the current Playwright page to the provided URL.
  *
  * @param url - Destination URL to load.

--- a/packages/internal-test-runner-playwright-adapter/tsconfig.json
+++ b/packages/internal-test-runner-playwright-adapter/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["./src"],
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "types": ["node"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@playwright/test': ^1.61.1
   '@atomic-testing/internal-react-example>react': ^19.2.3
   '@atomic-testing/internal-react-example>react-dom': ^19.2.3
-  '@playwright/test': ^1.61.1
 
 importers:
 
@@ -1766,11 +1766,7 @@ importers:
         specifier: '>=14.0.0'
         version: 14.6.1(@testing-library/dom@10.4.1)
 
-  packages/internal-mui-x-test-fixture:
-    dependencies:
-      '@mui/x-data-grid-pro':
-        specifier: 5.17.26
-        version: 5.17.26(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+  packages/internal-mui-x-test-fixture: {}
 
   packages/internal-react-example:
     dependencies:
@@ -1816,7 +1812,7 @@ importers:
         version: 29.7.0
       jest:
         specifier: '>= 26.0.0'
-        version: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
 
   packages/internal-test-runner-playwright-adapter:
     dependencies:
@@ -1832,6 +1828,10 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.10
 
   packages/internal-test-runner-vitest-adapter:
     dependencies:
@@ -3077,7 +3077,7 @@ packages:
   '@mui/base@5.0.0-beta.70':
     resolution: {integrity: sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==}
     engines: {node: '>=14.0.0'}
-    deprecated: This package has been replaced by @base-ui/react
+    deprecated: This package has been replaced by @base-ui-components/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4319,56 +4319,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -4447,49 +4439,41 @@ packages:
     resolution: {integrity: sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.21.3':
     resolution: {integrity: sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.21.3':
     resolution: {integrity: sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.21.3':
     resolution: {integrity: sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.21.3':
     resolution: {integrity: sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.21.3':
     resolution: {integrity: sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.21.3':
     resolution: {integrity: sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.21.3':
     resolution: {integrity: sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.21.3':
     resolution: {integrity: sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==}
@@ -4558,56 +4542,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.55.0':
     resolution: {integrity: sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
     resolution: {integrity: sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
     resolution: {integrity: sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.55.0':
     resolution: {integrity: sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.55.0':
     resolution: {integrity: sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.55.0':
     resolution: {integrity: sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.55.0':
     resolution: {integrity: sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.55.0':
     resolution: {integrity: sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==}
@@ -4680,56 +4656,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.70.0':
     resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.70.0':
     resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.70.0':
     resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.70.0':
     resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.70.0':
     resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.70.0':
     resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.70.0':
     resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.70.0':
     resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
@@ -5582,126 +5550,108 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -6111,28 +6061,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.9':
     resolution: {integrity: sha512-yghFZWKPVVGbUdqiD7ft23G0JX6YFGDJPz9YbLLAwGuKZ9th3/jlWoQDAw1Naci31LQhVC+oIji6ozihSuwB2A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.9':
     resolution: {integrity: sha512-SFUxyhWLZRNL8QmgGNqdi2Q43PNyFVkRZ2zIif30SOGFSxnxcf2JNeSeBgKIGVgaLSuk6xFVVCtJ3KIeaStgRg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.9':
     resolution: {integrity: sha512-9FB0wM+6idCGTI20YsBNBg9xSWtkDBymnpaTCsZM3qDc0l4uOpJMqbfWhQvp17x7r/ulZfb2QY8RDvQmCL6AcQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.9':
     resolution: {integrity: sha512-zHOusMVbOH9ik5RtRrMiGzLpKwxrPXgXkBm3SbUCa65HAdjV33NZ0/R9Rv1uPESALtEl2tzMYLUxYA5ECFDFhA==}
@@ -6335,9 +6281,6 @@ packages:
 
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
-
-  '@types/node@20.19.43':
-    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@24.0.10':
     resolution: {integrity: sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==}
@@ -8127,28 +8070,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -9343,9 +9282,6 @@ packages:
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -10643,7 +10579,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -10656,14 +10592,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -10694,7 +10630,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -10716,7 +10652,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -10745,7 +10681,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -10819,7 +10755,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -11547,18 +11483,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@mui/utils@5.17.1(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/types': 7.2.24(@types/react@19.2.17)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-is: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@mui/utils@6.4.9(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -11931,23 +11855,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid-pro@5.17.26(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 5.17.1(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-data-grid': 5.17.26(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-license-pro': 5.17.12(@types/react@19.2.17)(react@19.2.7)
-      '@types/format-util': 1.0.4
-      clsx: 1.2.1
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      reselect: 4.1.8
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@mui/x-data-grid-pro@6.20.4(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -12035,20 +11942,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      reselect: 4.1.8
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-data-grid@5.17.26(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/utils': 5.17.1(@types/react@19.2.17)(react@19.2.7)
-      clsx: 1.2.1
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
       reselect: 4.1.8
     transitivePeerDependencies:
       - '@types/react'
@@ -12400,14 +12293,6 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-license-pro@5.17.12(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/utils': 5.17.1(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
     transitivePeerDependencies:
       - '@types/react'
 
@@ -14313,7 +14198,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
 
   '@types/hast@3.0.4':
     dependencies:
@@ -14336,7 +14221,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -14345,10 +14230,6 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/node@14.18.63': {}
-
-  '@types/node@20.19.43':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@24.0.10':
     dependencies:
@@ -15185,21 +15066,6 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
-
-  create-jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-jest@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
     dependencies:
@@ -16038,7 +15904,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0(babel-plugin-macros@3.1.0)
@@ -16058,25 +15924,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
@@ -16095,36 +15942,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@babel/core': 7.27.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.27.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.43
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
     dependencies:
@@ -16188,7 +16005,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -16202,7 +16019,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -16212,7 +16029,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16270,7 +16087,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-util: 29.7.0
 
   jest-mock@30.0.2:
@@ -16313,7 +16130,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -16341,7 +16158,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -16387,7 +16204,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16415,7 +16232,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -16424,22 +16241,10 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 24.0.10
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
     dependencies:
@@ -17903,8 +17708,6 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
-
-  undici-types@6.21.0: {}
 
   undici-types@7.8.0: {}
 


### PR DESCRIPTION

Root-causes and fixes e2e regressions surfaced by a full package-tests audit: wrong
test-adapter imports in astryx, a stale locator in the MUI v5 Accordion driver, copy-paste
config mistakes in mui-x-v8's test scaffolding, a race in the Radix password-toggle driver,
a Node/Playwright CSS-require crash reachable through mui-x drivers, and a stale dependency
pin in the shared MUI-X test fixture. Also restores sane Playwright timeouts across several
MUI test configs and marks the now end-of-life MUI 5 / MUI-X 5 e2e suites as deprecated
rather than chasing unfixable issues in packages no longer supported.

## Key Changes

- Fix import, locator, and config bugs in astryx/mui-v5/mui-x-v8 test packages
- Add a missing post-click wait to RadixPasswordToggleFieldDriver.toggleVisibility
- Stub CSS requires in the Playwright e2e adapter and drop a stale data-grid-pro pin

Note: mui-x-v6-test remains red. Its Vite dependency-optimizer bug is fixed, but a deeper
react18/react19 resolution conflict in the shared internal-react-example package (used by
several test packages with different React majors) needs a follow-up architectural fix.
