### PR TITLE
feat(astryx)!: upgrade to 0.1.3 and add disabledMessage coverage

### DIFF
--- a/examples/example-astryx-workspace/package.json
+++ b/examples/example-astryx-workspace/package.json
@@ -14,8 +14,8 @@
     "test:e2e:chrome": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@astryxdesign/core": "^0.1.2",
-    "@astryxdesign/theme-neutral": "^0.1.2",
+    "@astryxdesign/core": "^0.1.3",
+    "@astryxdesign/theme-neutral": "^0.1.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router-dom": "^7.7.1"

--- a/examples/example-astryx-workspace/pnpm-lock.yaml
+++ b/examples/example-astryx-workspace/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@astryxdesign/core':
-        specifier: ^0.1.2
-        version: 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.1.3
+        version: 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@astryxdesign/theme-neutral':
-        specifier: ^0.1.2
-        version: 0.1.2(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: ^0.1.3
+        version: 0.1.3(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.3
         version: 19.2.7
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@atomic-testing/component-driver-astryx':
         specifier: ^0.89.0
-        version: 0.89.0(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.89.0(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@atomic-testing/component-driver-html':
         specifier: ^0.89.0
         version: 0.89.0
@@ -84,16 +84,17 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@astryxdesign/core@0.1.2':
-    resolution: {integrity: sha512-SJOEXUaRvcVgGbdPwV5UL5aYMbwIl09H2yQb3hPh4NNGWqmLTHE05IFTNRi37Mk9ywoo01+UM2ZrewmJe39f0A==}
+  '@astryxdesign/core@0.1.3':
+    resolution: {integrity: sha512-NTiKu0+keZckb5RB6enErCXDGYLF6j4cUYjK/V0uWrqbflX+47sUQgaCZVFZB4b2kAe4k4czBCZS3mtaJcbZlw==}
     peerDependencies:
+      '@stylexjs/stylex': ^0.18.3
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@astryxdesign/theme-neutral@0.1.2':
-    resolution: {integrity: sha512-kEBBJ7O5H+27IACsGEqZSEVFy2r4VlBu4Vzfm/LOJ/Ez6C/RBTCXq9Iu8CoZS4Qt/WkYUvqLPDiJlgXuALy9uQ==}
+  '@astryxdesign/theme-neutral@0.1.3':
+    resolution: {integrity: sha512-diwEEukajD0OHSeQ3XnyaNYHssaWgbjbwAGG5t/NANjE4X0sjFXUKb5drwWHhje5AU+hTFU7yOUltvjSW4LHvg==}
     peerDependencies:
-      '@astryxdesign/core': 0.1.2
+      '@astryxdesign/core': 0.1.3
       react: '>=19'
 
   '@atomic-testing/component-driver-astryx@0.89.0':
@@ -912,21 +913,21 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@stylexjs/stylex': 0.18.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@astryxdesign/theme-neutral@0.1.2(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-neutral@0.1.3(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.22.0(react@19.2.7)
       react: 19.2.7
 
-  '@atomic-testing/component-driver-astryx@0.89.0(@astryxdesign/core@0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@atomic-testing/component-driver-astryx@0.89.0(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@atomic-testing/component-driver-html': 0.89.0
       '@atomic-testing/core': 0.89.0
       react: 19.2.7

--- a/package-tests/component-driver-astryx-test/package.json
+++ b/package-tests/component-driver-astryx-test/package.json
@@ -27,8 +27,8 @@
     "test:e2e:chrome": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@astryxdesign/core": "^0.1.1",
-    "@astryxdesign/theme-neutral": "^0.1.1",
+    "@astryxdesign/core": "^0.1.3",
+    "@astryxdesign/theme-neutral": "^0.1.3",
     "@atomic-testing/core": "workspace:*",
     "@atomic-testing/internal-react-example": "workspace:*",
     "react": "^19.2.3",

--- a/package-tests/component-driver-astryx-test/playwright.config.ts
+++ b/package-tests/component-driver-astryx-test/playwright.config.ts
@@ -2,6 +2,12 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseUrl = 'http://localhost:3020';
 
+// CHROMIUM_EXECUTABLE lets sandboxed dev environments point at a preinstalled
+// Chromium (mirroring package-tests/storybook-test and the Angular Material
+// package-tests); CI and normal dev machines resolve the browsers through
+// Playwright's registry (npx playwright install).
+const executablePath = process.env.CHROMIUM_EXECUTABLE;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -31,7 +37,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], ...(executablePath ? { launchOptions: { executablePath } } : {}) },
     },
     {
       name: 'firefox',

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.examples.tsx
@@ -8,7 +8,10 @@ import React, { JSX, useState } from 'react';
  * The accessible control is the native `<input type="checkbox">`; the root is a
  * plain `<div>` and Astryx does NOT forward `data-testid`, so each instance is
  * wrapped in a testid'd container and the scene scopes to the inner checkbox. The
- * "All" instance is rendered indeterminate (`aria-checked="mixed"`).
+ * "All" instance is rendered indeterminate (`aria-checked="mixed"`). The
+ * "Locked" instance is disabled with a `disabledMessage`, so its native
+ * `<input>` renders a `role="tooltip"` layer reached through the composed
+ * `aria-describedby`.
  */
 export const CheckboxInputExample = () => {
   const [accept, setAccept] = useState(true);
@@ -24,6 +27,15 @@ export const CheckboxInputExample = () => {
       </div>
       <div data-testid='all-wrap'>
         <CheckboxInput label='All' value='indeterminate' onChange={() => {}} />
+      </div>
+      <div data-testid='locked-wrap'>
+        <CheckboxInput
+          label='Locked'
+          value={false}
+          onChange={() => {}}
+          isDisabled
+          disabledMessage='Managed by your administrator'
+        />
       </div>
     </div>
   );

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.examples.tsx
@@ -8,7 +8,8 @@ import React, { JSX, useState } from 'react';
  * The accessible control is the native `<input type="checkbox">`; the root is a
  * plain `<div>` and Astryx does NOT forward `data-testid`, so each instance is
  * wrapped in a testid'd container and the scene scopes to the inner checkbox. The
- * "All" instance is rendered indeterminate (`aria-checked="mixed"`). The
+ * "All" instance is rendered indeterminate (read via the native `:indeterminate`
+ * pseudo-class — Astryx 0.1.3 dropped `aria-checked="mixed"`). The
  * "Locked" instance is disabled with a `disabledMessage`, so its native
  * `<input>` renders a `role="tooltip"` layer reached through the composed
  * `aria-describedby`.

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-input/CheckboxInput.suite.ts
@@ -18,6 +18,10 @@ export const checkboxInputExampleScenePart = {
     locator: locatorUtil.append(byDataTestId('all-wrap'), byInputType('checkbox')),
     driver: CheckboxInputDriver,
   },
+  locked: {
+    locator: locatorUtil.append(byDataTestId('locked-wrap'), byInputType('checkbox')),
+    driver: CheckboxInputDriver,
+  },
 } satisfies ScenePart;
 
 export const checkboxInputExample: IExampleUnit<typeof checkboxInputExampleScenePart, JSX.Element> = {
@@ -56,6 +60,14 @@ export const checkboxInputExampleTestSuite: TestSuiteInfo<typeof checkboxInputEx
       test(`getLabel returns the checkbox label`, async () => {
         assertEqual(await engine().parts.accept.getLabel(), 'Accept terms');
         assertEqual(await engine().parts.subscribe.getLabel(), 'Subscribe');
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // composed aria-describedby; undefined when the checkbox isn't disabled
+      // with a message.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'Managed by your administrator');
+        assertEqual(await engine().parts.accept.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.examples.tsx
@@ -6,8 +6,10 @@ import React, { JSX, useState } from 'react';
  * Astryx CheckboxList scene.
  *
  * CheckboxList self-emits `data-testid` on its outer `<div>`; inside is a
- * `<ul role="list">` of `<li aria-checked>` rows. The per-item value is a React
- * key (not emitted to the DOM), so rows are addressed by their visible label.
+ * `<ul role="list">` of `<li role="listitem">` rows. Astryx 0.1.3 dropped the
+ * row's `aria-checked` (invalid on `role="listitem"`) — checked state is
+ * conveyed solely by the inner checkbox. The per-item value is a React key (not
+ * emitted to the DOM), so rows are addressed by their visible label.
  *
  * The second group is disabled with a group-level `disabledMessage`: the
  * tooltip's `aria-describedby` link composes onto the inner `role="group"`

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.examples.tsx
@@ -8,16 +8,32 @@ import React, { JSX, useState } from 'react';
  * CheckboxList self-emits `data-testid` on its outer `<div>`; inside is a
  * `<ul role="list">` of `<li aria-checked>` rows. The per-item value is a React
  * key (not emitted to the DOM), so rows are addressed by their visible label.
+ *
+ * The second group is disabled with a group-level `disabledMessage`: the
+ * tooltip's `aria-describedby` link composes onto the inner `role="group"`
+ * div, not onto any individual row.
  */
 export const CheckboxListExample = () => {
   const [selected, setSelected] = useState<string[]>(['email']);
 
   return (
-    <CheckboxList label='Notifications' value={selected} onChange={setSelected} data-testid='notifs'>
-      <CheckboxListItem label='Email' value='email' />
-      <CheckboxListItem label='SMS' value='sms' />
-      <CheckboxListItem label='Push' value='push' />
-    </CheckboxList>
+    <div>
+      <CheckboxList label='Notifications' value={selected} onChange={setSelected} data-testid='notifs'>
+        <CheckboxListItem label='Email' value='email' />
+        <CheckboxListItem label='SMS' value='sms' />
+        <CheckboxListItem label='Push' value='push' />
+      </CheckboxList>
+      <CheckboxList
+        label='Locked notifications'
+        value={['email']}
+        onChange={() => {}}
+        isDisabled
+        disabledMessage='Notifications are managed by your administrator'
+        data-testid='locked-notifs'>
+        <CheckboxListItem label='Email' value='email' />
+        <CheckboxListItem label='SMS' value='sms' />
+      </CheckboxList>
+    </div>
   );
 };
 

--- a/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/checkbox-list/CheckboxList.suite.ts
@@ -10,6 +10,10 @@ export const checkboxListExampleScenePart = {
     locator: byDataTestId('notifs'),
     driver: CheckboxListDriver,
   },
+  lockedNotifs: {
+    locator: byDataTestId('locked-notifs'),
+    driver: CheckboxListDriver,
+  },
 } satisfies ScenePart;
 
 export const checkboxListExample: IExampleUnit<typeof checkboxListExampleScenePart, JSX.Element> = {
@@ -47,6 +51,17 @@ export const checkboxListExampleTestSuite: TestSuiteInfo<typeof checkboxListExam
       test(`uncheckItemByLabel unchecks a row`, async () => {
         assertTrue(await engine().parts.notifs.uncheckItemByLabel('Email'));
         assertFalse(await engine().parts.notifs.isItemChecked('Email'));
+      });
+
+      // getDisabledMessage is a group-level concept: the tooltip's
+      // aria-describedby link composes onto the inner role="group" div, not any
+      // individual row. undefined when the group isn't disabled with a message.
+      test(`getDisabledMessage returns the group's disabled-reason tooltip text`, async () => {
+        assertEqual(
+          await engine().parts.lockedNotifs.getDisabledMessage(),
+          'Notifications are managed by your administrator'
+        );
+        assertEqual(await engine().parts.notifs.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/context-menu/ContextMenu.suite.ts
@@ -24,11 +24,6 @@ export const contextMenuExampleTestSuite: TestSuiteInfo<typeof contextMenuExampl
     describe(`${contextMenuExample.title}`, () => {
       const engine = useTestEngine(contextMenuExample.scene, getTestEngine, { beforeEach, afterEach });
 
-      // The trigger advertises a menu popup via aria-haspopup.
-      test(`getHasPopup reads the trigger's popup type`, async () => {
-        assertEqual(await engine().parts.ctxMenu.getHasPopup(), 'menu');
-      });
-
       // Items stay mounted in the DOM while closed, so labels/count read in jsdom.
       // Open-state is intentionally NOT asserted — it is E2E-only (native popover).
       test(`getItemLabels reads every menu item in order`, async () => {

--- a/package-tests/component-driver-astryx-test/src/examples/date-input/DateInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/date-input/DateInput.examples.tsx
@@ -13,17 +13,31 @@ const DeadlineInput = () => {
   return <DateInput data-testid='deadline' label='Deadline' value={value} onChange={setValue} />;
 };
 
+const LockedInput = () => (
+  <DateInput
+    data-testid='locked'
+    label='Event date'
+    value={undefined}
+    onChange={() => {}}
+    isDisabled
+    disabledMessage='You need the Editor role to change this'
+  />
+);
+
 /**
  * Astryx DateInput scene.
  *
  * DateInput self-emits `data-testid`; the editable control is an
  * `<input role="combobox">` (value = display string) with an "Open calendar"
  * toggle. `birthday` is pre-filled with a clear control; `deadline` starts empty.
+ * `locked` is disabled with a `disabledMessage`, so its `<input>` renders a
+ * `role="tooltip"` layer reached through the composed `aria-describedby`.
  */
 export const DateInputExample = () => (
   <>
     <BirthdayInput />
     <DeadlineInput />
+    <LockedInput />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/date-input/DateInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/date-input/DateInput.suite.ts
@@ -15,6 +15,10 @@ export const dateInputExampleScenePart = {
     locator: byDataTestId('deadline'),
     driver: DateInputDriver,
   },
+  locked: {
+    locator: byDataTestId('locked'),
+    driver: DateInputDriver,
+  },
 } satisfies ScenePart;
 
 export const dateInputExample: IExampleUnit<typeof dateInputExampleScenePart, JSX.Element> = {
@@ -60,6 +64,13 @@ export const dateInputExampleTestSuite: TestSuiteInfo<typeof dateInputExample.sc
         assertTrue(await engine().parts.birthday.clear());
         assertEqual(await engine().parts.birthday.getValue(), undefined);
         assertFalse(await engine().parts.deadline.clear());
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // input's composed aria-describedby; undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.deadline.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/date-range-input/DateRangeInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/date-range-input/DateRangeInput.examples.tsx
@@ -36,18 +36,32 @@ const BudgetRange = () => {
   );
 };
 
+const LockedRange = () => (
+  <DateRangeInput
+    data-testid='locked'
+    label='Reporting period'
+    value={null}
+    onChange={() => {}}
+    isDisabled
+    disabledMessage='You need the Editor role to change this'
+  />
+);
+
 /**
  * Astryx DateRangeInput scene.
  *
  * DateRangeInput self-emits `data-testid`; the trigger is a
  * `<button aria-haspopup="dialog">` whose text is the display range and whose
  * `aria-controls` (when open) points at the popover holding preset options and a
- * range calendar. Two range inputs verify selector scoping.
+ * range calendar. Two range inputs verify selector scoping. `locked` is disabled
+ * with a `disabledMessage`, so its trigger `<button>` renders a `role="tooltip"`
+ * layer reached through the composed `aria-describedby`.
  */
 export const DateRangeInputExample = () => (
   <>
     <ReportRange />
     <BudgetRange />
+    <LockedRange />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/date-range-input/DateRangeInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/date-range-input/DateRangeInput.suite.ts
@@ -15,6 +15,10 @@ export const dateRangeInputExampleScenePart = {
     locator: byDataTestId('budget'),
     driver: DateRangeInputDriver,
   },
+  locked: {
+    locator: byDataTestId('locked'),
+    driver: DateRangeInputDriver,
+  },
 } satisfies ScenePart;
 
 export const dateRangeInputExample: IExampleUnit<typeof dateRangeInputExampleScenePart, JSX.Element> = {
@@ -72,6 +76,13 @@ export const dateRangeInputExampleTestSuite: TestSuiteInfo<typeof dateRangeInput
         await engine().parts.report.selectPreset('Last 7 days');
         assertTrue(await engine().parts.report.clear());
         assertEqual(await engine().parts.report.getDisplayText(), 'Select date range');
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // trigger's composed aria-describedby; undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.report.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.examples.tsx
@@ -28,7 +28,10 @@ const LockedInput = () => (
  * Astryx DateTimeInput scene.
  *
  * DateTimeInput self-emits `data-testid` and pairs a date `<input role="combobox">`
- * (with a calendar popover) and a time `<input aria-label="Time">`. `meeting` is
+ * (with a calendar popover) and a time `<input>`. Astryx 0.1.3 no longer gives the
+ * time field a fixed `aria-label="Time"` — it defaults to `"{label} time"` and is
+ * overridable via `timeLabel`, so DateTimeInputDriver reaches it structurally
+ * instead (whichever input isn't the date combobox). `meeting` is
  * pre-filled; `reminder` starts empty. `locked` is disabled with a
  * `disabledMessage`: Astryx wires its `aria-describedby` onto the date field only,
  * so its `role="tooltip"` layer is reached through that field's composed

--- a/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.examples.tsx
@@ -13,17 +13,32 @@ const ReminderInput = () => {
   return <DateTimeInput data-testid='reminder' label='Reminder' value={value} onChange={setValue} />;
 };
 
+const LockedInput = () => (
+  <DateTimeInput
+    data-testid='locked'
+    label='Meeting time'
+    value={undefined}
+    onChange={() => {}}
+    isDisabled
+    disabledMessage='You need the Editor role to change this'
+  />
+);
+
 /**
  * Astryx DateTimeInput scene.
  *
  * DateTimeInput self-emits `data-testid` and pairs a date `<input role="combobox">`
  * (with a calendar popover) and a time `<input aria-label="Time">`. `meeting` is
- * pre-filled; `reminder` starts empty.
+ * pre-filled; `reminder` starts empty. `locked` is disabled with a
+ * `disabledMessage`: Astryx wires its `aria-describedby` onto the date field only,
+ * so its `role="tooltip"` layer is reached through that field's composed
+ * `aria-describedby`.
  */
 export const DateTimeInputExample = () => (
   <>
     <MeetingInput />
     <ReminderInput />
+    <LockedInput />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/date-time-input/DateTimeInput.suite.ts
@@ -15,6 +15,10 @@ export const dateTimeInputExampleScenePart = {
     locator: byDataTestId('reminder'),
     driver: DateTimeInputDriver,
   },
+  locked: {
+    locator: byDataTestId('locked'),
+    driver: DateTimeInputDriver,
+  },
 } satisfies ScenePart;
 
 export const dateTimeInputExample: IExampleUnit<typeof dateTimeInputExampleScenePart, JSX.Element> = {
@@ -51,6 +55,14 @@ export const dateTimeInputExampleTestSuite: TestSuiteInfo<typeof dateTimeInputEx
         assertEqual(await engine().parts.reminder.getDateValue(), 'March 3, 2024');
         await engine().parts.meeting.open();
         assertTrue(await engine().parts.meeting.isExpanded());
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the date
+      // field's composed aria-describedby (the time field carries no such link);
+      // undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.reminder.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/dropdown-menu/DropdownMenu.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/dropdown-menu/DropdownMenu.examples.tsx
@@ -9,7 +9,9 @@ import React, { JSX, useState } from 'react';
  * `aria-haspopup`/`aria-expanded`/`aria-controls`; the menu panel renders as a
  * sibling linked by `aria-controls`. A visible marker records the last selected
  * item so a selection can be observed without inspecting the (native-popover)
- * panel visibility. `hasAutoFocus` is disabled to keep jsdom focus quiet.
+ * panel visibility. Astryx 0.1.3 removed `hasAutoFocus` (it was only an escape
+ * hatch for documentation previews) — menus now always focus their first item on
+ * open, which is harmless under jsdom.
  */
 export const DropdownMenuExample = () => {
   const [last, setLast] = useState('none');
@@ -17,7 +19,6 @@ export const DropdownMenuExample = () => {
     <div>
       <DropdownMenu
         data-testid='dropdown'
-        hasAutoFocus={false}
         button={{ label: 'Actions' }}
         items={[
           { label: 'Edit', onClick: () => setLast('Edit') },

--- a/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.examples.tsx
@@ -11,8 +11,12 @@ import React, { JSX } from 'react';
  * `aria-required`, `aria-invalid`, `disabled`, and the `aria-describedby` status link
  * all live — so the scene anchors there.
  *
- * Three instances cover the readable surface: a basic single-file input, a required
- * multi-file dropzone, and a disabled input carrying an error `status`.
+ * Four instances cover the readable surface: a basic single-file input, a required
+ * multi-file dropzone, a disabled input carrying an error `status`, and a disabled
+ * input carrying a `disabledMessage`. The last exercises `getDisabledMessage`,
+ * which — unlike the other reads above — resolves through the focusable
+ * `div[role="button"]` wrapper's `aria-describedby`, not the hidden input's (Astryx
+ * 0.1.3 moved that link onto the wrapper).
  */
 export const FileInputExample = () => (
   <div>
@@ -33,6 +37,14 @@ export const FileInputExample = () => (
       value={null}
       onChange={() => {}}
       data-testid='fi-error'
+    />
+    <FileInput
+      label='Contract'
+      isDisabled
+      disabledMessage='Uploads are locked until your profile is verified'
+      value={null}
+      onChange={() => {}}
+      data-testid='fi-disabled-message'
     />
   </div>
 );

--- a/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/file-input/FileInput.suite.ts
@@ -18,6 +18,10 @@ export const fileInputExampleScenePart = {
     locator: byDataTestId('fi-error'),
     driver: FileInputDriver,
   },
+  fiDisabledMessage: {
+    locator: byDataTestId('fi-disabled-message'),
+    driver: FileInputDriver,
+  },
 } satisfies ScenePart;
 
 export const fileInputExample: IExampleUnit<typeof fileInputExampleScenePart, JSX.Element> = {
@@ -61,6 +65,15 @@ export const fileInputExampleTestSuite: TestSuiteInfo<typeof fileInputExample.sc
         assertFalse(await engine().parts.fiBasic.isMultiple());
         assertFalse(await engine().parts.fiBasic.isRequired());
         assertFalse(await engine().parts.fiBasic.isDisabled());
+      });
+
+      // getDisabledMessage resolves through the role="button" wrapper's aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(
+          await engine().parts.fiDisabledMessage.getDisabledMessage(),
+          'Uploads are locked until your profile is verified'
+        );
+        assertEqual(await engine().parts.fiBasic.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/more-menu/MoreMenu.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/more-menu/MoreMenu.examples.tsx
@@ -6,7 +6,9 @@ import React, { JSX, useState } from 'react';
  * Astryx MoreMenu scene (uncontrolled) — an icon-only "⋯" overflow menu over
  * DropdownMenu. The trigger has no visible text; its accessible name is the
  * default `aria-label` ("More options"). A visible marker records the last
- * selected item.
+ * selected item. Astryx 0.1.3 removed `hasAutoFocus` (it was only an escape
+ * hatch for documentation previews) — menus now always focus their first item on
+ * open, which is harmless under jsdom.
  */
 export const MoreMenuExample = () => {
   const [last, setLast] = useState('none');
@@ -14,7 +16,6 @@ export const MoreMenuExample = () => {
     <div>
       <MoreMenu
         data-testid='more-menu'
-        hasAutoFocus={false}
         items={[
           { label: 'Rename', onClick: () => setLast('Rename') },
           { label: 'Archive', onClick: () => setLast('Archive') },

--- a/package-tests/component-driver-astryx-test/src/examples/multi-selector/MultiSelector.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/multi-selector/MultiSelector.examples.tsx
@@ -37,16 +37,32 @@ const PermsMulti = () => {
   );
 };
 
+const LockedMulti = () => (
+  <MultiSelector
+    data-testid='locked'
+    label='Columns'
+    value={['name']}
+    onChange={() => {}}
+    options={[{ value: 'name', label: 'Name' }]}
+    isDisabled
+    disabledMessage='Select a table first'
+  />
+);
+
 /**
  * Astryx MultiSelector scene.
  *
  * The `fruits` selector (no "select all") gives a clean option list and a clear
- * control; `perms` enables "select all" to exercise {@link selectAll}.
+ * control; `perms` enables "select all" to exercise {@link selectAll}. The
+ * `locked` instance is disabled with a `disabledMessage`, so its trigger
+ * `<button>` renders a `role="tooltip"` layer reached through the composed
+ * `aria-describedby`.
  */
 export const MultiSelectorExample = () => (
   <>
     <FruitsMulti />
     <PermsMulti />
+    <LockedMulti />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/multi-selector/MultiSelector.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/multi-selector/MultiSelector.suite.ts
@@ -15,6 +15,10 @@ export const multiSelectorExampleScenePart = {
     locator: byDataTestId('perms'),
     driver: MultiSelectorDriver,
   },
+  locked: {
+    locator: byDataTestId('locked'),
+    driver: MultiSelectorDriver,
+  },
 } satisfies ScenePart;
 
 export const multiSelectorExample: IExampleUnit<typeof multiSelectorExampleScenePart, JSX.Element> = {
@@ -65,6 +69,13 @@ export const multiSelectorExampleTestSuite: TestSuiteInfo<typeof multiSelectorEx
         assertTrue(await engine().parts.perms.selectAll());
         assertTrue(await engine().parts.perms.isOptionSelected('Read'));
         assertTrue(await engine().parts.perms.isOptionSelected('Write'));
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // trigger's composed aria-describedby; undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'Select a table first');
+        assertEqual(await engine().parts.fruits.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/number-input/NumberInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/number-input/NumberInput.examples.tsx
@@ -7,21 +7,36 @@ import React, { JSX, useState } from 'react';
  *
  * NumberInput renders an `<input type="number">` (forwarding `data-testid` onto
  * it) with native `min`/`max`/`step` and a trailing units `<span>` sibling.
+ *
+ * A second, disabled input carries a `disabledMessage`, exercising
+ * `getDisabledMessage`'s resolution of the tooltip id out of the composed
+ * `aria-describedby` list.
  */
 export const NumberInputExample = () => {
   const [value, setValue] = useState(5);
+  const [price, setPrice] = useState(100);
 
   return (
-    <NumberInput
-      label='Quantity'
-      value={value}
-      onChange={setValue}
-      min={0}
-      max={10}
-      step={2}
-      units='kg'
-      data-testid='qty-input'
-    />
+    <div>
+      <NumberInput
+        label='Quantity'
+        value={value}
+        onChange={setValue}
+        min={0}
+        max={10}
+        step={2}
+        units='kg'
+        data-testid='qty-input'
+      />
+      <NumberInput
+        label='Price'
+        value={price}
+        onChange={setPrice}
+        data-testid='price-input'
+        isDisabled
+        disabledMessage='Pricing is locked while the order is processing'
+      />
+    </div>
   );
 };
 

--- a/package-tests/component-driver-astryx-test/src/examples/number-input/NumberInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/number-input/NumberInput.suite.ts
@@ -10,6 +10,10 @@ export const numberInputExampleScenePart = {
     locator: byDataTestId('qty-input'),
     driver: NumberInputDriver,
   },
+  priceInput: {
+    locator: byDataTestId('price-input'),
+    driver: NumberInputDriver,
+  },
 } satisfies ScenePart;
 
 export const numberInputExample: IExampleUnit<typeof numberInputExampleScenePart, JSX.Element> = {
@@ -50,6 +54,15 @@ export const numberInputExampleTestSuite: TestSuiteInfo<typeof numberInputExampl
       test(`setValue round-trips`, async () => {
         await engine().parts.qtyInput.setValue('8');
         assertEqual(await engine().parts.qtyInput.getValue(), '8');
+      });
+
+      // getDisabledMessage resolves the tooltip out of the composed aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(
+          await engine().parts.priceInput.getDisabledMessage(),
+          'Pricing is locked while the order is processing'
+        );
+        assertEqual(await engine().parts.qtyInput.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/power-search/PowerSearch.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/power-search/PowerSearch.examples.tsx
@@ -57,6 +57,21 @@ const EmptyBar = () => {
   );
 };
 
+const DisabledBar = () => {
+  const [filters] = useState<Filter[]>([]);
+  return (
+    <PowerSearch
+      data-testid='disabled-search'
+      label='Disabled filters'
+      config={config}
+      filters={filters as never}
+      onChange={() => {}}
+      isDisabled
+      disabledMessage='Filters are locked while the saved view is shared'
+    />
+  );
+};
+
 /**
  * Astryx PowerSearch scene.
  *
@@ -64,12 +79,17 @@ const EmptyBar = () => {
  * `data-testid`); filter chips are `span.astryx-token` keyed by their
  * field/operator label, with a `role="combobox"` query input and a trailing
  * "N results" count. The pre-populated and empty bars verify enumeration, removal,
- * and scoping.
+ * and scoping. A third, disabled bar carries a `disabledMessage`, exercising
+ * `getDisabledMessage`'s resolution through the inner combobox input's
+ * `aria-describedby` — PowerSearch forwards `disabledMessage` straight through to
+ * its internal Tokenizer, which wires the tooltip link there, not onto the
+ * `role="group"` root.
  */
 export const PowerSearchExample = () => (
   <>
     <FilterBar />
     <EmptyBar />
+    <DisabledBar />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/power-search/PowerSearch.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/power-search/PowerSearch.suite.ts
@@ -15,6 +15,10 @@ export const powerSearchExampleScenePart = {
     locator: byDataTestId('empty-search'),
     driver: PowerSearchDriver,
   },
+  disabled: {
+    locator: byDataTestId('disabled-search'),
+    driver: PowerSearchDriver,
+  },
 } satisfies ScenePart;
 
 export const powerSearchExample: IExampleUnit<typeof powerSearchExampleScenePart, JSX.Element> = {
@@ -64,6 +68,15 @@ export const powerSearchExampleTestSuite: TestSuiteInfo<typeof powerSearchExampl
         if (skipInteractionOnWebkit(test, browser())) return;
         assertFalse(await engine().parts.search.editFilter('Nope'));
         assertTrue(await engine().parts.search.editFilter('Priority: is'));
+      });
+
+      // getDisabledMessage resolves through the combobox input's aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(
+          await engine().parts.disabled.getDisabledMessage(),
+          'Filters are locked while the saved view is shared'
+        );
+        assertEqual(await engine().parts.search.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/radio-list/RadioList.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/radio-list/RadioList.examples.tsx
@@ -8,16 +8,32 @@ import React, { JSX, useState } from 'react';
  * RadioList self-emits `data-testid` on its OUTER `<div>`; inside, native
  * `<input type="radio" value>` controls live under a `role="radiogroup"`. Anchor
  * the outer testid and read/select by radio `value`.
+ *
+ * The second group is disabled with a group-level `disabledMessage`: the
+ * tooltip's `aria-describedby` link composes onto the inner
+ * `role="radiogroup"` div, not onto any individual radio.
  */
 export const RadioListExample = () => {
   const [pref, setPref] = useState('email');
 
   return (
-    <RadioList label='Notification preference' value={pref} onChange={setPref} data-testid='prefs'>
-      <RadioListItem label='Email' value='email' />
-      <RadioListItem label='SMS' value='sms' />
-      <RadioListItem label='Push' value='push' />
-    </RadioList>
+    <div>
+      <RadioList label='Notification preference' value={pref} onChange={setPref} data-testid='prefs'>
+        <RadioListItem label='Email' value='email' />
+        <RadioListItem label='SMS' value='sms' />
+        <RadioListItem label='Push' value='push' />
+      </RadioList>
+      <RadioList
+        label='Locked preference'
+        value='email'
+        onChange={() => {}}
+        isDisabled
+        disabledMessage='Preference is managed by your administrator'
+        data-testid='locked-prefs'>
+        <RadioListItem label='Email' value='email' />
+        <RadioListItem label='SMS' value='sms' />
+      </RadioList>
+    </div>
   );
 };
 

--- a/package-tests/component-driver-astryx-test/src/examples/radio-list/RadioList.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/radio-list/RadioList.suite.ts
@@ -10,6 +10,10 @@ export const radioListExampleScenePart = {
     locator: byDataTestId('prefs'),
     driver: RadioListDriver,
   },
+  lockedPrefs: {
+    locator: byDataTestId('locked-prefs'),
+    driver: RadioListDriver,
+  },
 } satisfies ScenePart;
 
 export const radioListExample: IExampleUnit<typeof radioListExampleScenePart, JSX.Element> = {
@@ -47,6 +51,17 @@ export const radioListExampleTestSuite: TestSuiteInfo<typeof radioListExample.sc
       test(`getLabel and isRequired read the group state`, async () => {
         assertEqual(await engine().parts.prefs.getLabel(), 'Notification preference');
         assertFalse(await engine().parts.prefs.isRequired());
+      });
+
+      // getDisabledMessage is a group-level concept: the tooltip's
+      // aria-describedby link composes onto the inner radiogroup, not any
+      // individual radio. undefined when the group isn't disabled with a message.
+      test(`getDisabledMessage returns the group's disabled-reason tooltip text`, async () => {
+        assertEqual(
+          await engine().parts.lockedPrefs.getDisabledMessage(),
+          'Preference is managed by your administrator'
+        );
+        assertEqual(await engine().parts.prefs.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/segmented-control/SegmentedControl.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/segmented-control/SegmentedControl.examples.tsx
@@ -12,6 +12,11 @@ import React, { JSX, useState } from 'react';
  * its `data-value` (not the visible label or a StyleX class).
  *
  * Two controls (distinct `aria-label`s) prove the anchor is not too broad.
+ *
+ * The "Locked view" control is disabled with a whole-group `disabledMessage`,
+ * reaching a `role="tooltip"` layer through the root radiogroup's composed
+ * `aria-describedby` — distinct from the "table" item's per-segment
+ * `isDisabled` (no message) above.
  */
 export const SegmentedControlExample = () => {
   const [view, setView] = useState('grid');
@@ -28,6 +33,16 @@ export const SegmentedControlExample = () => {
       <SegmentedControl value={density} onChange={setDensity} label='Density'>
         <SegmentedControlItem value='compact' label='Compact' />
         <SegmentedControlItem value='comfortable' label='Comfortable' />
+      </SegmentedControl>
+
+      <SegmentedControl
+        value='grid'
+        onChange={() => {}}
+        label='Locked view'
+        isDisabled
+        disabledMessage='View mode is fixed for this workspace'>
+        <SegmentedControlItem value='grid' label='Grid' />
+        <SegmentedControlItem value='list' label='List' />
       </SegmentedControl>
     </div>
   );

--- a/package-tests/component-driver-astryx-test/src/examples/segmented-control/SegmentedControl.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/segmented-control/SegmentedControl.suite.ts
@@ -15,6 +15,10 @@ export const segmentedControlExampleScenePart = {
     locator: locatorUtil.append(byRole('radiogroup'), byAriaLabel('Density', 'Same')),
     driver: SegmentedControlDriver,
   },
+  lockedView: {
+    locator: locatorUtil.append(byRole('radiogroup'), byAriaLabel('Locked view', 'Same')),
+    driver: SegmentedControlDriver,
+  },
 } satisfies ScenePart;
 
 export const segmentedControlExample: IExampleUnit<typeof segmentedControlExampleScenePart, JSX.Element> = {
@@ -70,6 +74,15 @@ export const segmentedControlExampleTestSuite: TestSuiteInfo<typeof segmentedCon
         await engine().parts.view.setValue('grid');
         assertEqual(await engine().parts.view.getValue(), 'grid');
         assertEqual(await engine().parts.density.getValue(), 'comfortable');
+      });
+
+      // getDisabledMessage is a whole-group concept: the tooltip's
+      // aria-describedby link composes onto the root radiogroup, distinct from a
+      // per-segment isDisabled (no message). undefined when the group isn't
+      // disabled with a message.
+      test(`getDisabledMessage returns the group's disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.lockedView.getDisabledMessage(), 'View mode is fixed for this workspace');
+        assertEqual(await engine().parts.view.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/selector/Selector.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/selector/Selector.examples.tsx
@@ -36,17 +36,33 @@ const SizeSelector = () => {
   );
 };
 
+const LockedSelector = () => (
+  <Selector
+    data-testid='locked'
+    label='Owner'
+    value='alice'
+    onChange={() => {}}
+    options={[{ value: 'alice', label: 'Alice' }]}
+    isDisabled
+    disabledMessage='You need the Editor role to change this'
+  />
+);
+
 /**
  * Astryx Selector scene.
  *
  * Selector self-emits `data-testid` on the root `<div>`; the `role="combobox"` sits
  * on an inner `<button>` whose text is the selected label, linked to the popup
  * `role="listbox"` by `aria-controls`. Two single-select selectors verify scoping.
+ * The "locked" instance is disabled with a `disabledMessage`, so its trigger
+ * `<button>` renders a `role="tooltip"` layer reached through the composed
+ * `aria-describedby`.
  */
 export const SelectorExample = () => (
   <>
     <FruitSelector />
     <SizeSelector />
+    <LockedSelector />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/selector/Selector.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/selector/Selector.suite.ts
@@ -15,6 +15,10 @@ export const selectorExampleScenePart = {
     locator: byDataTestId('size'),
     driver: SelectorDriver,
   },
+  locked: {
+    locator: byDataTestId('locked'),
+    driver: SelectorDriver,
+  },
 } satisfies ScenePart;
 
 export const selectorExample: IExampleUnit<typeof selectorExampleScenePart, JSX.Element> = {
@@ -60,6 +64,13 @@ export const selectorExampleTestSuite: TestSuiteInfo<typeof selectorExample.scen
         assertFalse(await engine().parts.fruit.selectByLabel('Nope'));
         assertTrue(await engine().parts.fruit.selectByLabel('Apple'));
         assertEqual(await engine().parts.fruit.getSelectedLabel(), 'Apple');
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // trigger's composed aria-describedby; undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.fruit.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/slider/Slider.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/slider/Slider.examples.tsx
@@ -7,21 +7,33 @@ import React, { JSX, useState } from 'react';
  *
  * Astryx puts `role="slider"` on the THUMB; the root forwards `data-testid`. The
  * value is exposed via `aria-valuenow` and driven by the keyboard (Arrow keys) —
- * `step={10}` keeps the keyboard-stepping test short.
+ * `step={10}` keeps the keyboard-stepping test short. The second slider is
+ * disabled with a `disabledMessage`, reaching a `role="tooltip"` layer through
+ * the thumb's composed `aria-describedby`.
  */
 export const SliderExample = () => {
   const [volume, setVolume] = useState(50);
 
   return (
-    <Slider
-      label='Volume'
-      value={volume}
-      onChange={setVolume}
-      min={0}
-      max={100}
-      step={10}
-      data-testid='volume-slider'
-    />
+    <div>
+      <Slider
+        label='Volume'
+        value={volume}
+        onChange={setVolume}
+        min={0}
+        max={100}
+        step={10}
+        data-testid='volume-slider'
+      />
+      <Slider
+        label='Screen-share volume'
+        value={50}
+        onChange={() => {}}
+        isDisabled
+        disabledMessage='Volume is locked while sharing your screen'
+        data-testid='locked-slider'
+      />
+    </div>
   );
 };
 

--- a/package-tests/component-driver-astryx-test/src/examples/slider/Slider.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/slider/Slider.suite.ts
@@ -10,6 +10,10 @@ export const sliderExampleScenePart = {
     locator: byDataTestId('volume-slider'),
     driver: SliderDriver,
   },
+  locked: {
+    locator: byDataTestId('locked-slider'),
+    driver: SliderDriver,
+  },
 } satisfies ScenePart;
 
 export const sliderExample: IExampleUnit<typeof sliderExampleScenePart, JSX.Element> = {
@@ -35,6 +39,14 @@ export const sliderExampleTestSuite: TestSuiteInfo<typeof sliderExample.scene> =
       test(`getLabel and isDisabled read the slider state`, async () => {
         assertEqual(await engine().parts.volume.getLabel(), 'Volume');
         assertFalse(await engine().parts.volume.isDisabled());
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // thumb's composed aria-describedby; undefined when the slider isn't
+      // disabled with a message.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'Volume is locked while sharing your screen');
+        assertEqual(await engine().parts.volume.getDisabledMessage(), undefined);
       });
 
       // setValue drives the value by keyboard (Arrow stepping).

--- a/package-tests/component-driver-astryx-test/src/examples/switch/Switch.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/switch/Switch.examples.tsx
@@ -7,7 +7,9 @@ import React, { JSX, useState } from 'react';
  *
  * Astryx puts `role="switch"` on the inner `<input type="checkbox">` and does NOT
  * forward `data-testid`, so each switch is wrapped in a testid'd container and the
- * scene scopes to `byRole('switch')`.
+ * scene scopes to `byRole('switch')`. The "Org-wide" instance is disabled with
+ * a `disabledMessage`, reaching a `role="tooltip"` layer through the composed
+ * `aria-describedby`.
  */
 export const SwitchExample = () => {
   const [notifications, setNotifications] = useState(true);
@@ -20,6 +22,15 @@ export const SwitchExample = () => {
       </div>
       <div data-testid='dark-wrap'>
         <Switch label='Dark mode' value={darkMode} onChange={c => setDarkMode(c)} />
+      </div>
+      <div data-testid='orgwide-wrap'>
+        <Switch
+          label='Org-wide setting'
+          value={false}
+          onChange={() => {}}
+          isDisabled
+          disabledMessage='Notifications are turned off org-wide'
+        />
       </div>
     </div>
   );

--- a/package-tests/component-driver-astryx-test/src/examples/switch/Switch.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/switch/Switch.suite.ts
@@ -14,6 +14,10 @@ export const switchControlExampleScenePart = {
     locator: locatorUtil.append(byDataTestId('dark-wrap'), byRole('switch')),
     driver: SwitchDriver,
   },
+  orgWide: {
+    locator: locatorUtil.append(byDataTestId('orgwide-wrap'), byRole('switch')),
+    driver: SwitchDriver,
+  },
 } satisfies ScenePart;
 
 export const switchControlExample: IExampleUnit<typeof switchControlExampleScenePart, JSX.Element> = {
@@ -48,6 +52,14 @@ export const switchControlExampleTestSuite: TestSuiteInfo<typeof switchControlEx
       test(`getLabel and isDisabled read the switch state`, async () => {
         assertEqual(await engine().parts.notifications.getLabel(), 'Notifications');
         assertFalse(await engine().parts.notifications.isDisabled());
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // composed aria-describedby; undefined when the switch isn't disabled
+      // with a message.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.orgWide.getDisabledMessage(), 'Notifications are turned off org-wide');
+        assertEqual(await engine().parts.notifications.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/text-area/TextArea.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/text-area/TextArea.examples.tsx
@@ -8,11 +8,28 @@ import React, { JSX, useState } from 'react';
  * TextArea renders a native `<textarea>` and forwards `data-testid` onto it, so
  * the scene anchors there. Controlled value so `setValue` round-trips; `rows`
  * sets the visible row count.
+ *
+ * A second, disabled textarea carries a `disabledMessage`, exercising
+ * `getDisabledMessage`'s resolution of the tooltip id out of the composed
+ * `aria-describedby` list.
  */
 export const TextAreaExample = () => {
   const [value, setValue] = useState('Hello');
+  const [notes, setNotes] = useState('Submitted');
 
-  return <TextArea label='Description' value={value} onChange={v => setValue(v)} rows={4} data-testid='desc-area' />;
+  return (
+    <div>
+      <TextArea label='Description' value={value} onChange={v => setValue(v)} rows={4} data-testid='desc-area' />
+      <TextArea
+        label='Notes'
+        value={notes}
+        onChange={v => setNotes(v)}
+        data-testid='notes-area'
+        isDisabled
+        disabledMessage='Notes are locked after submission'
+      />
+    </div>
+  );
 };
 
 export const textAreaUIExample: IExampleUIUnit<JSX.Element> = {

--- a/package-tests/component-driver-astryx-test/src/examples/text-area/TextArea.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/text-area/TextArea.suite.ts
@@ -10,6 +10,10 @@ export const textAreaExampleScenePart = {
     locator: byDataTestId('desc-area'),
     driver: TextAreaDriver,
   },
+  notesArea: {
+    locator: byDataTestId('notes-area'),
+    driver: TextAreaDriver,
+  },
 } satisfies ScenePart;
 
 export const textAreaExample: IExampleUnit<typeof textAreaExampleScenePart, JSX.Element> = {
@@ -45,6 +49,12 @@ export const textAreaExampleTestSuite: TestSuiteInfo<typeof textAreaExample.scen
       // getRows reads the rows attribute.
       test(`getRows returns the visible row count`, async () => {
         assertEqual(await engine().parts.descArea.getRows(), 4);
+      });
+
+      // getDisabledMessage resolves the tooltip out of the composed aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(await engine().parts.notesArea.getDisabledMessage(), 'Notes are locked after submission');
+        assertEqual(await engine().parts.descArea.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/text-input/TextInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/text-input/TextInput.examples.tsx
@@ -15,10 +15,16 @@ import React, { JSX, useState } from 'react';
  * description and an error status so `isRequired`/`isInvalid` have something to
  * read and `getStatusMessage` must resolve the status from a multi-id
  * `aria-describedby` (description id + status id), not just a single id.
+ *
+ * A third input is disabled with a `disabledMessage`, exercising
+ * `getDisabledMessage`'s resolution of the tooltip id out of that same
+ * multi-id `aria-describedby` list (Astryx composes the disabled-message
+ * tooltip alongside description/status ids).
  */
 export const TextInputExample = () => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [owner, setOwner] = useState('Alice');
 
   return (
     <div>
@@ -31,6 +37,14 @@ export const TextInputExample = () => {
         isRequired
         description='We never share it'
         status={{ type: 'error', message: 'Email is required' }}
+      />
+      <TextInput
+        label='Owner'
+        data-testid='owner-input'
+        value={owner}
+        onChange={v => setOwner(v)}
+        isDisabled
+        disabledMessage='You need the Editor role to change this'
       />
     </div>
   );

--- a/package-tests/component-driver-astryx-test/src/examples/text-input/TextInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/text-input/TextInput.suite.ts
@@ -15,6 +15,10 @@ export const textInputExampleScenePart = {
     locator: byDataTestId('email-input'),
     driver: TextInputDriver,
   },
+  ownerInput: {
+    locator: byDataTestId('owner-input'),
+    driver: TextInputDriver,
+  },
 } satisfies ScenePart;
 
 export const textInputExample: IExampleUnit<typeof textInputExampleScenePart, JSX.Element> = {
@@ -71,6 +75,12 @@ export const textInputExampleTestSuite: TestSuiteInfo<typeof textInputExample.sc
       test(`getStatusMessage returns the validation message, undefined when none`, async () => {
         assertEqual(await engine().parts.emailInput.getStatusMessage(), 'Email is required');
         assertEqual(await engine().parts.nameInput.getStatusMessage(), undefined);
+      });
+
+      // getDisabledMessage resolves the tooltip out of the composed aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(await engine().parts.ownerInput.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.nameInput.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/time-input/TimeInput.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/time-input/TimeInput.examples.tsx
@@ -8,15 +8,29 @@ import React, { JSX, useState } from 'react';
  * TimeInput renders a plain `<input type="text">` whose value is a formatted
  * display string (not ISO). It does NOT forward `data-testid`, so the example
  * wraps it in a testid'd container and the scene scopes to the inner text input.
+ * The "locked" instance is disabled with a `disabledMessage`, so its `<input>`
+ * renders a `role="tooltip"` layer reached through the composed
+ * `aria-describedby`.
  */
 export const TimeInputExample = () => {
   // TimeInput's value is a branded ISO time string; cast the controlled state.
   const [time, setTime] = useState<string>('09:30');
 
   return (
-    <div data-testid='time-wrap'>
-      <TimeInput label='Start time' value={time as never} onChange={v => setTime((v as string) ?? '')} />
-    </div>
+    <>
+      <div data-testid='time-wrap'>
+        <TimeInput label='Start time' value={time as never} onChange={v => setTime((v as string) ?? '')} />
+      </div>
+      <div data-testid='locked-wrap'>
+        <TimeInput
+          label='End time'
+          value={undefined}
+          onChange={() => {}}
+          isDisabled
+          disabledMessage='You need the Editor role to change this'
+        />
+      </div>
+    </>
   );
 };
 

--- a/package-tests/component-driver-astryx-test/src/examples/time-input/TimeInput.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/time-input/TimeInput.suite.ts
@@ -11,6 +11,10 @@ export const timeInputExampleScenePart = {
     locator: locatorUtil.append(byDataTestId('time-wrap'), byInputType('text')),
     driver: TimeInputDriver,
   },
+  locked: {
+    locator: locatorUtil.append(byDataTestId('locked-wrap'), byInputType('text')),
+    driver: TimeInputDriver,
+  },
 } satisfies ScenePart;
 
 export const timeInputExample: IExampleUnit<typeof timeInputExampleScenePart, JSX.Element> = {
@@ -33,6 +37,14 @@ export const timeInputExampleTestSuite: TestSuiteInfo<typeof timeInputExample.sc
       // getValue returns the formatted display string (12h by default), not ISO.
       test(`getValue returns the display string`, async () => {
         assertEqual(await engine().parts.timeInput.getValue(), '9:30 AM');
+      });
+
+      // getDisabledMessage (inherited from AstryxFieldInputDriver) resolves the
+      // disabled-reason tooltip through the input's composed aria-describedby;
+      // undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.timeInput.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/tokenizer/Tokenizer.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/tokenizer/Tokenizer.examples.tsx
@@ -40,17 +40,36 @@ const PlainTokenizer = () => {
   );
 };
 
+const DisabledTokenizer = () => {
+  const [value] = useState<Item[]>([{ id: 'banana', label: 'Banana' }]);
+  return (
+    <Tokenizer<Item>
+      data-testid='disabled-tags'
+      label='Disabled'
+      searchSource={fruitSource}
+      value={value}
+      onChange={() => {}}
+      isDisabled
+      disabledMessage='Tags are locked while the review is in progress'
+    />
+  );
+};
+
 /**
  * Astryx Tokenizer scene.
  *
  * Tokenizer renders a `role="group"` root (self-emitting `data-testid`) holding the
  * token chips and the `role="combobox"` input. `tags` enables `hasClear`/`hasCreate`;
- * a second tokenizer verifies selector scoping.
+ * a second tokenizer verifies selector scoping. A third, disabled tokenizer carries a
+ * `disabledMessage`, exercising `getDisabledMessage`'s resolution through the inner
+ * combobox input's `aria-describedby` (Astryx wires the tooltip link there, not onto
+ * the `role="group"` root).
  */
 export const TokenizerExample = () => (
   <>
     <TagTokenizer />
     <PlainTokenizer />
+    <DisabledTokenizer />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/tokenizer/Tokenizer.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/tokenizer/Tokenizer.suite.ts
@@ -15,6 +15,10 @@ export const tokenizerExampleScenePart = {
     locator: byDataTestId('plain-tags'),
     driver: TokenizerDriver,
   },
+  disabled: {
+    locator: byDataTestId('disabled-tags'),
+    driver: TokenizerDriver,
+  },
 } satisfies ScenePart;
 
 export const tokenizerExample: IExampleUnit<typeof tokenizerExampleScenePart, JSX.Element> = {
@@ -67,6 +71,15 @@ export const tokenizerExampleTestSuite: TestSuiteInfo<typeof tokenizerExample.sc
         if (skipInteractionOnWebkit(test, browser())) return;
         assertTrue(await engine().parts.tags.clearAll());
         assertEqual(await engine().parts.tags.getTokenCount(), 0);
+      });
+
+      // getDisabledMessage resolves through the combobox input's aria-describedby.
+      test(`getDisabledMessage returns the disabled-reason tooltip, undefined when none`, async () => {
+        assertEqual(
+          await engine().parts.disabled.getDisabledMessage(),
+          'Tags are locked while the review is in progress'
+        );
+        assertEqual(await engine().parts.tags.getDisabledMessage(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-astryx-test/src/examples/typeahead/Typeahead.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/typeahead/Typeahead.examples.tsx
@@ -44,17 +44,32 @@ const CityTypeahead = () => {
   );
 };
 
+const LockedTypeahead = () => (
+  <Typeahead<Item>
+    data-testid='locked-search'
+    label='Assignee'
+    searchSource={fruitSource}
+    value={null}
+    onChange={() => {}}
+    isDisabled
+    disabledMessage='You need the Editor role to change this'
+  />
+);
+
 /**
  * Astryx Typeahead scene.
  *
  * Typeahead self-emits `data-testid` on the root `<div>`; the `role="combobox"` is
  * the `<input>`, linked to the async results `role="listbox"`. Two typeaheads
- * verify selector scoping.
+ * verify selector scoping. The "locked" instance is disabled with a
+ * `disabledMessage`, so its `<input>` renders a `role="tooltip"` layer reached
+ * through the composed `aria-describedby`.
  */
 export const TypeaheadExample = () => (
   <>
     <FruitTypeahead />
     <CityTypeahead />
+    <LockedTypeahead />
   </>
 );
 

--- a/package-tests/component-driver-astryx-test/src/examples/typeahead/Typeahead.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/typeahead/Typeahead.suite.ts
@@ -15,6 +15,10 @@ export const typeaheadExampleScenePart = {
     locator: byDataTestId('city-search'),
     driver: TypeaheadDriver,
   },
+  locked: {
+    locator: byDataTestId('locked-search'),
+    driver: TypeaheadDriver,
+  },
 } satisfies ScenePart;
 
 export const typeaheadExample: IExampleUnit<typeof typeaheadExampleScenePart, JSX.Element> = {
@@ -58,6 +62,13 @@ export const typeaheadExampleTestSuite: TestSuiteInfo<typeof typeaheadExample.sc
         const labels = await engine().parts.city.getResultLabels();
         assertTrue(labels.includes('Prague'));
         assertFalse(labels.includes('Paris'));
+      });
+
+      // getDisabledMessage resolves the disabled-reason tooltip through the
+      // search input's composed aria-describedby; undefined when not in that state.
+      test(`getDisabledMessage returns the disabled-reason tooltip text`, async () => {
+        assertEqual(await engine().parts.locked.getDisabledMessage(), 'You need the Editor role to change this');
+        assertEqual(await engine().parts.fruit.getDisabledMessage(), undefined);
       });
     });
   },

--- a/packages/component-driver-astryx/package.json
+++ b/packages/component-driver-astryx/package.json
@@ -37,7 +37,7 @@
     "@types/react-dom": ">=19.0.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "^0.1.1",
+    "@astryxdesign/core": "^0.1.3",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   }

--- a/packages/component-driver-astryx/src/components/AstryxFieldInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/AstryxFieldInputDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
 import { byCssSelector, Optional } from '@atomic-testing/core';
 
-import { resolveLinkedLabelText } from '../internal/linkedLocators';
+import { resolveDescribedByRoleText, resolveLinkedLabelText } from '../internal/linkedLocators';
 
 /**
  * Shared base for Astryx single-control field inputs (TextInput, NumberInput,
@@ -80,5 +80,16 @@ export abstract class AstryxFieldInputDriver extends HTMLTextInputDriver {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the control's
+   * `aria-describedby` link to the `role="tooltip"` layer that
+   * `isDisabled` + `disabledMessage` renders (the same `useTooltip` primitive as
+   * the standalone Tooltip). `undefined` when the field isn't in that
+   * disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.locator, 'aria-describedby', 'tooltip');
   }
 }

--- a/packages/component-driver-astryx/src/components/BannerDriver.ts
+++ b/packages/component-driver-astryx/src/components/BannerDriver.ts
@@ -7,8 +7,9 @@ import { byAriaLabel, byCssSelector, ComponentDriver, listHelper, locatorUtil, O
  * Banner forwards `data-testid` onto its root, whose `role` is CONDITIONAL —
  * `"alert"` for error/warning, `"status"` for info/success — while the stable
  * severity lives in `data-status` on the inner header. The header shows the title
- * and optional description as consecutive `<p>`s; a dismiss button
- * (`aria-label="Dismiss"`) and, when the banner has collapsible content, an
+ * and optional description as consecutive `<div>`s (Astryx 0.1.2+ renders these as
+ * `<div>` rather than `<p>` so they can hold arbitrary ReactNode content); a dismiss
+ * button (`aria-label="Dismiss"`) and, when the banner has collapsible content, an
  * expand toggle (`aria-expanded`) appear in the header end.
  */
 export class BannerDriver extends ComponentDriver<{}> {
@@ -66,8 +67,18 @@ export class BannerDriver extends ComponentDriver<{}> {
     return locatorUtil.append(this.locator, byCssSelector('button[aria-expanded]'));
   }
 
+  /**
+   * The title/description are untagged `<div>`s with no distinguishing attribute,
+   * so they're reached structurally: the header's icon wrapper (`aria-hidden`) is
+   * always the first child, and the title/description container is always its next
+   * sibling — regardless of whether a trailing end-area (dismiss/expand buttons) is
+   * also rendered.
+   */
   private async headerParagraph(index: number): Promise<Optional<string>> {
-    const paragraphs = locatorUtil.append(this.locator, byCssSelector('[data-status] p'));
+    const paragraphs = locatorUtil.append(
+      this.locator,
+      byCssSelector('[data-status] > div[aria-hidden="true"] + div > div'),
+    );
     const item = await listHelper.getListItemByIndex(this, paragraphs, index, HTMLElementDriver);
     if (item == null) {
       return undefined;

--- a/packages/component-driver-astryx/src/components/BannerDriver.ts
+++ b/packages/component-driver-astryx/src/components/BannerDriver.ts
@@ -77,7 +77,7 @@ export class BannerDriver extends ComponentDriver<{}> {
   private async headerParagraph(index: number): Promise<Optional<string>> {
     const paragraphs = locatorUtil.append(
       this.locator,
-      byCssSelector('[data-status] > div[aria-hidden="true"] + div > div'),
+      byCssSelector('[data-status] > div[aria-hidden="true"] + div > div')
     );
     const item = await listHelper.getListItemByIndex(this, paragraphs, index, HTMLElementDriver);
     if (item == null) {

--- a/packages/component-driver-astryx/src/components/ButtonGroupDriver.ts
+++ b/packages/component-driver-astryx/src/components/ButtonGroupDriver.ts
@@ -13,10 +13,11 @@ import { ButtonDriver } from './ButtonDriver';
  * Driver for the Astryx ButtonGroup (`@astryxdesign/core/ButtonGroup`).
  *
  * ButtonGroup renders a `role="group"` root that self-emits `data-testid` and
- * carries the accessible name (`aria-label`) and `aria-orientation`; its children
- * are plain `<button>`s. Modelled as a list of {@link ButtonDriver}s located by
- * tag — the group's own `aria-label` is read off the root, not confused with a
- * child button's name.
+ * carries the accessible name (`aria-label`) and orientation (`data-orientation`
+ * — Astryx 0.1.3 dropped the invalid `aria-orientation`, which axe flagged as
+ * disallowed on `role="group"`); its children are plain `<button>`s. Modelled as
+ * a list of {@link ButtonDriver}s located by tag — the group's own `aria-label`
+ * is read off the root, not confused with a child button's name.
  *
  * The default `itemClass`/`itemLocator` are merged ahead of the engine-supplied
  * option so they survive even though the engine always passes a defined option.
@@ -31,9 +32,9 @@ export class ButtonGroupDriver extends ListComponentDriver<ButtonDriver> {
     return this.interactor.getAttribute(this.locator, 'aria-label');
   }
 
-  /** The group's orientation (`aria-orientation`), e.g. `'horizontal'`/`'vertical'`. */
+  /** The group's orientation (`data-orientation`), e.g. `'horizontal'`/`'vertical'`. */
   async getOrientation(): Promise<Optional<string>> {
-    return this.interactor.getAttribute(this.locator, 'aria-orientation');
+    return this.interactor.getAttribute(this.locator, 'data-orientation');
   }
 
   /** Number of buttons in the group. */

--- a/packages/component-driver-astryx/src/components/CheckboxInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/CheckboxInputDriver.ts
@@ -1,5 +1,5 @@
 import { HTMLCheckboxDriver } from '@atomic-testing/component-driver-html';
-import { Optional } from '@atomic-testing/core';
+import { byCssSelector, locatorUtil, Optional } from '@atomic-testing/core';
 
 import { resolveLinkedLabelText } from '../internal/linkedLocators';
 
@@ -9,9 +9,12 @@ import { resolveLinkedLabelText } from '../internal/linkedLocators';
  * The accessible control is the native `<input type="checkbox">` (its implicit
  * role is `checkbox`); the root is a plain styling `<div>` and Astryx does NOT
  * forward `data-testid`, so the scene anchors the `<input>` itself (e.g. scoped
- * `byInputType('checkbox')`). Checked/disabled come from {@link HTMLCheckboxDriver};
- * the indeterminate state is reported as `aria-checked="mixed"`, and the label is
- * resolved through the `<label for>`↔`id` link.
+ * `byInputType('checkbox')`). Checked/disabled come from {@link HTMLCheckboxDriver}.
+ * Astryx 0.1.3 dropped the redundant `aria-checked="mixed"` it used to set for the
+ * indeterminate state — only the native `.indeterminate` DOM property is set now
+ * (it isn't reflected as an HTML attribute), so this driver reads it via the
+ * `:indeterminate` CSS pseudo-class instead. The label is resolved through the
+ * `<label for>`↔`id` link.
  */
 export class CheckboxInputDriver extends HTMLCheckboxDriver {
   /** Whether the checkbox is checked. Alias of {@link isSelected}. */
@@ -19,9 +22,9 @@ export class CheckboxInputDriver extends HTMLCheckboxDriver {
     return this.isSelected();
   }
 
-  /** Whether the checkbox is indeterminate (`aria-checked="mixed"`). */
+  /** Whether the checkbox is indeterminate (matches `:indeterminate`). */
   async isIndeterminate(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.locator, 'aria-checked')) === 'mixed';
+    return this.interactor.exists(locatorUtil.append(this.locator, byCssSelector(':indeterminate', 'Same')));
   }
 
   /** Toggle the checked state. */

--- a/packages/component-driver-astryx/src/components/CheckboxInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/CheckboxInputDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLCheckboxDriver } from '@atomic-testing/component-driver-html';
 import { byCssSelector, locatorUtil, Optional } from '@atomic-testing/core';
 
-import { resolveLinkedLabelText } from '../internal/linkedLocators';
+import { resolveDescribedByRoleText, resolveLinkedLabelText } from '../internal/linkedLocators';
 
 /**
  * Driver for the Astryx CheckboxInput (`@astryxdesign/core/CheckboxInput`).
@@ -35,6 +35,17 @@ export class CheckboxInputDriver extends HTMLCheckboxDriver {
   /** The checkbox's visible label, resolved via the `<label for>`↔`id` link. */
   async getLabel(): Promise<Optional<string>> {
     return resolveLinkedLabelText(this.interactor, this.locator);
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the checkbox is disabled
+   * with a reason. Resolved through the native `<input>`'s composed
+   * `aria-describedby` — the id list also carries the description/status-message
+   * ids, so this picks out whichever target has `role="tooltip"`. `undefined`
+   * when the checkbox has no disabled-reason tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.locator, 'aria-describedby', 'tooltip');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/CheckboxListDriver.ts
+++ b/packages/component-driver-astryx/src/components/CheckboxListDriver.ts
@@ -1,12 +1,16 @@
 import {
+  byRole,
   byTagName,
   IComponentDriverOption,
   Interactor,
   listHelper,
   ListComponentDriver,
+  locatorUtil,
+  Optional,
   PartLocator,
 } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 import { CheckboxListItemDriver } from './CheckboxListItemDriver';
 
 /**
@@ -69,6 +73,20 @@ export class CheckboxListDriver extends ListComponentDriver<CheckboxListItemDriv
       await item.toggle();
     }
     return true;
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the whole group is disabled
+   * with a reason. `disabledMessage` is a group-level prop (individual rows
+   * have no reason of their own), and the tooltip's `aria-describedby` link is
+   * composed onto the inner `role="group"` div alongside the
+   * description/status-message ids — this picks out whichever target has
+   * `role="tooltip"`. `undefined` when the group has no disabled-reason
+   * tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    const group = locatorUtil.append(this.locator, byRole('group'));
+    return resolveDescribedByRoleText(this.interactor, group, 'aria-describedby', 'tooltip');
   }
 
   private async findByLabel(label: string): Promise<CheckboxListItemDriver | null> {

--- a/packages/component-driver-astryx/src/components/CheckboxListItemDriver.ts
+++ b/packages/component-driver-astryx/src/components/CheckboxListItemDriver.ts
@@ -3,10 +3,14 @@ import { byInputType, byTagName, ComponentDriver, locatorUtil, Optional } from '
 /**
  * Driver for a single Astryx CheckboxList row (`<li>`).
  *
- * Each row is a `<li aria-checked>` containing the native `<input type="checkbox">`
- * and a `<button>` whose text is the row's visible label. The item's identity is
- * NOT emitted as a DOM value (it is a React key), so rows are addressed by label
- * text or index — this driver exposes both the label and the checked state.
+ * Each row is a plain `<li role="listitem">` containing the native
+ * `<input type="checkbox">` and a `<button>` whose text is the row's visible
+ * label. Astryx 0.1.3 dropped the row's `aria-checked` (invalid on
+ * `role="listitem"` — axe: aria-allowed-attr); checked state is now conveyed
+ * solely by the inner checkbox, so this driver reads it there instead. The
+ * item's identity is NOT emitted as a DOM value (it is a React key), so rows
+ * are addressed by label text or index — this driver exposes both the label
+ * and the checked state.
  */
 export class CheckboxListItemDriver extends ComponentDriver<{}> {
   /** The row's visible label (the row button's text). */
@@ -18,9 +22,9 @@ export class CheckboxListItemDriver extends ComponentDriver<{}> {
     return (await this.getText()) ?? undefined;
   }
 
-  /** Whether the row is checked (`aria-checked="true"` on the `<li>`). */
+  /** Whether the row is checked (the inner checkbox's checked state). */
   async isChecked(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.locator, 'aria-checked')) === 'true';
+    return this.interactor.isChecked(locatorUtil.append(this.locator, byInputType('checkbox')));
   }
 
   /** Toggle the row by clicking its checkbox. */

--- a/packages/component-driver-astryx/src/components/ContextMenuDriver.ts
+++ b/packages/component-driver-astryx/src/components/ContextMenuDriver.ts
@@ -1,16 +1,18 @@
-import { byCssSelector, Optional, PartLocator } from '@atomic-testing/core';
+import { byCssSelector, PartLocator } from '@atomic-testing/core';
 
 import { AstryxMenuDriver } from './AstryxMenuDriver';
 
 /**
  * Driver for the Astryx ContextMenu (`@astryxdesign/core/ContextMenu`).
  *
- * The scene anchors this driver on the **trigger** `<div>`, which carries only
- * `aria-haspopup="menu"` (Astryx forwards `data-testid` here). Unlike Popover, the
- * trigger has **no `aria-expanded` and no `aria-controls`** — the only way to open
- * the menu is a `contextmenu`/right-click event, and the `role="menu"` layer is a
- * `popover` rendered as a sibling at the document root with no id link back to the
- * trigger. So:
+ * The scene anchors this driver on the **trigger** `<div>` (Astryx forwards
+ * `data-testid` here). Unlike Popover, the trigger has **no `aria-haspopup`, no
+ * `aria-expanded`, and no `aria-controls`** — Astryx 0.1.3 removed the trigger's
+ * `aria-haspopup="menu"` (it sat on a role-less, non-focusable wrapper, where it
+ * conveyed nothing to assistive tech), leaving no popup-type ARIA to read at all.
+ * The only way to open the menu is a `contextmenu`/right-click event, and the
+ * `role="menu"` layer is a `popover` rendered as a sibling at the document root
+ * with no id link back to the trigger. So:
  *
  * - {@link open} uses the `contextMenu` interactor primitive (the dedicated
  *   right-click event — the menu has no controlled-open prop to flip).
@@ -43,11 +45,6 @@ export class ContextMenuDriver extends AstryxMenuDriver {
    */
   protected override resolveMenuLocator(): Promise<PartLocator | null> {
     return Promise.resolve(byCssSelector('[role="menu"]', 'Root'));
-  }
-
-  /** The trigger's popup type (`aria-haspopup`, always `"menu"`). */
-  async getHasPopup(): Promise<Optional<string>> {
-    return this.interactor.getAttribute(this.locator, 'aria-haspopup');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/DateInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/DateInputDriver.ts
@@ -1,5 +1,7 @@
 import { byCssSelector, byRole, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
+
 /**
  * Driver for the Astryx DateInput (`@astryxdesign/core/DateInput`).
  *
@@ -40,6 +42,16 @@ export class DateInputDriver extends ComponentDriver {
   /** Whether the input is invalid (`aria-invalid="true"`). */
   async isInvalid(): Promise<boolean> {
     return (await this.interactor.getAttribute(this.input, 'aria-invalid')) === 'true';
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the input's composed
+   * `aria-describedby` — the id list also carries the description/status-message
+   * ids, so this picks out whichever target has `role="tooltip"`. `undefined`
+   * when the input has no disabled-reason tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.input, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/DateRangeInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/DateRangeInputDriver.ts
@@ -7,8 +7,11 @@ import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } fr
  * native-popover dialog. The scene anchors on the root `<div>` (self-emitting
  * `data-testid`); the trigger is a `<button aria-haspopup="dialog">` whose text is
  * the display string and which links — only while open — to the popover via
- * `aria-controls`. The popover `[role="dialog"]` holds a `[role="listbox"]` of
- * preset `[role="option"]` buttons and a range Calendar of `[data-date]` cells.
+ * `aria-controls`. The popover `[role="dialog"]` holds a labeled `[role="group"]`
+ * of preset `<button>`s (Astryx 0.1.3 dropped the `listbox`/`option` roles, which
+ * misrepresented the actual Tab-between-buttons interaction; the active preset is
+ * now marked `aria-current` rather than `aria-selected`) and a range Calendar of
+ * `[data-date]` cells.
  *
  * The popover renders in jsdom once React opens it (reachable via `aria-controls`),
  * so open/preset/range-pick are exercised in jsdom and the browser alike; its true
@@ -93,7 +96,7 @@ export class DateRangeInputDriver extends ComponentDriver {
     return labels;
   }
 
-  /** The label of the active preset (`aria-selected="true"`), or `undefined` when none is. Opens the popover. */
+  /** The label of the active preset (`aria-current="true"`), or `undefined` when none is. Opens the popover. */
   async getSelectedPreset(): Promise<Optional<string>> {
     await this.open();
     const popoverId = await this.popoverId();
@@ -105,7 +108,7 @@ export class DateRangeInputDriver extends ComponentDriver {
       if (!(await this.interactor.exists(option))) {
         break;
       }
-      if ((await this.interactor.getAttribute(option, 'aria-selected')) === 'true') {
+      if ((await this.interactor.getAttribute(option, 'aria-current')) === 'true') {
         return (await this.interactor.getText(option))?.trim();
       }
     }

--- a/packages/component-driver-astryx/src/components/DateRangeInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/DateRangeInputDriver.ts
@@ -1,5 +1,7 @@
 import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
+
 /**
  * Driver for the Astryx DateRangeInput (`@astryxdesign/core/DateRangeInput`).
  *
@@ -32,6 +34,16 @@ export class DateRangeInputDriver extends ComponentDriver {
   /** Whether the popover is open — read from the trigger's `aria-expanded`. */
   async isExpanded(): Promise<boolean> {
     return (await this.interactor.getAttribute(this.trigger, 'aria-expanded')) === 'true';
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the trigger's composed
+   * `aria-describedby` — the id list also carries the description/status-message
+   * ids, so this picks out whichever target has `role="tooltip"`. `undefined`
+   * when the trigger has no disabled-reason tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.trigger, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/DateTimeInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/DateTimeInputDriver.ts
@@ -16,6 +16,12 @@ import { DateInputDriver } from './DateInputDriver';
  * `timeLabel` prop), so it's no longer a stable match value. Since the widget only
  * ever renders these two `<input>`s, the time field is instead reached as
  * whichever one is NOT the date combobox.
+ *
+ * `disabledMessage` renders a single tooltip for the whole control, but Astryx
+ * wires its `aria-describedby` link onto the date field only — the time
+ * `<input>` carries no `aria-describedby` at all. {@link getDisabledMessage},
+ * inherited from {@link DateInputDriver}, already resolves through the date
+ * field and needs no override here.
  */
 export class DateTimeInputDriver extends DateInputDriver {
   private get timeInput(): PartLocator {

--- a/packages/component-driver-astryx/src/components/DateTimeInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/DateTimeInputDriver.ts
@@ -1,4 +1,4 @@
-import { byAriaLabel, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
+import { byCssSelector, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
 import { DateInputDriver } from './DateInputDriver';
 
@@ -7,14 +7,19 @@ import { DateInputDriver } from './DateInputDriver';
  *
  * DateTimeInput pairs a date field — an `<input role="combobox">` with a calendar
  * popover, identical to {@link DateInputDriver}, whose behaviour this driver
- * inherits — with a separate time `<input aria-label="Time">`. The root `<div>`
- * self-emits `data-testid`. The date field's accessors are reused as
- * {@link getDateValue}/{@link setDate}; the time field adds {@link getTimeValue}/
- * {@link setTime}.
+ * inherits — with a separate time `<input>`. The root `<div>` self-emits
+ * `data-testid`. The date field's accessors are reused as {@link getDateValue}/
+ * {@link setDate}; the time field adds {@link getTimeValue}/{@link setTime}.
+ *
+ * The time input's accessible name is no longer a fixed `aria-label="Time"` as of
+ * Astryx 0.1.3 — it defaults to `"{label} time"` (and is overridable via a
+ * `timeLabel` prop), so it's no longer a stable match value. Since the widget only
+ * ever renders these two `<input>`s, the time field is instead reached as
+ * whichever one is NOT the date combobox.
  */
 export class DateTimeInputDriver extends DateInputDriver {
   private get timeInput(): PartLocator {
-    return locatorUtil.append(this.locator, byAriaLabel('Time'));
+    return locatorUtil.append(this.locator, byCssSelector('input:not([role="combobox"])'));
   }
 
   /** The date field's displayed value (formatted date), or `undefined` when empty. */

--- a/packages/component-driver-astryx/src/components/EmptyStateDriver.ts
+++ b/packages/component-driver-astryx/src/components/EmptyStateDriver.ts
@@ -5,11 +5,14 @@ import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } fr
  *
  * EmptyState renders a `<div role="status">` (the live-region root, where
  * `data-testid` is forwarded) wrapping a heading (`<h1>`–`<h6>`, defaulting to
- * `<h3>`), a `<p>` description, and — when `actions` are supplied — a trailing
+ * `<h3>`), a description, and — when `actions` are supplied — a trailing
  * actions `<div>` holding the action `<button>`s. The scene anchors on the root
  * and reaches the heading/description/action by their native tags rather than by
  * StyleX-hashed classes. The heading level is read off whichever `h*` tag exists,
- * since the rendered level varies with the `headingLevel` prop.
+ * since the rendered level varies with the `headingLevel` prop. The description is
+ * an untagged `<div>` (Astryx 0.1.2+ renders it as `<div>` rather than `<p>` so it
+ * can hold arbitrary ReactNode content), reached as the heading's immediate next
+ * sibling rather than by tag name.
  */
 export class EmptyStateDriver extends ComponentDriver<{}> {
   /**
@@ -21,8 +24,14 @@ export class EmptyStateDriver extends ComponentDriver<{}> {
     return locatorUtil.append(this.locator, byCssSelector(`h${level}`));
   }
 
-  private get description(): PartLocator {
-    return locatorUtil.append(this.locator, byCssSelector('p'));
+  /**
+   * The description, the heading's immediate next sibling `<div>`. Probed one
+   * level at a time (like {@link headingAt}) rather than via an `h1 + div, …`
+   * selector list — a comma list would leave the later alternatives unscoped,
+   * matching another EmptyState's description on the page.
+   */
+  private descriptionAfter(level: number): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector(`h${level} + div`));
   }
 
   private get action(): PartLocator {
@@ -42,10 +51,13 @@ export class EmptyStateDriver extends ComponentDriver<{}> {
 
   /** The description paragraph text, or `undefined` when no description is rendered. */
   async getDescription(): Promise<Optional<string>> {
-    if (!(await this.interactor.exists(this.description))) {
-      return undefined;
+    for (let level = 1; level <= 6; level++) {
+      const description = this.descriptionAfter(level);
+      if (await this.interactor.exists(description)) {
+        return (await this.interactor.getText(description)) ?? undefined;
+      }
     }
-    return (await this.interactor.getText(this.description)) ?? undefined;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/FileInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/FileInputDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLFileInputDriver } from '@atomic-testing/component-driver-html';
 import { byCssSelector, Optional, PartLocator } from '@atomic-testing/core';
 
-import { resolveLinkedLabelText } from '../internal/linkedLocators';
+import { resolveDescribedByRoleText, resolveLinkedLabelText } from '../internal/linkedLocators';
 
 /**
  * Driver for the Astryx FileInput (`@astryxdesign/core/FileInput`).
@@ -93,6 +93,21 @@ export class FileInputDriver extends HTMLFileInputDriver {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the `role="button"`
+   * wrapper's `aria-describedby` link — like `aria-required`/`aria-invalid`
+   * (see the class doc), the disabled-message tooltip describes the operable
+   * wrapper, not the hidden native input. `undefined` when the field isn't in
+   * that disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    const wrapper = await this.wrapperLocator();
+    if (wrapper == null) {
+      return undefined;
+    }
+    return resolveDescribedByRoleText(this.interactor, wrapper, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/FileInputDriver.ts
+++ b/packages/component-driver-astryx/src/components/FileInputDriver.ts
@@ -1,5 +1,5 @@
 import { HTMLFileInputDriver } from '@atomic-testing/component-driver-html';
-import { byCssSelector, Optional } from '@atomic-testing/core';
+import { byCssSelector, Optional, PartLocator } from '@atomic-testing/core';
 
 import { resolveLinkedLabelText } from '../internal/linkedLocators';
 
@@ -7,12 +7,17 @@ import { resolveLinkedLabelText } from '../internal/linkedLocators';
  * Driver for the Astryx FileInput (`@astryxdesign/core/FileInput`).
  *
  * Astryx forwards `data-testid` onto the **hidden native `<input type="file">`**,
- * not the visible `div[role="button"]` dropzone — which is convenient, because the
- * input is the element every meaningful read and the upload itself live on:
- * `accept`, `multiple`, `aria-required`, `aria-invalid`, `disabled`, and the
- * `aria-describedby` → status-message link are all attributes of the input, and
- * `setInputFiles` must target a real `<input type="file">`. The scene therefore
+ * not the visible `div[role="button"]` dropzone — which is convenient, because
+ * `accept`, `multiple`, and `disabled` (native HTML semantics the real file picker
+ * needs) plus `setInputFiles`'s target are all the input's. The scene therefore
  * anchors this driver on that input.
+ *
+ * Astryx 0.1.3 moved `aria-describedby`/`aria-required`/`aria-invalid` off the
+ * hidden, never-focused input onto the focusable `div[role="button"]` wrapper
+ * that describes the operable control (forms-6). Since this codebase's CSS
+ * locators have no parent axis, those three reads resolve the wrapper via `:has()`
+ * keyed on the input's own `id` (which Astryx always sets via `useId()`) rather
+ * than walking up from `this.locator`.
  *
  * It extends {@link HTMLFileInputDriver} to inherit `uploadFiles` (the
  * `setInputFiles` primitive — `userEvent.upload` in jsdom, `locator.setInputFiles`
@@ -32,14 +37,16 @@ export class FileInputDriver extends HTMLFileInputDriver {
     return this.interactor.hasAttribute(this.locator, 'multiple');
   }
 
-  /** Whether the field is required (`aria-required="true"`). */
+  /** Whether the field is required (`aria-required="true"` on the `role="button"` wrapper). */
   async isRequired(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.locator, 'aria-required')) === 'true';
+    const wrapper = await this.wrapperLocator();
+    return wrapper != null && (await this.interactor.getAttribute(wrapper, 'aria-required')) === 'true';
   }
 
-  /** Whether the field is in an error state (`aria-invalid="true"`, mirrored by the button's `data-status="error"`). */
+  /** Whether the field is in an error state (`aria-invalid="true"` on the `role="button"` wrapper). */
   async isInvalid(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.locator, 'aria-invalid')) === 'true';
+    const wrapper = await this.wrapperLocator();
+    return wrapper != null && (await this.interactor.getAttribute(wrapper, 'aria-invalid')) === 'true';
   }
 
   /** Whether the field is disabled (native `disabled` on the input). */
@@ -58,10 +65,11 @@ export class FileInputDriver extends HTMLFileInputDriver {
   }
 
   /**
-   * The validation message text, resolved through the input's `aria-describedby`
-   * → status element id link. `undefined` when the field carries no status.
+   * The validation message text, resolved through the `role="button"` wrapper's
+   * `aria-describedby` → status element id link. `undefined` when the field
+   * carries no status.
    *
-   * `aria-describedby` is an IDREF *list*: Astryx points the input at both its
+   * `aria-describedby` is an IDREF *list*: Astryx points the wrapper at both its
    * description and its status when both are present (`FileInput` joins
    * `descriptionID` + `statusMessageID`). The status is the `FieldStatus` element
    * carrying a `data-type` severity marker (the description is a plain element
@@ -70,7 +78,11 @@ export class FileInputDriver extends HTMLFileInputDriver {
    * mirrors {@link AstryxFieldInputDriver.getStatusMessage}.
    */
   async getStatusMessage(): Promise<Optional<string>> {
-    const describedBy = await this.interactor.getAttribute(this.locator, 'aria-describedby');
+    const wrapper = await this.wrapperLocator();
+    if (wrapper == null) {
+      return undefined;
+    }
+    const describedBy = await this.interactor.getAttribute(wrapper, 'aria-describedby');
     if (!describedBy) {
       return undefined;
     }
@@ -81,6 +93,20 @@ export class FileInputDriver extends HTMLFileInputDriver {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The focusable `div[role="button"]` wrapper around the hidden input, resolved
+   * from the document by the input's own `id` — the closest thing to a parent
+   * lookup this locator system supports. `null` when the input carries no `id`
+   * (shouldn't happen; Astryx always sets one via `useId()`).
+   */
+  private async wrapperLocator(): Promise<PartLocator | null> {
+    const inputId = await this.interactor.getAttribute(this.locator, 'id');
+    if (!inputId) {
+      return null;
+    }
+    return byCssSelector(`div[role="button"]:has(> input[id="${inputId}"])`, 'Root');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/InputGroupDriver.ts
+++ b/packages/component-driver-astryx/src/components/InputGroupDriver.ts
@@ -5,15 +5,24 @@ import { byCssSelector, ComponentDriver, listHelper, locatorUtil, Optional } fro
  * Driver for the Astryx InputGroup (`@astryxdesign/core/InputGroup`).
  *
  * InputGroup self-emits `data-testid` on its inner `role="group"` div (anchored
- * by the scene), which also carries the accessible name (`aria-label`). The group
- * holds prefix/suffix addons (`InputGroupText` → plain `<div>`) alongside the
- * input wrapper (`<div data-pressable-container>`); addons are the non-wrapper
- * child divs.
+ * by the scene), which carries the accessible name via `aria-labelledby` pointing
+ * at the field label's `id`. The group holds prefix/suffix addons
+ * (`InputGroupText` → plain `<div>`) alongside the input wrapper
+ * (`<div data-pressable-container>`); addons are the non-wrapper child divs.
  */
 export class InputGroupDriver extends ComponentDriver<{}> {
-  /** The group's accessible name (`aria-label`). */
+  /**
+   * The group's accessible name — resolved from `aria-labelledby`, re-rooting
+   * from the document by the referenced `id` since the field label isn't
+   * necessarily a descendant of the group root.
+   */
   async getLabel(): Promise<Optional<string>> {
-    return this.interactor.getAttribute(this.locator, 'aria-label');
+    const labelId = await this.interactor.getAttribute(this.locator, 'aria-labelledby');
+    if (!labelId) {
+      return undefined;
+    }
+    const label = byCssSelector(`[id="${labelId}"]`, 'Root');
+    return (await this.interactor.getText(label)) ?? undefined;
   }
 
   /** Texts of the prefix/suffix addons, in DOM order. */

--- a/packages/component-driver-astryx/src/components/MultiSelectorDriver.ts
+++ b/packages/component-driver-astryx/src/components/MultiSelectorDriver.ts
@@ -1,5 +1,6 @@
 import { byCssSelector, locatorUtil, Optional } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 import { AstryxComboboxDriver } from './AstryxComboboxDriver';
 
 /** Default accessible label of the optional "select all" option (Astryx `selectAllLabel`). */
@@ -64,6 +65,17 @@ export class MultiSelectorDriver extends AstryxComboboxDriver {
   async isOptionSelected(label: string): Promise<boolean> {
     await this.open();
     return this.isOptionLabelSelected(label);
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the trigger's (the
+   * `role="combobox"` control) `aria-describedby` link — Astryx wires
+   * `disabledMessage`'s `aria-describedby` onto that inner `<button>`, not the
+   * root `<div>`. `undefined` when the selector isn't in that
+   * disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.combobox, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/PowerSearchDriver.ts
+++ b/packages/component-driver-astryx/src/components/PowerSearchDriver.ts
@@ -1,6 +1,7 @@
 import { byAriaLabel, byCssSelector, escapeUtil, locatorUtil, Optional } from '@atomic-testing/core';
 
 import { IndexedOptionListDriver } from '../internal/IndexedOptionListDriver';
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 
 /** A filter chip is `<span class="astryx-token">`; the class is a stable semantic hook, not StyleX-hashed. */
 const TOKEN_SELECTOR = 'span.astryx-token';
@@ -49,6 +50,17 @@ export class PowerSearchDriver extends IndexedOptionListDriver {
   /** The current query text in the input. */
   async getQuery(): Promise<string> {
     return (await this.interactor.getInputValue(this.combobox)) ?? '';
+  }
+
+  /**
+   * The `disabledMessage` tooltip text. PowerSearch is a thin wrapper that
+   * forwards `isDisabled`/`disabledMessage` straight through to an internal
+   * Tokenizer, which wires `aria-describedby` onto its `role="combobox"` query
+   * input — not the `role="group"` root. `undefined` when the field isn't in
+   * that disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.combobox, 'aria-describedby', 'tooltip');
   }
 
   /** Type into the query input to search field/operator suggestions. */

--- a/packages/component-driver-astryx/src/components/ProgressBarDriver.ts
+++ b/packages/component-driver-astryx/src/components/ProgressBarDriver.ts
@@ -4,13 +4,15 @@ import { byCssSelector, ComponentDriver, locatorUtil, Optional, PartLocator } fr
  * Driver for the Astryx ProgressBar (`@astryxdesign/core/ProgressBar`).
  *
  * The root `<div>` carries `data-testid` and `data-variant` but is itself
- * ROLELESS — the ARIA semantics live on an inner track `<div>` whose `role`
- * SWITCHES with mode: `role="meter"` for a determinate bar (with
- * `aria-valuenow`/`min`/`max`/`text`) and `role="progressbar"` for an
- * indeterminate one (with NO `aria-value*`). The driver therefore reads the
- * value attributes off the track and treats their absence (the `progressbar`
- * role) as indeterminate. The label is the header `<span id>`; the variant is the
- * root's `data-variant`.
+ * ROLELESS — the ARIA semantics live on an inner track `<div>` with
+ * `role="progressbar"` in BOTH modes (Astryx 0.1.3 dropped the determinate
+ * bar's `role="meter"` — a progress bar conveys task completion and should be
+ * announced on update, which `meter`'s static-gauge semantics don't convey).
+ * The two modes are now distinguished only by the presence of
+ * `aria-valuenow`/`min`/`max`/`text`, which a determinate bar carries and an
+ * indeterminate one omits. The driver reads the value attributes off the track
+ * and treats their absence as indeterminate. The label is the header
+ * `<span id>`; the variant is the root's `data-variant`.
  */
 export class ProgressBarDriver extends ComponentDriver<{}> {
   /**
@@ -63,12 +65,12 @@ export class ProgressBarDriver extends ComponentDriver<{}> {
   }
 
   /**
-   * Whether the bar is indeterminate. Indeterminate bars render the track with
-   * `role="progressbar"` (and no `aria-valuenow`); determinate bars use
-   * `role="meter"`.
+   * Whether the bar is indeterminate. Both modes render `role="progressbar"`, so
+   * this is read off the presence of `aria-valuenow` instead — indeterminate bars
+   * omit it, determinate bars always carry it.
    */
   async isIndeterminate(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.track, 'role')) === 'progressbar';
+    return (await this.getValueNow()) == null;
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/RadioListDriver.ts
+++ b/packages/component-driver-astryx/src/components/RadioListDriver.ts
@@ -1,5 +1,5 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
-import { byChecked, byInputType, byRole, byValue, locatorUtil, Optional } from '@atomic-testing/core';
+import { byChecked, byCssSelector, byInputType, byRole, byValue, locatorUtil, Optional } from '@atomic-testing/core';
 
 /**
  * Driver for the Astryx RadioList (`@astryxdesign/core/RadioList`).
@@ -75,13 +75,20 @@ export class RadioListDriver extends HTMLRadioButtonGroupDriver {
   /**
    * The group's accessible name.
    *
-   * Read from the inner radiogroup's `aria-label` (which Astryx sets to the group
-   * label) rather than the `<label>` element — the root also contains each item's
-   * own `<label>`, so a `label` match is ambiguous (Playwright rejects it).
+   * The radiogroup names itself via `aria-labelledby` pointing at the field
+   * label's `id` (not a `label` match on the root — the root also contains each
+   * item's own `<label>`, so that would be ambiguous, and Playwright rejects it).
+   * The referenced label re-roots from the document by that `id`, so it resolves
+   * regardless of where Astryx places it in the tree.
    */
   async getLabel(): Promise<Optional<string>> {
     const group = locatorUtil.append(this.locator, byRole('radiogroup'));
-    return this.interactor.getAttribute(group, 'aria-label');
+    const labelId = await this.interactor.getAttribute(group, 'aria-labelledby');
+    if (!labelId) {
+      return undefined;
+    }
+    const label = byCssSelector(`[id="${labelId}"]`, 'Root');
+    return (await this.interactor.getText(label)) ?? undefined;
   }
 
   /** Whether the group is required (`aria-required` on the inner radiogroup). */

--- a/packages/component-driver-astryx/src/components/RadioListDriver.ts
+++ b/packages/component-driver-astryx/src/components/RadioListDriver.ts
@@ -1,6 +1,8 @@
 import { HTMLRadioButtonGroupDriver } from '@atomic-testing/component-driver-html';
 import { byChecked, byCssSelector, byInputType, byRole, byValue, locatorUtil, Optional } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
+
 /**
  * Driver for the Astryx RadioList (`@astryxdesign/core/RadioList`).
  *
@@ -95,6 +97,20 @@ export class RadioListDriver extends HTMLRadioButtonGroupDriver {
   async isRequired(): Promise<boolean> {
     const group = locatorUtil.append(this.locator, byRole('radiogroup'));
     return (await this.interactor.getAttribute(group, 'aria-required')) === 'true';
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the whole group is disabled
+   * with a reason. `disabledMessage` is a group-level prop (individual radios
+   * have no reason of their own), and the tooltip's `aria-describedby` link is
+   * composed onto the inner `role="radiogroup"` div alongside the
+   * description/status-message ids — this picks out whichever target has
+   * `role="tooltip"`. `undefined` when the group has no disabled-reason
+   * tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    const group = locatorUtil.append(this.locator, byRole('radiogroup'));
+    return resolveDescribedByRoleText(this.interactor, group, 'aria-describedby', 'tooltip');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/SegmentedControlDriver.ts
+++ b/packages/component-driver-astryx/src/components/SegmentedControlDriver.ts
@@ -8,6 +8,8 @@ import {
   PartLocator,
 } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
+
 /**
  * Driver for the Astryx SegmentedControl (`@astryxdesign/core/SegmentedControl`).
  *
@@ -78,6 +80,17 @@ export class SegmentedControlDriver extends ComponentDriver<{}> implements IInpu
   /** The accessible name of the group (`aria-label` on the radiogroup root). */
   async getLabel(): Promise<Optional<string>> {
     return this.interactor.getAttribute(this.locator, 'aria-label');
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the whole control is
+   * disabled with a reason. Resolved through the root radiogroup's
+   * `aria-describedby` (SegmentedControl composes no other id onto it, but the
+   * shared resolver still confirms the target has `role="tooltip"`).
+   * `undefined` when the control has no disabled-reason tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.locator, 'aria-describedby', 'tooltip');
   }
 
   get driverName(): string {

--- a/packages/component-driver-astryx/src/components/SelectorDriver.ts
+++ b/packages/component-driver-astryx/src/components/SelectorDriver.ts
@@ -1,5 +1,6 @@
 import { Optional } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 import { AstryxComboboxDriver } from './AstryxComboboxDriver';
 
 /**
@@ -32,6 +33,17 @@ export class SelectorDriver extends AstryxComboboxDriver {
   async isOptionSelected(label: string): Promise<boolean> {
     await this.open();
     return this.isOptionLabelSelected(label);
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the trigger's (the
+   * `role="combobox"` control) `aria-describedby` link — Astryx wires
+   * `disabledMessage`'s `aria-describedby` onto that inner `<button>`, not the
+   * root `<div>`. `undefined` when the selector isn't in that
+   * disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.combobox, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/components/SliderDriver.ts
+++ b/packages/component-driver-astryx/src/components/SliderDriver.ts
@@ -1,5 +1,7 @@
 import { byRole, ComponentDriver, IInputDriver, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
+
 /**
  * Driver for the Astryx Slider (`@astryxdesign/core/Slider`), single-thumb scope.
  *
@@ -70,6 +72,29 @@ export class SliderDriver extends ComponentDriver<{}> implements IInputDriver<nu
   /** The slider's accessible name (`aria-label` on the thumb). */
   async getLabel(): Promise<Optional<string>> {
     return this.interactor.getAttribute(this.thumbLocator, 'aria-label');
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the slider is disabled with
+   * a reason. Resolved through the thumb's composed `aria-describedby` — the
+   * id list also carries the description/status-message ids, so this picks out
+   * whichever target has `role="tooltip"`.
+   *
+   * Gated on {@link isDisabled}: an enabled thumb's default value bubble
+   * (`valueDisplay="tooltip"`, Astryx's live-value preview) is a *second,
+   * unrelated* `role="tooltip"` layer linked through the same
+   * `aria-describedby`, so probing the DOM unconditionally would surface the
+   * current value instead of `undefined`. Astryx suppresses the value bubble
+   * only when a disabled-reason message is actually showing, so this can still
+   * misreport the value as the message on a slider that is disabled *without*
+   * a `disabledMessage` (upstream ambiguity — there is no way to tell the two
+   * `role="tooltip"` layers apart from the DOM alone).
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    if (!(await this.isDisabled())) {
+      return undefined;
+    }
+    return resolveDescribedByRoleText(this.interactor, this.thumbLocator, 'aria-describedby', 'tooltip');
   }
 
   private async readThumbNumber(attribute: string): Promise<number> {

--- a/packages/component-driver-astryx/src/components/SwitchDriver.ts
+++ b/packages/component-driver-astryx/src/components/SwitchDriver.ts
@@ -1,7 +1,7 @@
 import { HTMLCheckboxDriver } from '@atomic-testing/component-driver-html';
 import { Optional } from '@atomic-testing/core';
 
-import { resolveLinkedLabelText } from '../internal/linkedLocators';
+import { resolveDescribedByRoleText, resolveLinkedLabelText } from '../internal/linkedLocators';
 
 /**
  * Driver for the Astryx Switch (`@astryxdesign/core/Switch`).
@@ -46,6 +46,17 @@ export class SwitchDriver extends HTMLCheckboxDriver {
   /** The switch's visible label, resolved via the `<label for>`↔`id` link. */
   async getLabel(): Promise<Optional<string>> {
     return resolveLinkedLabelText(this.interactor, this.locator);
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, shown when the switch is disabled with
+   * a reason. Resolved through the native `<input>`'s composed
+   * `aria-describedby` — the id list also carries the description/status-message
+   * ids, so this picks out whichever target has `role="tooltip"`. `undefined`
+   * when the switch has no disabled-reason tooltip.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.locator, 'aria-describedby', 'tooltip');
   }
 
   override get driverName(): string {

--- a/packages/component-driver-astryx/src/components/TableDriver.ts
+++ b/packages/component-driver-astryx/src/components/TableDriver.ts
@@ -17,8 +17,8 @@ export type TableSortDirection = 'ascending' | 'descending';
  * checkbox column from the synthetic `data-column-key="__xds_selection"` — never
  * from StyleX-hashed classes.
  *
- * `@astryxdesign/core@0.1.1` renders the **full** table (no virtualization), so
- * every row reads faithfully in jsdom as well as the browser; row indices below are
+ * `@astryxdesign/core` renders the **full** table (no virtualization), so every
+ * row reads faithfully in jsdom as well as the browser; row indices below are
  * zero-based and exclude the header.
  */
 export class TableDriver extends ComponentDriver {
@@ -114,9 +114,14 @@ export class TableDriver extends ComponentDriver {
     return (await this.interactor.isChecked(this.selectAllCheckbox)) && !(await this.isSelectionIndeterminate());
   }
 
-  /** Whether the selection is partial — the header checkbox reports `aria-checked="mixed"`. */
+  /**
+   * Whether the selection is partial — the header checkbox matches
+   * `:indeterminate`. Astryx 0.1.3 dropped the redundant `aria-checked="mixed"` it
+   * used to set alongside the native `.indeterminate` DOM property (which isn't
+   * reflected as an HTML attribute), so this reads the CSS pseudo-class instead.
+   */
   async isSelectionIndeterminate(): Promise<boolean> {
-    return (await this.interactor.getAttribute(this.selectAllCheckbox, 'aria-checked')) === 'mixed';
+    return this.interactor.exists(locatorUtil.append(this.selectAllCheckbox, byCssSelector(':indeterminate', 'Same')));
   }
 
   /** Toggle the select-all checkbox in the header. */

--- a/packages/component-driver-astryx/src/components/TokenizerDriver.ts
+++ b/packages/component-driver-astryx/src/components/TokenizerDriver.ts
@@ -1,5 +1,6 @@
-import { byAriaLabel, byCssSelector, childListHelper, locatorUtil, PartLocator } from '@atomic-testing/core';
+import { byAriaLabel, byCssSelector, childListHelper, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 import { AstryxComboboxDriver } from './AstryxComboboxDriver';
 
 /** Astryx renders each chip as `<span class="astryx-token">`; the class is a stable semantic hook, not StyleX-hashed. */
@@ -53,6 +54,17 @@ export class TokenizerDriver extends AstryxComboboxDriver {
   /** The current query text in the input. */
   async getQuery(): Promise<string> {
     return (await this.interactor.getInputValue(this.combobox)) ?? '';
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the query input's (the
+   * `role="combobox"` control) `aria-describedby` link — Astryx wires
+   * `disabledMessage`'s `aria-describedby` onto that inner input, not the
+   * `role="group"` root. `undefined` when the field isn't in that
+   * disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.combobox, 'aria-describedby', 'tooltip');
   }
 
   /** Type a query into the input, triggering a search. */

--- a/packages/component-driver-astryx/src/components/TypeaheadDriver.ts
+++ b/packages/component-driver-astryx/src/components/TypeaheadDriver.ts
@@ -1,5 +1,6 @@
-import { byCssSelector, locatorUtil, PartLocator } from '@atomic-testing/core';
+import { byCssSelector, locatorUtil, Optional, PartLocator } from '@atomic-testing/core';
 
+import { resolveDescribedByRoleText } from '../internal/linkedLocators';
 import { AstryxComboboxDriver } from './AstryxComboboxDriver';
 
 /**
@@ -45,6 +46,15 @@ export class TypeaheadDriver extends AstryxComboboxDriver {
   async getResultLabels(): Promise<readonly string[]> {
     await this.waitForOptions();
     return this.optionLabels();
+  }
+
+  /**
+   * The `disabledMessage` tooltip text, resolved via the search input's (the
+   * `role="combobox"` control) `aria-describedby` link. `undefined` when the
+   * typeahead isn't in that disabled-with-message state.
+   */
+  async getDisabledMessage(): Promise<Optional<string>> {
+    return resolveDescribedByRoleText(this.interactor, this.combobox, 'aria-describedby', 'tooltip');
   }
 
   /**

--- a/packages/component-driver-astryx/src/internal/linkedLocators.ts
+++ b/packages/component-driver-astryx/src/internal/linkedLocators.ts
@@ -62,3 +62,35 @@ export async function resolveLinkedElementText(
   }
   return (await interactor.getText(target)) ?? undefined;
 }
+
+/**
+ * Resolve the text of the element linked through a space-separated IDREF
+ * attribute (e.g. `aria-describedby`) whose target carries a specific `role`.
+ * Astryx composes `aria-describedby` from multiple ids (description, status
+ * message, disabled-message tooltip, …) rather than a single id, so unlike
+ * {@link resolveLinkedElementText} this splits the list and probes each id in
+ * order, returning the text of whichever target matches `role` — e.g. the
+ * `disabledMessage` tooltip (`useTooltip`, shared with {@link TooltipDriver})
+ * always renders with `role="tooltip"`, distinguishing it from the plain
+ * description/status-message targets in the same list. Re-roots at the
+ * document (`'Root'`) because these targets — like the Tooltip/HoverCard
+ * layers — render outside the control's subtree.
+ */
+export async function resolveDescribedByRoleText(
+  interactor: Interactor,
+  controlLocator: PartLocator,
+  idRefAttribute: string,
+  role: string
+): Promise<Optional<string>> {
+  const ids = await interactor.getAttribute(controlLocator, idRefAttribute);
+  if (!ids) {
+    return undefined;
+  }
+  for (const id of ids.split(' ').filter(Boolean)) {
+    const target = byAttribute('id', id, 'Root');
+    if ((await interactor.exists(target)) && (await interactor.getAttribute(target, 'role')) === role) {
+      return (await interactor.getText(target)) ?? undefined;
+    }
+  }
+  return undefined;
+}

--- a/packages/component-driver-astryx/src/internal/linkedLocators.ts
+++ b/packages/component-driver-astryx/src/internal/linkedLocators.ts
@@ -64,7 +64,7 @@ export async function resolveLinkedElementText(
 }
 
 /**
- * Resolve the text of the element linked through a space-separated IDREF
+ * Resolve the text of the element linked through a whitespace-separated IDREF
  * attribute (e.g. `aria-describedby`) whose target carries a specific `role`.
  * Astryx composes `aria-describedby` from multiple ids (description, status
  * message, disabled-message tooltip, …) rather than a single id, so unlike
@@ -86,7 +86,7 @@ export async function resolveDescribedByRoleText(
   if (!ids) {
     return undefined;
   }
-  for (const id of ids.split(' ').filter(Boolean)) {
+  for (const id of ids.split(/\s+/).filter(Boolean)) {
     const target = byAttribute('id', id, 'Root');
     if ((await interactor.exists(target)) && (await interactor.getAttribute(target, 'role')) === role) {
       return (await interactor.getText(target)) ?? undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,11 +368,11 @@ importers:
   package-tests/component-driver-astryx-test:
     dependencies:
       '@astryxdesign/core':
-        specifier: ^0.1.1
-        version: 0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.1.3
+        version: 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@astryxdesign/theme-neutral':
-        specifier: ^0.1.1
-        version: 0.1.1(@astryxdesign/core@0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: ^0.1.3
+        version: 0.1.3(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@atomic-testing/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1516,8 +1516,8 @@ importers:
   packages/component-driver-astryx:
     dependencies:
       '@astryxdesign/core':
-        specifier: ^0.1.1
-        version: 0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.1.3
+        version: 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@atomic-testing/component-driver-html':
         specifier: workspace:*
         version: link:../component-driver-html
@@ -2208,16 +2208,17 @@ packages:
       '@angular/animations':
         optional: true
 
-  '@astryxdesign/core@0.1.1':
-    resolution: {integrity: sha512-9lU1lY4ztfgYsfkaXzQ3P3igXvTLN5CRqHoLgrVCkTYYciGxU8GitDBq+mWoa1TDxQgBB8ZTLNKPK3o5Hqeiiw==}
+  '@astryxdesign/core@0.1.3':
+    resolution: {integrity: sha512-NTiKu0+keZckb5RB6enErCXDGYLF6j4cUYjK/V0uWrqbflX+47sUQgaCZVFZB4b2kAe4k4czBCZS3mtaJcbZlw==}
     peerDependencies:
+      '@stylexjs/stylex': ^0.18.3
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@astryxdesign/theme-neutral@0.1.1':
-    resolution: {integrity: sha512-B3+q0z4exOnT7AXTAEqHq1eVetWzkbkAU2SC3pdQgEGTqDt3kaqIYCbnVEjja6QUTjwHwQYrAh8LmdXFpRlNPg==}
+  '@astryxdesign/theme-neutral@0.1.3':
+    resolution: {integrity: sha512-diwEEukajD0OHSeQ3XnyaNYHssaWgbjbwAGG5t/NANjE4X0sjFXUKb5drwWHhje5AU+hTFU7yOUltvjSW4LHvg==}
     peerDependencies:
-      '@astryxdesign/core': 0.1.1
+      '@astryxdesign/core': 0.1.3
       react: '>=19'
 
   '@babel/code-frame@7.29.7':
@@ -4319,48 +4320,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -4439,41 +4448,49 @@ packages:
     resolution: {integrity: sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.21.3':
     resolution: {integrity: sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.21.3':
     resolution: {integrity: sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.21.3':
     resolution: {integrity: sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.21.3':
     resolution: {integrity: sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.21.3':
     resolution: {integrity: sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.21.3':
     resolution: {integrity: sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.21.3':
     resolution: {integrity: sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.21.3':
     resolution: {integrity: sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==}
@@ -4542,48 +4559,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.55.0':
     resolution: {integrity: sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
     resolution: {integrity: sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
     resolution: {integrity: sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.55.0':
     resolution: {integrity: sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.55.0':
     resolution: {integrity: sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.55.0':
     resolution: {integrity: sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.55.0':
     resolution: {integrity: sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.55.0':
     resolution: {integrity: sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==}
@@ -4656,48 +4681,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.70.0':
     resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.70.0':
     resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.70.0':
     resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.70.0':
     resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.70.0':
     resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.70.0':
     resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.70.0':
     resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.70.0':
     resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
@@ -5550,108 +5583,126 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -6061,24 +6112,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.9':
     resolution: {integrity: sha512-yghFZWKPVVGbUdqiD7ft23G0JX6YFGDJPz9YbLLAwGuKZ9th3/jlWoQDAw1Naci31LQhVC+oIji6ozihSuwB2A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.9':
     resolution: {integrity: sha512-SFUxyhWLZRNL8QmgGNqdi2Q43PNyFVkRZ2zIif30SOGFSxnxcf2JNeSeBgKIGVgaLSuk6xFVVCtJ3KIeaStgRg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.9':
     resolution: {integrity: sha512-9FB0wM+6idCGTI20YsBNBg9xSWtkDBymnpaTCsZM3qDc0l4uOpJMqbfWhQvp17x7r/ulZfb2QY8RDvQmCL6AcQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.9':
     resolution: {integrity: sha512-zHOusMVbOH9ik5RtRrMiGzLpKwxrPXgXkBm3SbUCa65HAdjV33NZ0/R9Rv1uPESALtEl2tzMYLUxYA5ECFDFhA==}
@@ -8070,24 +8125,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -9805,15 +9864,15 @@ snapshots:
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@astryxdesign/core@0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@stylexjs/stylex': 0.18.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@astryxdesign/theme-neutral@0.1.1(@astryxdesign/core@0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-neutral@0.1.3(@astryxdesign/core@0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.1.3(@stylexjs/stylex@0.18.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.22.0(react@19.2.7)
       react: 19.2.7
 


### PR DESCRIPTION
## Summary

- Upgraded `@astryxdesign/core`/`@astryxdesign/theme-neutral` from `0.1.1` → `0.1.3` across the driver package, its test package, and the example workspace, and repaired the driver/example breakage caused by upstream DOM/ARIA changes: indeterminate checkboxes/table-select-all dropped `aria-checked="mixed"` for the native `.indeterminate` property, RadioList/InputGroup moved from `aria-label` to `aria-labelledby`, ButtonGroup's `aria-orientation` (invalid on `role="group"`) became `data-orientation`, ProgressBar's determinate mode merged into `role="progressbar"`, FileInput's described-by/required/invalid attributes moved onto the focusable wrapper, DateTimeInput/DateRangeInput changed field labels and preset markup, ContextMenu dropped `aria-haspopup` entirely, and DropdownMenu/MoreMenu dropped the `hasAutoFocus` prop.
- Added `getDisabledMessage()` driver coverage for Astryx 0.1.3's new `disabledMessage` prop, present on ~19 components (a tooltip explaining why a control is disabled, while the control stays keyboard-focusable via `aria-disabled`). Backed by a new shared `resolveDescribedByRoleText` locator helper (`packages/component-driver-astryx/src/internal/linkedLocators.ts`) that resolves the composed `aria-describedby` id list to whichever target carries `role="tooltip"`. Each affected driver was verified individually against the real Astryx 0.1.3 source for exactly which element carries the link (the control itself for simple inputs, the group role for RadioList/CheckboxList, an inner combobox sub-element for Tokenizer/PowerSearch/Selector/MultiSelector/Typeahead, the operable wrapper for FileInput); TextInput/NumberInput/TextArea/TimeInput inherit it from shared base classes with no override, and Slider guards on `isDisabled()` since an enabled thumb's live-value bubble is a second, unrelated `role="tooltip"` layer on the same link.

## Breaking change

Removed `ContextMenuDriver.getHasPopup()` — Astryx 0.1.3 dropped `aria-haspopup` from the ContextMenu trigger entirely (it sat on a role-less, non-focusable wrapper and conveyed nothing to assistive tech), so there is nothing left for the method to read.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (component-driver-astryx-test: 91/91 suites, 339/339 tests; example-astryx-workspace: vitest suite green)
- [ ] `pnpm test:e2e` (relevant packages, all three browsers) — only **Chromium** could be verified in this sandboxed environment (339/339 tests passing); Firefox and WebKit binaries aren't available here, so those two browsers still need a run before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QTJX9CTWVMw3aQTXH5n4z5)_