### PR TITLE
fix(angular-material): disable test-harness animations to eliminate menu pointer-events race

### DIFF
--- a/package-tests/component-driver-angular-material-v20-test/__tests__/AutocompleteDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/AutocompleteDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { AutocompleteExampleComponent } from '../src/examples/autocomplete/Autocomplete.examples';
 import { autocompleteScenePart, autocompleteTestSuite } from '../src/examples/autocomplete/Autocomplete.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/ButtonDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/ButtonDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { ButtonExampleComponent } from '../src/examples/button/Button.examples';
 import { buttonScenePart, buttonTestSuite } from '../src/examples/button/Button.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/CheckboxDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/CheckboxDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { CheckboxExampleComponent } from '../src/examples/checkbox/Checkbox.examples';
 import { checkboxScenePart, checkboxTestSuite } from '../src/examples/checkbox/Checkbox.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/DialogDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/DialogDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { DialogExampleComponent } from '../src/examples/dialog/Dialog.examples';
 import { dialogScenePart, dialogTestSuite } from '../src/examples/dialog/Dialog.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/InputDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/InputDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { InputExampleComponent } from '../src/examples/input/Input.examples';
 import { inputScenePart, inputTestSuite } from '../src/examples/input/Input.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/MenuDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/MenuDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { MenuExampleComponent } from '../src/examples/menu/Menu.examples';
 import { menuScenePart, menuTestSuite } from '../src/examples/menu/Menu.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/RadioDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/RadioDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { RadioExampleComponent } from '../src/examples/radio/Radio.examples';
 import { radioScenePart, radioTestSuite } from '../src/examples/radio/Radio.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/SelectDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/SelectDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SelectExampleComponent } from '../src/examples/select/Select.examples';
 import { selectScenePart, selectTestSuite } from '../src/examples/select/Select.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/SlideToggleDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/SlideToggleDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SlideToggleExampleComponent } from '../src/examples/slideToggle/SlideToggle.examples';
 import { slideToggleScenePart, slideToggleTestSuite } from '../src/examples/slideToggle/SlideToggle.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/SnackbarDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/SnackbarDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SnackbarExampleComponent } from '../src/examples/snackbar/Snackbar.examples';
 import { snackbarScenePart, snackbarTestSuite } from '../src/examples/snackbar/Snackbar.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/TableDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/TableDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TableExampleComponent } from '../src/examples/table/Table.examples';
 import { tableScenePart, tableTestSuite } from '../src/examples/table/Table.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/__tests__/TabsDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v20-test/__tests__/TabsDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-20';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TabsExampleComponent } from '../src/examples/tabs/Tabs.examples';
 import { tabsScenePart, tabsTestSuite } from '../src/examples/tabs/Tabs.suite';
 

--- a/package-tests/component-driver-angular-material-v20-test/src/createTestEngine.ts
+++ b/package-tests/component-driver-angular-material-v20-test/src/createTestEngine.ts
@@ -1,0 +1,44 @@
+import { ANIMATION_MODULE_TYPE, Type } from '@angular/core';
+import { createTestEngine as bootstrapTestEngine, IAngularTestEngineOption } from '@atomic-testing/angular-20';
+import { ScenePart, TestEngine } from '@atomic-testing/core';
+
+/**
+ * Bootstraps every example in this package through
+ * `@atomic-testing/angular-20`'s `createTestEngine`, with animations disabled
+ * by default.
+ *
+ * Material's real CSS animations (e.g. `mat-menu`'s ~120ms enter transition)
+ * apply `pointer-events: none` to the animating panel, cleared only by a real
+ * `animationend` event — Material has a JS fallback timer for the *close*
+ * path but none for *open*. Under CI load that event can be delayed past
+ * `MenuItemDriver.click()`'s defensive wait (which times out silently rather
+ * than throwing), so the click proceeds while pointer events are still
+ * suppressed and hits `@testing-library/user-event`'s own guard — the
+ * intermittent `MatMenu` "activating an item" failure this wrapper exists to
+ * eliminate.
+ *
+ * `ANIMATION_MODULE_TYPE: 'NoopAnimations'` is what every Material component
+ * itself reads (via `_animationsDisabled()`, see `@angular/material/core`) to
+ * decide whether to run its real CSS animation at all — it does not go
+ * through `@angular/platform-browser/animations`' `provideNoopAnimations()`,
+ * which additionally pulls in `@angular/animations/browser`'s renderer
+ * factory, a package this workspace does not otherwise depend on. Setting
+ * just the token Material already consults disables the animation classes
+ * (and the pointer-events race with them) without that extra dependency.
+ * Every affected driver already waits on DOM/attribute state via `waitUntil`
+ * rather than a fixed animation duration, so resolving that state sooner is
+ * safe, not just faster.
+ *
+ * `option.providers`, when supplied, is appended after this provider, so a
+ * caller can still override it (Angular DI: later provider wins).
+ */
+export function createTestEngine<T extends ScenePart>(
+  component: Type<unknown>,
+  partDefinitions: T,
+  option?: Readonly<Partial<IAngularTestEngineOption>>
+): Promise<TestEngine<T>> {
+  return bootstrapTestEngine(component, partDefinitions, {
+    ...option,
+    providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }, ...(option?.providers ?? [])],
+  });
+}

--- a/package-tests/component-driver-angular-material-v20-test/src/main.ts
+++ b/package-tests/component-driver-angular-material-v20-test/src/main.ts
@@ -7,8 +7,17 @@ import '@angular/compiler';
 // under the `style` condition, which Vite's JS-import resolution does not
 // apply — the bare specifier fails to resolve.
 import '../node_modules/@angular/material/prebuilt-themes/azure-blue.css';
+import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './AppComponent';
 
-bootstrapApplication(AppComponent).catch(error => console.error(error));
+// Animations disabled for the same reason src/createTestEngine.ts disables
+// them for the Vitest dom suites: Material's real CSS enter/exit animations
+// are cleared only by a real `animationend`, which the e2e (Playwright) path
+// can also race under load. See src/createTestEngine.ts for the full root
+// cause and why this uses the ANIMATION_MODULE_TYPE token directly rather
+// than `provideNoopAnimations()`.
+bootstrapApplication(AppComponent, {
+  providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }],
+}).catch(error => console.error(error));

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/AutocompleteDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/AutocompleteDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { AutocompleteExampleComponent } from '../src/examples/autocomplete/Autocomplete.examples';
 import { autocompleteScenePart, autocompleteTestSuite } from '../src/examples/autocomplete/Autocomplete.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/ButtonDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/ButtonDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { ButtonExampleComponent } from '../src/examples/button/Button.examples';
 import { buttonScenePart, buttonTestSuite } from '../src/examples/button/Button.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/CheckboxDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/CheckboxDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { CheckboxExampleComponent } from '../src/examples/checkbox/Checkbox.examples';
 import { checkboxScenePart, checkboxTestSuite } from '../src/examples/checkbox/Checkbox.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/DialogDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/DialogDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { DialogExampleComponent } from '../src/examples/dialog/Dialog.examples';
 import { dialogScenePart, dialogTestSuite } from '../src/examples/dialog/Dialog.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/InputDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/InputDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { InputExampleComponent } from '../src/examples/input/Input.examples';
 import { inputScenePart, inputTestSuite } from '../src/examples/input/Input.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/MenuDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/MenuDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { MenuExampleComponent } from '../src/examples/menu/Menu.examples';
 import { menuScenePart, menuTestSuite } from '../src/examples/menu/Menu.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/RadioDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/RadioDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { RadioExampleComponent } from '../src/examples/radio/Radio.examples';
 import { radioScenePart, radioTestSuite } from '../src/examples/radio/Radio.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/SelectDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/SelectDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SelectExampleComponent } from '../src/examples/select/Select.examples';
 import { selectScenePart, selectTestSuite } from '../src/examples/select/Select.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/SlideToggleDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/SlideToggleDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SlideToggleExampleComponent } from '../src/examples/slideToggle/SlideToggle.examples';
 import { slideToggleScenePart, slideToggleTestSuite } from '../src/examples/slideToggle/SlideToggle.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/SnackbarDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/SnackbarDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SnackbarExampleComponent } from '../src/examples/snackbar/Snackbar.examples';
 import { snackbarScenePart, snackbarTestSuite } from '../src/examples/snackbar/Snackbar.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/TableDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/TableDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TableExampleComponent } from '../src/examples/table/Table.examples';
 import { tableScenePart, tableTestSuite } from '../src/examples/table/Table.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/__tests__/TabsDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v21-test/__tests__/TabsDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-21';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TabsExampleComponent } from '../src/examples/tabs/Tabs.examples';
 import { tabsScenePart, tabsTestSuite } from '../src/examples/tabs/Tabs.suite';
 

--- a/package-tests/component-driver-angular-material-v21-test/src/createTestEngine.ts
+++ b/package-tests/component-driver-angular-material-v21-test/src/createTestEngine.ts
@@ -1,0 +1,44 @@
+import { ANIMATION_MODULE_TYPE, Type } from '@angular/core';
+import { createTestEngine as bootstrapTestEngine, IAngularTestEngineOption } from '@atomic-testing/angular-21';
+import { ScenePart, TestEngine } from '@atomic-testing/core';
+
+/**
+ * Bootstraps every example in this package through
+ * `@atomic-testing/angular-21`'s `createTestEngine`, with animations disabled
+ * by default.
+ *
+ * Material's real CSS animations (e.g. `mat-menu`'s ~120ms enter transition)
+ * apply `pointer-events: none` to the animating panel, cleared only by a real
+ * `animationend` event — Material has a JS fallback timer for the *close*
+ * path but none for *open*. Under CI load that event can be delayed past
+ * `MenuItemDriver.click()`'s defensive wait (which times out silently rather
+ * than throwing), so the click proceeds while pointer events are still
+ * suppressed and hits `@testing-library/user-event`'s own guard — the
+ * intermittent `MatMenu` "activating an item" failure this wrapper exists to
+ * eliminate.
+ *
+ * `ANIMATION_MODULE_TYPE: 'NoopAnimations'` is what every Material component
+ * itself reads (via `_animationsDisabled()`, see `@angular/material/core`) to
+ * decide whether to run its real CSS animation at all — it does not go
+ * through `@angular/platform-browser/animations`' `provideNoopAnimations()`,
+ * which additionally pulls in `@angular/animations/browser`'s renderer
+ * factory, a package this workspace does not otherwise depend on. Setting
+ * just the token Material already consults disables the animation classes
+ * (and the pointer-events race with them) without that extra dependency.
+ * Every affected driver already waits on DOM/attribute state via `waitUntil`
+ * rather than a fixed animation duration, so resolving that state sooner is
+ * safe, not just faster.
+ *
+ * `option.providers`, when supplied, is appended after this provider, so a
+ * caller can still override it (Angular DI: later provider wins).
+ */
+export function createTestEngine<T extends ScenePart>(
+  component: Type<unknown>,
+  partDefinitions: T,
+  option?: Readonly<Partial<IAngularTestEngineOption>>
+): Promise<TestEngine<T>> {
+  return bootstrapTestEngine(component, partDefinitions, {
+    ...option,
+    providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }, ...(option?.providers ?? [])],
+  });
+}

--- a/package-tests/component-driver-angular-material-v21-test/src/main.ts
+++ b/package-tests/component-driver-angular-material-v21-test/src/main.ts
@@ -7,8 +7,17 @@ import '@angular/compiler';
 // under the `style` condition, which Vite's JS-import resolution does not
 // apply — the bare specifier fails to resolve.
 import '../node_modules/@angular/material/prebuilt-themes/azure-blue.css';
+import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './AppComponent';
 
-bootstrapApplication(AppComponent).catch(error => console.error(error));
+// Animations disabled for the same reason src/createTestEngine.ts disables
+// them for the Vitest dom suites: Material's real CSS enter/exit animations
+// are cleared only by a real `animationend`, which the e2e (Playwright) path
+// can also race under load. See src/createTestEngine.ts for the full root
+// cause and why this uses the ANIMATION_MODULE_TYPE token directly rather
+// than `provideNoopAnimations()`.
+bootstrapApplication(AppComponent, {
+  providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }],
+}).catch(error => console.error(error));

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/AutocompleteDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/AutocompleteDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { AutocompleteExampleComponent } from '../src/examples/autocomplete/Autocomplete.examples';
 import { autocompleteScenePart, autocompleteTestSuite } from '../src/examples/autocomplete/Autocomplete.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/ButtonDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/ButtonDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { ButtonExampleComponent } from '../src/examples/button/Button.examples';
 import { buttonScenePart, buttonTestSuite } from '../src/examples/button/Button.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/CheckboxDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/CheckboxDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { CheckboxExampleComponent } from '../src/examples/checkbox/Checkbox.examples';
 import { checkboxScenePart, checkboxTestSuite } from '../src/examples/checkbox/Checkbox.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/DialogDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/DialogDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { DialogExampleComponent } from '../src/examples/dialog/Dialog.examples';
 import { dialogScenePart, dialogTestSuite } from '../src/examples/dialog/Dialog.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/InputDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/InputDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { InputExampleComponent } from '../src/examples/input/Input.examples';
 import { inputScenePart, inputTestSuite } from '../src/examples/input/Input.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/MenuDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/MenuDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { MenuExampleComponent } from '../src/examples/menu/Menu.examples';
 import { menuScenePart, menuTestSuite } from '../src/examples/menu/Menu.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/RadioDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/RadioDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { RadioExampleComponent } from '../src/examples/radio/Radio.examples';
 import { radioScenePart, radioTestSuite } from '../src/examples/radio/Radio.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/SelectDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/SelectDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SelectExampleComponent } from '../src/examples/select/Select.examples';
 import { selectScenePart, selectTestSuite } from '../src/examples/select/Select.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/SlideToggleDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/SlideToggleDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SlideToggleExampleComponent } from '../src/examples/slideToggle/SlideToggle.examples';
 import { slideToggleScenePart, slideToggleTestSuite } from '../src/examples/slideToggle/SlideToggle.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/SnackbarDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/SnackbarDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { SnackbarExampleComponent } from '../src/examples/snackbar/Snackbar.examples';
 import { snackbarScenePart, snackbarTestSuite } from '../src/examples/snackbar/Snackbar.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/TableDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/TableDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TableExampleComponent } from '../src/examples/table/Table.examples';
 import { tableScenePart, tableTestSuite } from '../src/examples/table/Table.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/__tests__/TabsDriver.dom.test.ts
+++ b/package-tests/component-driver-angular-material-v22-test/__tests__/TabsDriver.dom.test.ts
@@ -1,7 +1,7 @@
-import { createTestEngine } from '@atomic-testing/angular-22';
 import { testRunner } from '@atomic-testing/internal-test-runner';
 import { vitestAdapter } from '@atomic-testing/internal-test-runner-vitest-adapter';
 
+import { createTestEngine } from '../src/createTestEngine';
 import { TabsExampleComponent } from '../src/examples/tabs/Tabs.examples';
 import { tabsScenePart, tabsTestSuite } from '../src/examples/tabs/Tabs.suite';
 

--- a/package-tests/component-driver-angular-material-v22-test/src/createTestEngine.ts
+++ b/package-tests/component-driver-angular-material-v22-test/src/createTestEngine.ts
@@ -1,0 +1,44 @@
+import { ANIMATION_MODULE_TYPE, Type } from '@angular/core';
+import { createTestEngine as bootstrapTestEngine, IAngularTestEngineOption } from '@atomic-testing/angular-22';
+import { ScenePart, TestEngine } from '@atomic-testing/core';
+
+/**
+ * Bootstraps every example in this package through
+ * `@atomic-testing/angular-22`'s `createTestEngine`, with animations disabled
+ * by default.
+ *
+ * Material's real CSS animations (e.g. `mat-menu`'s ~120ms enter transition)
+ * apply `pointer-events: none` to the animating panel, cleared only by a real
+ * `animationend` event — Material has a JS fallback timer for the *close*
+ * path but none for *open*. Under CI load that event can be delayed past
+ * `MenuItemDriver.click()`'s defensive wait (which times out silently rather
+ * than throwing), so the click proceeds while pointer events are still
+ * suppressed and hits `@testing-library/user-event`'s own guard — the
+ * intermittent `MatMenu` "activating an item" failure this wrapper exists to
+ * eliminate.
+ *
+ * `ANIMATION_MODULE_TYPE: 'NoopAnimations'` is what every Material component
+ * itself reads (via `_animationsDisabled()`, see `@angular/material/core`) to
+ * decide whether to run its real CSS animation at all — it does not go
+ * through `@angular/platform-browser/animations`' `provideNoopAnimations()`,
+ * which additionally pulls in `@angular/animations/browser`'s renderer
+ * factory, a package this workspace does not otherwise depend on. Setting
+ * just the token Material already consults disables the animation classes
+ * (and the pointer-events race with them) without that extra dependency.
+ * Every affected driver already waits on DOM/attribute state via `waitUntil`
+ * rather than a fixed animation duration, so resolving that state sooner is
+ * safe, not just faster.
+ *
+ * `option.providers`, when supplied, is appended after this provider, so a
+ * caller can still override it (Angular DI: later provider wins).
+ */
+export function createTestEngine<T extends ScenePart>(
+  component: Type<unknown>,
+  partDefinitions: T,
+  option?: Readonly<Partial<IAngularTestEngineOption>>
+): Promise<TestEngine<T>> {
+  return bootstrapTestEngine(component, partDefinitions, {
+    ...option,
+    providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }, ...(option?.providers ?? [])],
+  });
+}

--- a/package-tests/component-driver-angular-material-v22-test/src/main.ts
+++ b/package-tests/component-driver-angular-material-v22-test/src/main.ts
@@ -7,8 +7,17 @@ import '@angular/compiler';
 // under the `style` condition, which Vite's JS-import resolution does not
 // apply — the bare specifier fails to resolve.
 import '../node_modules/@angular/material/prebuilt-themes/azure-blue.css';
+import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './AppComponent';
 
-bootstrapApplication(AppComponent).catch(error => console.error(error));
+// Animations disabled for the same reason src/createTestEngine.ts disables
+// them for the Vitest dom suites: Material's real CSS enter/exit animations
+// are cleared only by a real `animationend`, which the e2e (Playwright) path
+// can also race under load. See src/createTestEngine.ts for the full root
+// cause and why this uses the ANIMATION_MODULE_TYPE token directly rather
+// than `provideNoopAnimations()`.
+bootstrapApplication(AppComponent, {
+  providers: [{ provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations' }],
+}).catch(error => console.error(error));


### PR DESCRIPTION
## Summary

`Test Angular Material v21/v22 components` CI jobs intermittently failed `MenuDriver.dom.test.ts`'s "activating an item runs its handler and closes the menu" with `Unable to perform pointer interaction as the element has 'pointer-events: none': BUTTON(label=Settings)`.

Root cause: Angular Material's `mat-menu` panel applies `pointer-events: none` via CSS while its real enter-animation (120ms) is in flight, cleared only by a real `animationend` DOM event — Material has a JS fallback timer for the *close* path but none for *open*. None of the `component-driver-angular-material-v{20,21,22}-test` packages configured Angular's animations module, so under CI load the `animationend` event could be delayed past `MenuItemDriver.click()`'s existing defensive wait (which times out silently rather than throwing), letting the click proceed while pointer events were still suppressed. This affects v20 identically (byte-identical code); it just hadn't flipped in that CI run.

Fix: each `component-driver-angular-material-v{20,21,22}-test` package gets a `src/createTestEngine.ts` wrapper that provides `ANIMATION_MODULE_TYPE: 'NoopAnimations'` by default for every Vitest/jsdom example (callers can still override via `option.providers`), with all 12 `__tests__/*.dom.test.ts` files per package switched to import it instead of the raw `@atomic-testing/angular-2X` `createTestEngine`. The same provider is added to each package's `src/main.ts` for the e2e/dev-server bootstrap path.

The DI-token form (`ANIMATION_MODULE_TYPE`) is used instead of `provideNoopAnimations()`/`provideNoopAnimationsAsync()`, since those pull in `@angular/platform-browser/animations` → `@angular/animations/browser`, a package none of these three workspaces depend on. Angular Material's own `_animationsDisabled()` reads `ANIMATION_MODULE_TYPE` directly via optional injection, so setting just the token disables Material's CSS animation classes (and the pointer-events race) with zero new dependencies.

## Verification

- **Reproduced the original flake**: stashed the fix, saturated all 4 local cores with CPU load, hit the exact reported failure on the first run.
- **Confirmed the fix under identical load**: restored the fix, same CPU saturation, 24 consecutive clean runs of the target test.
- Full `pnpm test:dom` suites for v20/v21/v22 (zone + zoneless, 188 tests each) run 4× with no regressions in the other examples (Dialog, Select, Snackbar, Autocomplete, Table, Tabs, etc.), which all wait on DOM/attribute state rather than fixed animation durations.
- `MenuDriver.dom.test.ts` isolated: 20 runs (v20), 5 runs each (v21/v22), consistently 12/12 passing in both zone and zoneless variants.
- Root `check:type`/`check:lint`/`check:style`: clean (only 3 pre-existing, unrelated `tsgo` errors, byte-identical before/after this change).
- **Not verified**: Playwright e2e for these three packages — not wired into CI (`buildui.yml`'s Angular Material jobs only run `pnpm test:dom`), so out of this fix's verification scope. The `main.ts` change is applied there too for consistency but is unverified end-to-end.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (component-driver-angular-material-v20/v21/v22-test, zone + zoneless, repeated + stress-tested)
- [ ] `pnpm test:e2e` — not applicable; these packages aren't wired into CI's e2e path

## Breaking change

- [ ] This PR introduces a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcJn3neEbPSQyDpeXvFmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAcJn3neEbPSQyDpeXvFmw)_