### PR TITLE
fix(core)!: fix interactor read-path defects and narrow ComponentDriver primitives

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -178,6 +178,35 @@ jobs:
         run: pnpm test:dom
         working-directory: ./package-tests/${{ matrix.directory }}
 
+  # Interactor conformance suite (TCK, #1046): the same specs run against every
+  # interactor to prove they honor the one jsdom-defined contract (ADR-006). This
+  # runs the jsdom (DOMInteractor) leg; the real-browser Playwright leg needs the
+  # matched Playwright browser and is tracked as follow-up. The suite itself lives
+  # in packages/internal-interactor-conformance.
+  interactor-conformance-test:
+    name: Test interactor conformance (TCK)
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup dependencies only
+        uses: ./.github/actions/deps-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: built-packages
+          path: packages
+
+      - name: Run conformance suite (DOM)
+        run: pnpm test:dom
+        working-directory: ./package-tests/internal-interactor-conformance-test
+
   # Storybook integration fixture — runs Driver-powered stories as real-browser
   # Vitest tests (@storybook/addon-vitest, Vitest browser mode, Chromium) through
   # @atomic-testing/storybook. See issue #951.

--- a/agent-docs/adr/015-component-driver-protected-primitives.md
+++ b/agent-docs/adr/015-component-driver-protected-primitives.md
@@ -1,0 +1,84 @@
+# ADR-015: Narrow ComponentDriver's low-level primitives to `protected`
+
+## Status
+
+Accepted (2026-07-08). Part of the 1.0 freeze. Issue #1045.
+
+## Context
+
+`ComponentDriver` (`packages/core/src/drivers/ComponentDriver.ts`) exposed a
+large, uniform, low-level surface — every raw pointer and keyboard gesture
+(`mouseDown/Up/Move/Over/Out/Enter/Leave`, `dragTo`, `drag`, `contextMenu`,
+`activate`, `scrollBy`), plus `getBoundingRect` and `innerHTML` — publicly. That
+surface is inherited by **every** concrete driver and by the engine root
+(`TestEngine`), where most of it is meaningless and, for the DOM/Playwright
+adapters, actively crashed on the `[]` root locator (see
+[#1048](https://github.com/atomic-testing/atomic-testing/issues/1048)).
+
+1.0 freezes the public API ([ADR-006](006-1.0-api-freeze-and-evolution.md)). The
+reversibility here is **asymmetric**:
+
+- Widening a member from `protected` to `public` later is **non-breaking** —
+  existing callers keep working.
+- Narrowing a member from `public` to `protected` later is **breaking** — it
+  removes something callers may depend on.
+
+So the conservative 1.0 choice is to ship these primitives `protected` and widen
+any that earn a public use case, rather than freeze the whole uniform surface and
+be unable to take it back.
+
+## Decision
+
+Ship the raw low-level primitives as `protected` on `ComponentDriver`; keep only
+the semantic, intended actions public.
+
+**Narrowed to `protected`:** `mouseMove`, `mouseDown`, `mouseUp`, `mouseOver`,
+`mouseOut`, `mouseEnter`, `mouseLeave`, `contextMenu`, `activate`, `scrollBy`,
+`dragTo`, `drag`, `getBoundingRect`, `innerHTML`.
+
+**Kept public (semantic actions and reads):** `click`, `hover`, `focus`,
+`pressKey`, `scrollIntoView`, `isVisible`, `getText`, `getAttribute`, `exists`,
+the `waitUntil*` family, `runtimeCssSelector`, and the driver-model members
+(`parts`, `locator`, `interactor`, `commutableOption`, `driverName`, the static
+portal hooks).
+
+Concrete drivers still compose the narrowed primitives internally: they remain
+callable on `this`, and a driver that needs a child part's primitive drives it
+through the interactor against the child's resolved locator —
+`this.interactor.<primitive>(this.parts.<child>.locator, …)` — since a
+`protected` member is not reachable on a sibling driver instance of another
+class.
+
+## Consequences
+
+- ✅ The frozen public driver surface is the semantic API only; the raw gestures
+  are an internal composition detail that can be widened case by case without a
+  breaking change.
+- ✅ The engine root no longer advertises a pile of primitives that are
+  meaningless (and were crash-prone) at the scene root.
+- ⚠️ Breaking for any external caller that invoked a now-`protected` primitive
+  directly on a driver instance — intended, and done now, before the 1.0 tag.
+- ℹ️ All in-repo callers resolved cleanly through the interactor, so **no method
+  needed a public-surface exception**: the shipped drivers
+  (`DialogDriver` in `component-driver-mui-v6/-v7/-v9` used `mouseDown`/`mouseUp`
+  on the dialog container; `SliderDriver` in `component-driver-primevue-v4` and
+  `component-driver-radix-v1` used `drag` on the handle/thumb) and the driver
+  test suites (mouse-event, drag, scroll, activate, context-menu, geometry,
+  scroll-area, nav-icon) now call the interactor with the child's `locator`.
+- ℹ️ The generated API reference already partitions members into own / inherited
+  / protected sections, so the narrowed members surface there as `protected`; the
+  committed `etc/core.api.md` report is regenerated to match.
+
+## Alternatives considered
+
+| Alternative                                                  | Why not chosen                                                                                                                               |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep every primitive public, document intent in prose        | Freezes a large uniform surface at 1.0 that is breaking to narrow later; a doc note cannot un-freeze it.                                     |
+| Remove the primitives from `ComponentDriver` entirely        | Drivers legitimately compose them; removing them would push the raw-gesture logic into every driver and duplicate the interactor delegation. |
+| Split the primitives onto a separate opt-in mixin/base class | Speculative structure for no present need; the `protected` narrowing achieves the surface goal with a far smaller, right-sized change.       |
+
+## Related
+
+- [ADR-006](006-1.0-api-freeze-and-evolution.md) — the 1.0 API freeze this serves.
+- [#1048](https://github.com/atomic-testing/atomic-testing/issues/1048) — the engine-root crash that motivated auditing the inherited surface.
+- Issue #1045.

--- a/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/nav-icon/NavIcon.suite.ts
@@ -27,7 +27,7 @@ export const navIconExampleTestSuite: TestSuiteInfo<typeof navIconExample.scene>
       // NavIcon is display-only: it exists and renders the supplied icon markup.
       test(`renders the icon and is present`, async () => {
         assertTrue(await engine().parts.basic.exists());
-        assertTrue((await engine().parts.basic.innerHTML()).includes('★'));
+        assertTrue((await engine().interactor.innerHTML(engine().parts.basic.locator)).includes('★'));
       });
     });
   },

--- a/package-tests/component-driver-html-test/src/examples/activate/Activate.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/activate/Activate.suite.ts
@@ -37,12 +37,12 @@ export const activateExampleTestSuite: TestSuiteInfo<typeof activateExample.scen
       });
 
       test(`Activating the first hidden radio selects it`, async () => {
-        await engine().parts.first.activate();
+        await engine().interactor.activate(engine().parts.first.locator);
         assertEqual(await engine().parts.detail.getText(), 'first');
       });
 
       test(`Activating targets the specific radio, not a sibling`, async () => {
-        await engine().parts.second.activate();
+        await engine().interactor.activate(engine().parts.second.locator);
         assertEqual(await engine().parts.detail.getText(), 'second');
       });
     });

--- a/package-tests/component-driver-html-test/src/examples/contextMenu/ContextMenu.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/contextMenu/ContextMenu.suite.ts
@@ -38,7 +38,7 @@ export const contextMenuExampleTestSuite: TestSuiteInfo<typeof contextMenuExampl
       });
 
       test(`contextMenu fires the contextmenu event and reveals the menu`, async () => {
-        await engine().parts.contextTarget.contextMenu();
+        await engine().interactor.contextMenu(engine().parts.contextTarget.locator);
         // Poll the count for e2e robustness: the browser right-click and the
         // React re-render it triggers are asynchronous.
         const count = await engine().parts.contextCount.waitUntil({

--- a/package-tests/component-driver-html-test/src/examples/drag/Drag.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/drag/Drag.suite.ts
@@ -49,7 +49,7 @@ export const dragExampleTestSuite: TestSuiteInfo<typeof dragExample.scene> = {
       // box) so the target stays topmost at release in a real browser. Positional
       // outcome is not asserted here.
       test(`dragTo drops onto the target`, async () => {
-        await engine().parts.dragSource.dragTo(engine().parts.dropTarget);
+        await engine().interactor.dragTo(engine().parts.dragSource.locator, engine().parts.dropTarget.locator);
         const status = await engine().parts.dropStatus.waitUntil({
           probeFn: () => engine().parts.dropStatus.getText(),
           terminateCondition: 'dropped',
@@ -62,7 +62,7 @@ export const dragExampleTestSuite: TestSuiteInfo<typeof dragExample.scene> = {
       // This proves the event wiring, not the coordinates.
       test(`drag fires the mousedown interaction`, async () => {
         assertEqual(await engine().parts.dragInteractions.getText(), '0');
-        await engine().parts.dragBox.drag({ x: 40, y: 20 });
+        await engine().interactor.drag(engine().parts.dragBox.locator, { x: 40, y: 20 });
         const count = await engine().parts.dragInteractions.waitUntil({
           probeFn: () => engine().parts.dragInteractions.getText(),
           terminateCondition: '1',
@@ -75,7 +75,7 @@ export const dragExampleTestSuite: TestSuiteInfo<typeof dragExample.scene> = {
       // movement is browser-only — assert the offset reaches roughly the delta.
       if (hasLayout) {
         test(`drag moves the box by the delta`, async () => {
-          await engine().parts.dragBox.drag({ x: 40, y: 20 });
+          await engine().interactor.drag(engine().parts.dragBox.locator, { x: 40, y: 20 });
           const position = await engine().parts.dragPosition.waitUntil({
             probeFn: () => engine().parts.dragPosition.getText(),
             terminateCondition: text => text != null && text !== '0,0',

--- a/package-tests/component-driver-html-test/src/examples/drag/Geometry.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/drag/Geometry.suite.ts
@@ -28,7 +28,7 @@ export const geometryExampleTestSuite: TestSuiteInfo<typeof geometryExample.scen
 
       // Cross-engine: the rect is structurally valid in both engines.
       test(`getBoundingRect returns a numeric x/y/width/height shape`, async () => {
-        const r = await engine().parts.dragBox.getBoundingRect();
+        const r = await engine().interactor.getBoundingRect(engine().parts.dragBox.locator);
         assertEqual(typeof r.width, 'number');
         assertEqual(typeof r.height, 'number');
         assertEqual(typeof r.x, 'number');
@@ -38,7 +38,7 @@ export const geometryExampleTestSuite: TestSuiteInfo<typeof geometryExample.scen
       // jsdom-only: no layout engine, so getBoundingClientRect is all zeros.
       if (!hasLayout) {
         test(`getBoundingRect returns a zero-rect under jsdom`, async () => {
-          const r = await engine().parts.dragBox.getBoundingRect();
+          const r = await engine().interactor.getBoundingRect(engine().parts.dragBox.locator);
           assertEqual(r.width, 0);
           assertEqual(r.height, 0);
         });
@@ -47,7 +47,7 @@ export const geometryExampleTestSuite: TestSuiteInfo<typeof geometryExample.scen
       // E2E-only: a real layout engine reports the box's actual 120x60-ish size.
       if (hasLayout) {
         test(`getBoundingRect returns the box's real dimensions`, async () => {
-          const r = await engine().parts.dragBox.getBoundingRect();
+          const r = await engine().interactor.getBoundingRect(engine().parts.dragBox.locator);
           assertTrue(r.width > 0 && r.height > 0);
         });
       }

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/MouseLocation.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/MouseLocation.suite.ts
@@ -38,7 +38,7 @@ export const mouseLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof mouse
       const engine = useTestEngine(mouseLocationMouseEventExample.scene, getTestEngine, { beforeEach, afterEach });
 
       test('Mousemove on somewhere in the target should display the correct coordinates', async () => {
-        await engine().parts.target.mouseMove({
+        await engine().interactor.mouseMove(engine().parts.target.locator, {
           position: {
             x: 20,
             y: 15,
@@ -56,13 +56,13 @@ export const mouseLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof mouse
       });
 
       test('Mousedown on somewhere in the target should display the correct coordinates', async () => {
-        await engine().parts.target.mouseMove({
+        await engine().interactor.mouseMove(engine().parts.target.locator, {
           position: {
             x: 20,
             y: 15,
           },
         });
-        await engine().parts.target.mouseDown({
+        await engine().interactor.mouseDown(engine().parts.target.locator, {
           position: {
             x: 12,
             y: 16,
@@ -80,19 +80,19 @@ export const mouseLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof mouse
       });
 
       test('MouseUp on somewhere in the target should display the correct coordinates', async () => {
-        await engine().parts.target.mouseMove({
+        await engine().interactor.mouseMove(engine().parts.target.locator, {
           position: {
             x: 20,
             y: 15,
           },
         });
-        await engine().parts.target.mouseDown({
+        await engine().interactor.mouseDown(engine().parts.target.locator, {
           position: {
             x: 12,
             y: 16,
           },
         });
-        await engine().parts.target.mouseUp({
+        await engine().interactor.mouseUp(engine().parts.target.locator, {
           position: {
             x: 11,
             y: 15,

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/MouseOver.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/MouseOver.suite.ts
@@ -41,25 +41,25 @@ export const mouseOverMouseEventExampleTestSuite: TestSuiteInfo<typeof mouseOver
       const engine = useTestEngine(mouseOverMouseEventExample.scene, getTestEngine, { beforeEach, afterEach });
 
       test('MouseOver', async () => {
-        await engine().parts.target.mouseOver();
+        await engine().interactor.mouseOver(engine().parts.target.locator);
         const text = await engine().parts.mouseOverDisplay.getText();
         assertEqual(text, 'true');
       });
 
       test('MouseOut', async () => {
-        await engine().parts.target.mouseOut();
+        await engine().interactor.mouseOut(engine().parts.target.locator);
         const text = await engine().parts.mouseOutDisplay.getText();
         assertEqual(text, 'true');
       });
 
       test('MouseEnter', async () => {
-        await engine().parts.target.mouseEnter();
+        await engine().interactor.mouseEnter(engine().parts.target.locator);
         const text = await engine().parts.mouseEnterDisplay.getText();
         assertEqual(text, 'true');
       });
 
       test('MouseLeave', async () => {
-        await engine().parts.target.mouseLeave();
+        await engine().interactor.mouseLeave(engine().parts.target.locator);
         const text = await engine().parts.mouseLeaveDisplay.getText();
         assertEqual(text, 'true');
       });

--- a/package-tests/component-driver-html-test/src/examples/scroll/Scroll.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/scroll/Scroll.suite.ts
@@ -40,7 +40,7 @@ export const scrollExampleTestSuite: TestSuiteInfo<typeof scrollExample.scene> =
       });
 
       test(`scrollBy resolves and the container still exists`, async () => {
-        await engine().parts.scrollContainer.scrollBy({ x: 0, y: 300 });
+        await engine().interactor.scrollBy(engine().parts.scrollContainer.locator, { x: 0, y: 300 });
         assertEqual(await engine().parts.scrollContainer.exists(), true);
       });
 
@@ -59,7 +59,7 @@ export const scrollExampleTestSuite: TestSuiteInfo<typeof scrollExample.scene> =
         });
 
         test(`scrollBy reveals the target`, async () => {
-          await engine().parts.scrollContainer.scrollBy({ x: 0, y: 1000 });
+          await engine().interactor.scrollBy(engine().parts.scrollContainer.locator, { x: 0, y: 1000 });
           const v = await engine().parts.targetVisibility.waitUntil({
             probeFn: () => engine().parts.targetVisibility.getText(),
             terminateCondition: 'true',

--- a/package-tests/component-driver-radix-test/src/examples/scroll-area/ScrollArea.suite.ts
+++ b/package-tests/component-driver-radix-test/src/examples/scroll-area/ScrollArea.suite.ts
@@ -45,7 +45,7 @@ export const scrollAreaExampleTestSuite: TestSuiteInfo<typeof scrollAreaExample.
       // still exists, exercising the event wiring; jsdom has no layout engine so
       // the resulting scroll offset is not asserted here.
       test(`scrollBy on the viewport resolves without throwing`, async () => {
-        await engine().parts.scrollArea.parts.viewport.scrollBy({ x: 0, y: 200 });
+        await engine().interactor.scrollBy(engine().parts.scrollArea.parts.viewport.locator, { x: 0, y: 200 });
         assertEqual(await engine().parts.scrollArea.parts.viewport.exists(), true);
       });
 
@@ -54,9 +54,9 @@ export const scrollAreaExampleTestSuite: TestSuiteInfo<typeof scrollAreaExample.
       // viewport). A row's page-relative y position moves up by ~the scroll delta.
       if (hasLayout) {
         test(`scrollBy moves row geometry by roughly the delta`, async () => {
-          const before = await engine().parts.row.getBoundingRect();
-          await engine().parts.scrollArea.parts.viewport.scrollBy({ x: 0, y: 200 });
-          const after = await engine().parts.row.getBoundingRect();
+          const before = await engine().interactor.getBoundingRect(engine().parts.row.locator);
+          await engine().interactor.scrollBy(engine().parts.scrollArea.parts.viewport.locator, { x: 0, y: 200 });
+          const after = await engine().interactor.getBoundingRect(engine().parts.row.locator);
           assertTrue(Math.abs(before.y - after.y - 200) < 5);
         });
       }

--- a/package-tests/internal-interactor-conformance-test/__tests__/InteractorConformance.dom.test.ts
+++ b/package-tests/internal-interactor-conformance-test/__tests__/InteractorConformance.dom.test.ts
@@ -1,0 +1,17 @@
+import { createTestEngine } from '@atomic-testing/dom-core';
+import {
+  conformanceFixtureHtml,
+  conformanceScenePart,
+  defineConformanceSuite,
+} from '@atomic-testing/internal-interactor-conformance';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+
+// DOMInteractor leg: mount the framework-agnostic fixture into the jsdom
+// document and drive it with the DOM adapter. jsdom is the contract every other
+// interactor is proven against (ADR-006).
+defineConformanceSuite(jestTestAdapter, {
+  getTestEngine: (scenePart: typeof conformanceScenePart) => {
+    document.body.innerHTML = conformanceFixtureHtml;
+    return createTestEngine(document.body, scenePart);
+  },
+});

--- a/package-tests/internal-interactor-conformance-test/__tests__/InteractorConformance.e2e.test.ts
+++ b/package-tests/internal-interactor-conformance-test/__tests__/InteractorConformance.e2e.test.ts
@@ -1,0 +1,25 @@
+import {
+  conformanceFixtureHtml,
+  conformanceScenePart,
+  defineConformanceSuite,
+} from '@atomic-testing/internal-interactor-conformance';
+import { E2eTestInterface, E2eTestRunEnvironmentFixture } from '@atomic-testing/internal-test-runner';
+import {
+  playwrightGetTestEngine,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+import { Page } from '@playwright/test';
+
+// PlaywrightInteractor leg: load the SAME fixture via page.setContent (no dev
+// server needed) and drive it with the Playwright adapter. Passing against the
+// jsdom-defined specs proves the #1047 read-path fixes bring PlaywrightInteractor
+// into conformance.
+const interaction: E2eTestInterface<typeof conformanceScenePart> = {
+  getTestEngine: playwrightGetTestEngine,
+  goto: async (_url: string, fixture?: E2eTestRunEnvironmentFixture): Promise<void> => {
+    const page = fixture!.page as Page;
+    await page.setContent(conformanceFixtureHtml);
+  },
+};
+
+defineConformanceSuite(playWrightTestFrameworkMapper, interaction);

--- a/package-tests/internal-interactor-conformance-test/jest.config.js
+++ b/package-tests/internal-interactor-conformance-test/jest.config.js
@@ -1,0 +1,11 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  // This package has no `src` — only the __tests__ adapters that run the shared
+  // conformance suite — so scope roots to __tests__ to avoid a missing-root warning.
+  roots: ['<rootDir>/__tests__'],
+  testRegex: '(/__tests__/.*.dom.(test|spec)).(ts?)$',
+  displayName: 'internal-interactor-conformance-test',
+  testEnvironment: 'jsdom',
+};

--- a/package-tests/internal-interactor-conformance-test/package.json
+++ b/package-tests/internal-interactor-conformance-test/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@atomic-testing/internal-interactor-conformance-test",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Runs the interactor conformance suite (TCK) under Jest (DOMInteractor) and Playwright (PlaywrightInteractor)",
+  "license": "MIT",
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git"
+  },
+  "scripts": {
+    "test:dom": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:chrome": "playwright test --project=chromium"
+  },
+  "devDependencies": {
+    "@atomic-testing/core": "workspace:*",
+    "@atomic-testing/dom-core": "workspace:*",
+    "@atomic-testing/internal-interactor-conformance": "workspace:*",
+    "@atomic-testing/internal-test-runner": "workspace:*",
+    "@atomic-testing/internal-test-runner-jest-adapter": "workspace:*",
+    "@atomic-testing/internal-test-runner-playwright-adapter": "workspace:*",
+    "@atomic-testing/playwright": "workspace:*"
+  }
+}

--- a/package-tests/internal-interactor-conformance-test/playwright.config.ts
+++ b/package-tests/internal-interactor-conformance-test/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * The conformance e2e leg loads its fixture with `page.setContent`, so no dev
+ * server / baseURL is needed — unlike the driver package-tests that serve React
+ * examples through Vite.
+ */
+export default defineConfig({
+  testDir: './__tests__',
+  testMatch: /.*\.e2e\.(test|spec)\.(ts|tsx)$/,
+  timeout: 10 * 1000,
+  expect: {
+    timeout: 5000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    actionTimeout: 0,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});

--- a/packages/component-driver-mui-v6/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/DialogDriver.ts
@@ -68,8 +68,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
     // drive the full press/release/click sequence on the container's empty corner
     // (the click target must be the container, not the centered paper).
     const cornerClick = { position: { x: 5, y: 5 } } as const;
-    await this.parts.dialogContainer.mouseDown(cornerClick);
-    await this.parts.dialogContainer.mouseUp(cornerClick);
+    // Raw press/release primitives are protected on ComponentDriver (#1045), so
+    // drive them through the interactor against the child's resolved locator.
+    const containerLocator = this.parts.dialogContainer.locator;
+    await this.interactor.mouseDown(containerLocator, cornerClick);
+    await this.interactor.mouseUp(containerLocator, cornerClick);
     await this.parts.dialogContainer.click(cornerClick);
     return this.waitForClose(timeoutMs);
   }

--- a/packages/component-driver-mui-v7/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/DialogDriver.ts
@@ -68,8 +68,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
     // drive the full press/release/click sequence on the container's empty corner
     // (the click target must be the container, not the centered paper).
     const cornerClick = { position: { x: 5, y: 5 } } as const;
-    await this.parts.dialogContainer.mouseDown(cornerClick);
-    await this.parts.dialogContainer.mouseUp(cornerClick);
+    // Raw press/release primitives are protected on ComponentDriver (#1045), so
+    // drive them through the interactor against the child's resolved locator.
+    const containerLocator = this.parts.dialogContainer.locator;
+    await this.interactor.mouseDown(containerLocator, cornerClick);
+    await this.interactor.mouseUp(containerLocator, cornerClick);
     await this.parts.dialogContainer.click(cornerClick);
     return this.waitForClose(timeoutMs);
   }

--- a/packages/component-driver-mui-v9/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/DialogDriver.ts
@@ -68,8 +68,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
     // drive the full press/release/click sequence on the container's empty corner
     // (the click target must be the container, not the centered paper).
     const cornerClick = { position: { x: 5, y: 5 } } as const;
-    await this.parts.dialogContainer.mouseDown(cornerClick);
-    await this.parts.dialogContainer.mouseUp(cornerClick);
+    // Raw press/release primitives are protected on ComponentDriver (#1045), so
+    // drive them through the interactor against the child's resolved locator.
+    const containerLocator = this.parts.dialogContainer.locator;
+    await this.interactor.mouseDown(containerLocator, cornerClick);
+    await this.interactor.mouseUp(containerLocator, cornerClick);
     await this.parts.dialogContainer.click(cornerClick);
     return this.waitForClose(timeoutMs);
   }

--- a/packages/component-driver-primevue-v4/src/components/SliderDriver.ts
+++ b/packages/component-driver-primevue-v4/src/components/SliderDriver.ts
@@ -104,7 +104,9 @@ export class SliderDriver
    * resolves without throwing under jsdom, exercising the event wiring only.
    */
   async dragBy(delta: Point): Promise<void> {
-    return this.parts.handle.drag(delta);
+    // drag is protected on ComponentDriver (#1045); reach the child handle's
+    // gesture through the interactor and the child's resolved locator.
+    return this.interactor.drag(this.parts.handle.locator, delta);
   }
 
   /** Whether the slider is disabled (`p-disabled` state class on the root — see class doc). */

--- a/packages/component-driver-radix-v1/src/components/SliderDriver.ts
+++ b/packages/component-driver-radix-v1/src/components/SliderDriver.ts
@@ -95,7 +95,9 @@ export class SliderDriver extends ComponentDriver<typeof parts> implements IInpu
    * resolves without throwing under jsdom, exercising the event wiring only.
    */
   async dragBy(delta: Point): Promise<void> {
-    return this.parts.thumb.drag(delta);
+    // drag is protected on ComponentDriver (#1045); reach the child thumb's
+    // gesture through the interactor and the child's resolved locator.
+    return this.interactor.drag(this.parts.thumb.locator, delta);
   }
 
   /** Whether the slider is disabled (`data-disabled` presence on the root). */

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -507,6 +507,14 @@ export namespace listHelper {
 // @public
 export type LocatorRelativePosition = 'Root' | 'Descendant' | 'Same';
 
+// @public
+export class LocatorResolutionError extends InteractorErrorBase {
+    constructor(locator: PartLocator, reason: string);
+}
+
+// @public (undocumented)
+export const LocatorResolutionErrorId = "LocatorResolutionError";
+
 // @public (undocumented)
 export type LocatorType = 'css';
 

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -523,7 +523,7 @@ export const LocatorTypeLookup: Record<string, LocatorType>;
 
 // @public (undocumented)
 export namespace locatorUtil {
-    export { OverrideLocatorRelativePositionOption, append, defaultOverrideLocatorRelativePositionOption, getLinkedCssLocatorMatchingTargetValue, getLocatorInfoForErrorLog, isChain, overrideLocatorRelativePosition, toChain, toCssSelector };
+    export { OverrideLocatorRelativePositionOption, append, defaultOverrideLocatorRelativePositionOption, documentRootSelector, getLinkedCssLocatorMatchingTargetValue, getLocatorInfoForErrorLog, isChain, overrideLocatorRelativePosition, toChain, toCssSelector };
 }
 
 // @public (undocumented)

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -77,13 +77,13 @@ export namespace collectionUtil {
 // @public
 export abstract class ComponentDriver<T extends ScenePart = {}> implements IComponentDriver<T> {
     constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption<T>>);
-    activate(): Promise<void>;
+    protected activate(): Promise<void>;
     // (undocumented)
     click(option?: Partial<ClickOption>): Promise<void>;
     readonly commutableOption: IComponentDriverOption<T>;
-    contextMenu(): Promise<void>;
-    drag(delta: Point): Promise<void>;
-    dragTo(target: ComponentDriver<any>): Promise<void>;
+    protected contextMenu(): Promise<void>;
+    protected drag(delta: Point): Promise<void>;
+    protected dragTo(target: ComponentDriver<any>): Promise<void>;
     // (undocumented)
     abstract get driverName(): string;
     protected enforcePartExistence(partName: PartName<T> | ReadonlyArray<PartName<T>>): Promise<void>;
@@ -92,36 +92,36 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
     focus(option?: Partial<FocusOption>): Promise<void>;
     // (undocumented)
     getAttribute(attributeName: string): Promise<Optional<string>>;
-    getBoundingRect(): Promise<BoundingRect>;
+    protected getBoundingRect(): Promise<BoundingRect>;
     protected getMissingPartNames(partName: PartName<T> | ReadonlyArray<PartName<T>>): Promise<readonly PartName<T>[]>;
     getText(): Promise<Optional<string>>;
     // (undocumented)
     hover(option?: Partial<HoverOption>): Promise<void>;
-    innerHTML(): Promise<string>;
+    protected innerHTML(): Promise<string>;
     // (undocumented)
     readonly interactor: Interactor;
     isVisible(): Promise<boolean>;
     get locator(): PartLocator;
     // (undocumented)
-    mouseDown(option?: Partial<MouseDownOption>): Promise<void>;
+    protected mouseDown(option?: Partial<MouseDownOption>): Promise<void>;
     // (undocumented)
-    mouseEnter(option?: Partial<MouseEnterOption>): Promise<void>;
+    protected mouseEnter(option?: Partial<MouseEnterOption>): Promise<void>;
     // (undocumented)
-    mouseLeave(option?: Partial<MouseLeaveOption>): Promise<void>;
+    protected mouseLeave(option?: Partial<MouseLeaveOption>): Promise<void>;
     // (undocumented)
-    mouseMove(option?: Partial<MouseMoveOption>): Promise<void>;
+    protected mouseMove(option?: Partial<MouseMoveOption>): Promise<void>;
     // (undocumented)
-    mouseOut(option?: Partial<MouseOutOption>): Promise<void>;
+    protected mouseOut(option?: Partial<MouseOutOption>): Promise<void>;
     // (undocumented)
-    mouseOver(option?: Partial<HoverOption>): Promise<void>;
+    protected mouseOver(option?: Partial<HoverOption>): Promise<void>;
     // (undocumented)
-    mouseUp(option?: Partial<MouseUpOption>): Promise<void>;
+    protected mouseUp(option?: Partial<MouseUpOption>): Promise<void>;
     static overriddenParentLocator(): Optional<PartLocator>;
     static overrideLocatorRelativePosition(): Optional<LocatorRelativePosition>;
     get parts(): ScenePartDriver<T>;
     pressKey(key: string, option?: Partial<PressKeyOption>): Promise<void>;
     runtimeCssSelector(): Promise<string>;
-    scrollBy(delta: Point): Promise<void>;
+    protected scrollBy(delta: Point): Promise<void>;
     scrollIntoView(): Promise<void>;
     // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;

--- a/packages/core/src/drivers/ComponentDriver.ts
+++ b/packages/core/src/drivers/ComponentDriver.ts
@@ -175,31 +175,38 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
     return this.interactor.hover(this.locator, option);
   }
 
-  async mouseMove(option?: Partial<MouseMoveOption>): Promise<void> {
+  // Low-level pointer/keyboard primitives below are `protected` for the 1.0
+  // freeze. They are inherited by every driver and by the engine root (where
+  // most are meaningless — see #1048), so exposing them publicly would freeze a
+  // large uniform surface that is breaking to narrow later but safe to widen
+  // (ADR-015). Concrete drivers compose them internally to build semantic
+  // actions; the raw gestures stay out of the public API. See #1045.
+
+  protected async mouseMove(option?: Partial<MouseMoveOption>): Promise<void> {
     return this.interactor.mouseMove(this.locator, option);
   }
 
-  async mouseDown(option?: Partial<MouseDownOption>): Promise<void> {
+  protected async mouseDown(option?: Partial<MouseDownOption>): Promise<void> {
     return this.interactor.mouseDown(this.locator, option);
   }
 
-  async mouseUp(option?: Partial<MouseUpOption>): Promise<void> {
+  protected async mouseUp(option?: Partial<MouseUpOption>): Promise<void> {
     return this.interactor.mouseUp(this.locator, option);
   }
 
-  async mouseOver(option?: Partial<HoverOption>): Promise<void> {
+  protected async mouseOver(option?: Partial<HoverOption>): Promise<void> {
     return this.interactor.mouseOver(this.locator, option);
   }
 
-  async mouseOut(option?: Partial<MouseOutOption>): Promise<void> {
+  protected async mouseOut(option?: Partial<MouseOutOption>): Promise<void> {
     return this.interactor.mouseOut(this.locator, option);
   }
 
-  async mouseEnter(option?: Partial<MouseEnterOption>): Promise<void> {
+  protected async mouseEnter(option?: Partial<MouseEnterOption>): Promise<void> {
     return this.interactor.mouseEnter(this.locator, option);
   }
 
-  async mouseLeave(option?: Partial<MouseLeaveOption>): Promise<void> {
+  protected async mouseLeave(option?: Partial<MouseLeaveOption>): Promise<void> {
     return this.interactor.mouseLeave(this.locator, option);
   }
 
@@ -219,14 +226,14 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
   /**
    * Dispatch a right-click / `contextmenu` event on the component. See {@link Interactor.contextMenu}.
    */
-  async contextMenu(): Promise<void> {
+  protected async contextMenu(): Promise<void> {
     return this.interactor.contextMenu(this.locator);
   }
 
   /**
    * Activate the component without relying on pointer geometry. See {@link Interactor.activate}.
    */
-  async activate(): Promise<void> {
+  protected async activate(): Promise<void> {
     return this.interactor.activate(this.locator);
   }
 
@@ -248,7 +255,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
    *
    * @param delta Pixel offset to scroll by
    */
-  async scrollBy(delta: Point): Promise<void> {
+  protected async scrollBy(delta: Point): Promise<void> {
     return this.interactor.scrollBy(this.locator, delta);
   }
 
@@ -262,7 +269,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
    *
    * @param target Another driver whose root element is the drop target
    */
-  async dragTo(target: ComponentDriver<any>): Promise<void> {
+  protected async dragTo(target: ComponentDriver<any>): Promise<void> {
     return this.interactor.dragTo(this.locator, target.locator);
   }
 
@@ -276,7 +283,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
    *
    * @param delta Pixel offset to drag by
    */
-  async drag(delta: Point): Promise<void> {
+  protected async drag(delta: Point): Promise<void> {
     return this.interactor.drag(this.locator, delta);
   }
 
@@ -286,7 +293,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
    * jsdom has no layout engine, so every coordinate and dimension is `0` there;
    * real geometry is E2E-only.
    */
-  getBoundingRect(): Promise<BoundingRect> {
+  protected getBoundingRect(): Promise<BoundingRect> {
     return this.interactor.getBoundingRect(this.locator);
   }
 
@@ -336,7 +343,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
    * Get the inner HTML of the component
    * @returns The inner HTML of the component
    */
-  innerHTML(): Promise<string> {
+  protected innerHTML(): Promise<string> {
     return this.interactor.innerHTML(this.locator);
   }
 

--- a/packages/core/src/errors/ElementNotFoundError.ts
+++ b/packages/core/src/errors/ElementNotFoundError.ts
@@ -1,5 +1,5 @@
 import { PartLocator } from '../locators';
-import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
+import { getLocatorInfoForErrorLog } from '../utils/getLocatorInfoForErrorLog';
 import { InteractorErrorBase } from './InteractorErrorBase';
 
 export const ElementNotFoundErrorId = 'ElementNotFoundError';

--- a/packages/core/src/errors/ItemNotFoundError.ts
+++ b/packages/core/src/errors/ItemNotFoundError.ts
@@ -1,5 +1,5 @@
 import { PartLocator } from '../locators';
-import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
+import { getLocatorInfoForErrorLog } from '../utils/getLocatorInfoForErrorLog';
 import { ErrorBase } from './ErrorBase';
 
 export const ItemNotFoundErrorId = 'ItemNotFoundError';

--- a/packages/core/src/errors/LocatorResolutionError.ts
+++ b/packages/core/src/errors/LocatorResolutionError.ts
@@ -1,5 +1,5 @@
 import { PartLocator } from '../locators';
-import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
+import { getLocatorInfoForErrorLog } from '../utils/getLocatorInfoForErrorLog';
 import { InteractorErrorBase } from './InteractorErrorBase';
 
 export const LocatorResolutionErrorId = 'LocatorResolutionError';

--- a/packages/core/src/errors/LocatorResolutionError.ts
+++ b/packages/core/src/errors/LocatorResolutionError.ts
@@ -1,0 +1,28 @@
+import { PartLocator } from '../locators';
+import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
+import { InteractorErrorBase } from './InteractorErrorBase';
+
+export const LocatorResolutionErrorId = 'LocatorResolutionError';
+
+function getErrorMessage(locator: PartLocator, reason: string): string {
+  const selector = getLocatorInfoForErrorLog(locator);
+  return `Cannot resolve locator: ${reason}. Locator: ${selector}`;
+}
+
+/**
+ * Error thrown when a {@link PartLocator} cannot be reduced to a CSS selector —
+ * e.g. a {@link LinkedCssLocator} whose match target is absent, or a
+ * `valueExtract` method the resolver does not implement.
+ *
+ * Lives in the interactor-level error hierarchy (ADR-010): it carries only a
+ * serializable {@link locatorDescription} derived via
+ * {@link getLocatorInfoForErrorLog}, so consumers that catch on
+ * `InteractorErrorBase` see it alongside {@link ElementNotFoundError} rather than
+ * a bare `Error` escaping the frozen contract (#1051).
+ */
+export class LocatorResolutionError extends InteractorErrorBase {
+  constructor(locator: PartLocator, reason: string) {
+    super(getErrorMessage(locator, reason), getLocatorInfoForErrorLog(locator));
+    this.name = LocatorResolutionErrorId;
+  }
+}

--- a/packages/core/src/errors/WaitForFailureError.ts
+++ b/packages/core/src/errors/WaitForFailureError.ts
@@ -1,6 +1,6 @@
 import { WaitForOption } from '../drivers/WaitForOption';
 import { PartLocator } from '../locators';
-import { getLocatorInfoForErrorLog } from '../utils/locatorUtil';
+import { getLocatorInfoForErrorLog } from '../utils/getLocatorInfoForErrorLog';
 import { InteractorErrorBase } from './InteractorErrorBase';
 
 export const WaitForFailureErrorId = 'WaitForFailureError';

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -2,5 +2,6 @@ export { ElementNotFoundError, ElementNotFoundErrorId } from './ElementNotFoundE
 export { ErrorBase } from './ErrorBase';
 export { InteractorErrorBase } from './InteractorErrorBase';
 export { ItemNotFoundError, ItemNotFoundErrorId } from './ItemNotFoundError';
+export { LocatorResolutionError, LocatorResolutionErrorId } from './LocatorResolutionError';
 export { MissingPartError, MissingPartErrorId } from './MissingPartError';
 export { WaitForFailureError, WaitForFailureErrorId } from './WaitForFailureError';

--- a/packages/core/src/utils/__tests__/locatorUtil.test.ts
+++ b/packages/core/src/utils/__tests__/locatorUtil.test.ts
@@ -1,0 +1,31 @@
+import { Interactor } from '../../interactor/Interactor';
+import { byCssSelector } from '../../locators/byCssSelector';
+import { byDataTestId } from '../../locators/byDataTestId';
+import { documentRootSelector, toCssSelector } from '../locatorUtil';
+
+// toCssSelector only consults the interactor to resolve LinkedCssLocators; the
+// plain-CSS chains exercised here never touch it, so a bare stub is enough.
+const stubInteractor = {} as Interactor;
+
+describe('toCssSelector', () => {
+  test('reduces an empty locator chain to the portable document-root selector (#1048)', async () => {
+    // The engine-root locator ([]) previously reduced to '', which throws a CSS
+    // parse error in both jsdom and Chromium.
+    expect(await toCssSelector([], stubInteractor)).toBe(documentRootSelector);
+    expect(documentRootSelector).toBe(':root');
+  });
+
+  test('leaves a single non-empty locator unchanged', async () => {
+    expect(await toCssSelector(byDataTestId('submit'), stubInteractor)).toBe('[data-testid="submit"]');
+  });
+
+  test('joins a descendant chain with a space separator', async () => {
+    const chain = [byCssSelector('.parent'), byCssSelector('.child')];
+    expect(await toCssSelector(chain, stubInteractor)).toBe('.parent .child');
+  });
+
+  test('does not insert a separator for a Same-level locator', async () => {
+    const chain = [byCssSelector('.parent'), byCssSelector('.self', 'Same')];
+    expect(await toCssSelector(chain, stubInteractor)).toBe('.parent.self');
+  });
+});

--- a/packages/core/src/utils/getLocatorInfoForErrorLog.ts
+++ b/packages/core/src/utils/getLocatorInfoForErrorLog.ts
@@ -1,0 +1,26 @@
+import { PartLocator } from '../locators/PartLocator';
+
+/**
+ * Display a rough description of the locators for error logging
+ * this is an estimate, not a precise description with the absence of interactor
+ * locators such as LinkedCssLocator would not be interpreted correctly
+ *
+ * Lives in its own leaf module (imports only the locator model, never the error
+ * hierarchy) so the interactor errors that build their `locatorDescription` from
+ * it can depend on it without pulling in `locatorUtil` — which throws
+ * {@link LocatorResolutionError} and would otherwise close a `locatorUtil ↔
+ * error` import cycle.
+ *
+ * @param locator
+ * @returns
+ */
+export function getLocatorInfoForErrorLog(locator: PartLocator): string {
+  const locators = Array.isArray(locator) ? locator : [locator];
+
+  const selectors: string[] = [];
+  for (const loc of locators) {
+    selectors.push(loc.selector);
+  }
+
+  return selectors.join(', ');
+}

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -180,20 +180,8 @@ export function overrideLocatorRelativePosition(
   });
 }
 
-/**
- * Display a rough description of the locators for error logging
- * this is an estimate, not a precise description with the absence of interactor
- * locators such as LinkedCssLocator would not be interpreted correctly
- * @param locator
- * @returns
- */
-export function getLocatorInfoForErrorLog(locator: PartLocator): string {
-  const locators = Array.isArray(locator) ? locator : [locator];
-
-  const selectors: string[] = [];
-  for (const loc of locators) {
-    selectors.push(loc.selector);
-  }
-
-  return selectors.join(', ');
-}
+// Re-exported from a leaf module so the interactor errors can build their
+// `locatorDescription` from it without importing `locatorUtil` (which throws
+// LocatorResolutionError) — breaking a `locatorUtil ↔ error` import cycle while
+// keeping `locatorUtil.getLocatorInfoForErrorLog` on the public surface.
+export { getLocatorInfoForErrorLog } from './getLocatorInfoForErrorLog';

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -1,4 +1,5 @@
 import { Optional } from '../dataTypes';
+import { LocatorResolutionError } from '../errors/LocatorResolutionError';
 import { Interactor } from '../interactor/Interactor';
 import { byAttribute } from '../locators/byAttribute';
 import { CssLocator } from '../locators/CssLocator';
@@ -93,15 +94,14 @@ async function getLinkedCssLocator(
   const matchTargetValue = await getLinkedCssLocatorMatchingTargetValue(locator, context, interactor);
 
   if (matchTargetValue == null) {
-    // TODO: Produce more descriptive error to help with troubleshooting
-    throw new Error('Match target not found for LinkedCssLocator');
+    throw new LocatorResolutionError(locator, 'match target of LinkedCssLocator not found');
   }
 
   let resolvedLocator: CssLocator;
   if (locator.valueExtract.type === 'attribute') {
     resolvedLocator = byAttribute(locator.valueExtract.attributeName, matchTargetValue, locator.relative);
   } else {
-    throw new Error(`Cannot handle valueExtract method type ${locator.valueExtract.type}`);
+    throw new LocatorResolutionError(locator, `unsupported valueExtract type "${locator.valueExtract.type}"`);
   }
   return resolvedLocator;
 }
@@ -116,7 +116,10 @@ export async function getLinkedCssLocatorMatchingTargetValue(
     return await interactor.getAttribute(entireLocator, locator.matchingTargetValueExtract.attributeName);
   }
 
-  throw new Error(`Cannot handle valueExtract method type ${locator.matchingTargetValueExtract.type}`);
+  throw new LocatorResolutionError(
+    locator,
+    `unsupported matchingTargetValueExtract type "${locator.matchingTargetValueExtract.type}"`
+  );
 }
 
 function getLocatorStatement(locator: CssLocator): string {

--- a/packages/core/src/utils/locatorUtil.ts
+++ b/packages/core/src/utils/locatorUtil.ts
@@ -7,6 +7,15 @@ import { LinkedCssLocator } from '../locators/LinkedCssLocator';
 import type { LocatorRelativePosition } from '../locators/LocatorRelativePosition';
 import { CssLocatorChain, PartLocator } from '../locators/PartLocator';
 
+/**
+ * The portable document-root selector an empty locator chain reduces to. `<html>`
+ * in the DOM, matched by both `document.querySelector(':root')` (jsdom) and
+ * `page.locator(':root')` (Chromium). Used so the engine-root locator (`[]`, in
+ * the DOM/Playwright adapters) resolves to a real element instead of `''`, which
+ * throws a CSS parse error in every engine. See #1048.
+ */
+export const documentRootSelector = ':root';
+
 export function isChain(locator: PartLocator): locator is CssLocatorChain {
   return Array.isArray(locator);
 }
@@ -83,7 +92,12 @@ export async function toCssSelector(locator: PartLocator, interactor: Interactor
     statements.push(separator + statement);
   }
 
-  return Promise.resolve(statements.join('').trim());
+  const selector = statements.join('').trim();
+  // An empty locator chain (the engine root, which the DOM/Playwright adapters
+  // mount at `[]`) reduces to `''`. Running `''` as a selector throws a
+  // SyntaxError, crashing every engine-level read/mutation, so fall back to the
+  // portable document-root selector. See #1048.
+  return Promise.resolve(selector === '' ? documentRootSelector : selector);
 }
 
 async function getLinkedCssLocator(

--- a/packages/dom-core/etc/dom-core.api.md
+++ b/packages/dom-core/etc/dom-core.api.md
@@ -32,7 +32,7 @@ import { WaitUntilOption } from '@atomic-testing/core';
 export const createDomTestEngine: typeof createTestEngine;
 
 // @public
-export function createTestEngine<T extends ScenePart>(element: HTMLElement, partDefinitions: T, _option?: ITestEngineOption): TestEngine<T>;
+export function createTestEngine<T extends ScenePart>(element: HTMLElement, partDefinitions: T): TestEngine<T>;
 
 // @public (undocumented)
 export class DOMInteractor implements Interactor {

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -710,7 +710,13 @@ export class DOMInteractor implements Interactor {
   async getElement<T extends Element = Element>(locator: PartLocator): Promise<Optional<T>>;
   async getElement<T extends Element = Element>(locator: PartLocator, isMultiple = false) {
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const queryRoot = this.escapesToDocumentRoot(locator) ? this.rootEl.ownerDocument : this.rootEl;
+    // The engine-root locator (`[]`) resolves to `:root`, which matches `<html>` —
+    // an ancestor of `rootEl`, so `rootEl.querySelector(':root')` finds nothing.
+    // Query from the document in that case, matching `document.querySelector(':root')`
+    // and Playwright's `page.locator(':root')`. See #1048.
+    const escapesToDocumentRoot =
+      cssLocator === locatorUtil.documentRootSelector || this.escapesToDocumentRoot(locator);
+    const queryRoot = escapesToDocumentRoot ? this.rootEl.ownerDocument : this.rootEl;
     if (isMultiple) {
       const elList = queryRoot.querySelectorAll<T>(cssLocator);
       const result: T[] = [];

--- a/packages/dom-core/src/createTestEngine.ts
+++ b/packages/dom-core/src/createTestEngine.ts
@@ -1,4 +1,4 @@
-import { ITestEngineOption, ScenePart, TestEngine } from '@atomic-testing/core';
+import { ScenePart, TestEngine } from '@atomic-testing/core';
 
 import { DOMInteractor } from './DOMInteractor';
 
@@ -6,15 +6,9 @@ import { DOMInteractor } from './DOMInteractor';
  * Create test engine for DOM testing
  * @param element The element to test, if not sure, use document.body
  * @param partDefinitions The scene part definitions
- * @param _option Reserved for future use; accepted for entry-point symmetry with
- *   the other adapters and currently ignored.
  * @returns The test engine
  */
-export function createTestEngine<T extends ScenePart>(
-  element: HTMLElement,
-  partDefinitions: T,
-  _option?: ITestEngineOption
-): TestEngine<T> {
+export function createTestEngine<T extends ScenePart>(element: HTMLElement, partDefinitions: T): TestEngine<T> {
   const cleanup = () => Promise.resolve();
   return new TestEngine(
     [],

--- a/packages/internal-interactor-conformance/package.json
+++ b/packages/internal-interactor-conformance/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@atomic-testing/internal-interactor-conformance",
+  "version": "0.95.0",
+  "private": true,
+  "description": "Interactor conformance suite (TCK) proving every interactor behaves identically; not for production use",
+  "keywords": [],
+  "license": "MIT",
+  "author": "Tianzhen Lin <tangent@usa.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atomic-testing/atomic-testing.git"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check:type": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@atomic-testing/core": "workspace:*",
+    "@atomic-testing/internal-test-runner": "workspace:*"
+  },
+  "peerDependencies": {}
+}

--- a/packages/internal-interactor-conformance/src/conformanceFixture.ts
+++ b/packages/internal-interactor-conformance/src/conformanceFixture.ts
@@ -1,0 +1,49 @@
+import { byDataTestId, ComponentDriver, ScenePart } from '@atomic-testing/core';
+
+/**
+ * Framework-agnostic DOM the conformance suite probes. It is plain HTML so the
+ * SAME markup drives every interactor: the Jest leg mounts it via
+ * `@atomic-testing/dom-core`, the Playwright leg loads it with `page.setContent`.
+ *
+ * Every element the suite queries lives here; the `absent` test ids are
+ * deliberately NOT present so missing-element behavior can be asserted.
+ */
+export const conformanceFixtureHtml = `
+  <main>
+    <button type="button" data-testid="present">present</button>
+
+    <!-- Multi-match: two elements share a locator; reads must resolve to the first. -->
+    <div data-testid="dup" data-order="first">first</div>
+    <div data-testid="dup" data-order="second">second</div>
+
+    <!-- Value reads: a real input vs. a non-input element. -->
+    <input type="text" data-testid="text-input" value="typed" />
+    <div data-testid="not-input">not an input</div>
+
+    <!-- A checkbox so isChecked has a positive control. -->
+    <input type="checkbox" data-testid="checked-box" checked />
+
+    <!-- A selected <option> with NO value attribute: its value must fall back to
+         the option text (HTML IDL semantics), not be dropped. A single option
+         keeps selectedness unambiguous across jsdom and real browsers (jsdom
+         mis-marks later options selected when a <select> is parsed via innerHTML). -->
+    <select data-testid="valueless-select">
+      <option selected>Apple</option>
+    </select>
+  </main>
+`;
+
+/**
+ * A trivial driver so the scene part can construct a {@link TestEngine}. The
+ * conformance tests drive `engine().interactor` with raw locators rather than
+ * this driver's methods, so it needs no behavior of its own.
+ */
+export class ConformanceProbeDriver extends ComponentDriver {
+  get driverName(): string {
+    return 'ConformanceProbeDriver';
+  }
+}
+
+export const conformanceScenePart = {
+  present: { locator: byDataTestId('present'), driver: ConformanceProbeDriver },
+} satisfies ScenePart;

--- a/packages/internal-interactor-conformance/src/conformanceSuites.ts
+++ b/packages/internal-interactor-conformance/src/conformanceSuites.ts
@@ -1,0 +1,141 @@
+import {
+  byDataTestId,
+  byLinkedElement,
+  ElementNotFoundErrorId,
+  InteractorErrorBase,
+  LocatorResolutionErrorId,
+} from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+
+import { conformanceScenePart } from './conformanceFixture';
+
+/**
+ * Bound an interactor's fast-fail behavior. `DOMInteractor` answers a
+ * missing-element read instantly, but `PlaywrightInteractor` auto-waits for
+ * actionability; a genuinely-absent element would otherwise hang to the action
+ * timeout. The read primitives are all fixed to short-circuit on absence
+ * (#1047), and mutations translate to `ElementNotFoundError` only after the
+ * timeout — so cap it low for the one mutation-on-absent assertion. jsdom has no
+ * `page` and ignores this.
+ */
+function boundAutoWait(interactor: unknown): void {
+  const withPage = interactor as { page?: { setDefaultTimeout(ms: number): void } };
+  withPage.page?.setDefaultTimeout(2000);
+}
+
+async function captureError(run: () => Promise<unknown>): Promise<Error | undefined> {
+  try {
+    await run();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+}
+
+/**
+ * Interactor conformance suite (TCK). The same specs run under every
+ * `TestFrameworkMapper` (Jest, Playwright), proving each interactor honors the
+ * one contract jsdom defines (ADR-006). The cases encode the corrected,
+ * jsdom-conforming behavior of the four `PlaywrightInteractor` read-path defects
+ * fixed in #1047, plus error-hierarchy conformance (ADR-010).
+ *
+ * NOT covered — future work: mechanically verifying that every mutating
+ * primitive routes through a single `runInteraction` template-method seam. That
+ * seam does not exist yet (unfiled epic row 8); once it lands the suite should
+ * assert the routing directly.
+ */
+export const interactorConformanceSuite: TestSuiteInfo<typeof conformanceScenePart> = {
+  title: 'Interactor conformance (TCK)',
+  url: '/interactor-conformance',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(conformanceScenePart, getTestEngine, { beforeEach, afterEach });
+    const interactor = () => engine().interactor;
+    const absent = byDataTestId('definitely-absent');
+
+    // Defect 1: a read on a missing element returns the same undefined/false the
+    // DOM yields, instead of Playwright auto-waiting and throwing TimeoutError.
+    describe('missing element reads', () => {
+      test('getText / getAttribute / getInputValue return undefined', async () => {
+        assertEqual(await interactor().getText(absent), undefined);
+        assertEqual(await interactor().getAttribute(absent, 'id'), undefined);
+        assertEqual(await interactor().getInputValue(absent), undefined);
+      });
+
+      test('boolean state reads return false', async () => {
+        assertFalse(await interactor().isChecked(absent));
+        assertFalse(await interactor().isDisabled(absent));
+        assertFalse(await interactor().isReadonly(absent));
+        assertFalse(await interactor().isRequired(absent));
+        assertFalse(await interactor().isError(absent));
+        assertFalse(await interactor().hasAttribute(absent, 'id'));
+        assertFalse(await interactor().hasCssClass(absent, 'anything'));
+        assertFalse(await interactor().isVisible(absent));
+      });
+    });
+
+    // Defect 3: a locator matching multiple elements resolves to the first,
+    // matching querySelector, instead of a Playwright strict-mode violation.
+    describe('multiple matches resolve to the first', () => {
+      const dup = byDataTestId('dup');
+
+      test('getText reads the first match', async () => {
+        assertEqual(await interactor().getText(dup), 'first');
+      });
+
+      test('getAttribute reads the first match', async () => {
+        assertEqual(await interactor().getAttribute(dup, 'data-order'), 'first');
+      });
+    });
+
+    // Defect 2: getInputValue on a non-input element yields undefined rather than
+    // Playwright's "Node is not an <input>" throw; a real input still reads back.
+    describe('input value reads', () => {
+      test('reads the value of an <input>', async () => {
+        assertEqual(await interactor().getInputValue(byDataTestId('text-input')), 'typed');
+      });
+
+      test('returns undefined for a non-input element', async () => {
+        assertEqual(await interactor().getInputValue(byDataTestId('not-input')), undefined);
+      });
+    });
+
+    // Defect 4: a selected <option> with no value attribute yields its text (the
+    // value IDL property's spec fallback), instead of being silently dropped.
+    describe('select with a value-less selected option', () => {
+      const select = byDataTestId('valueless-select');
+
+      test('getSelectValues falls back to the option text', async () => {
+        assertEqual(await interactor().getSelectValues(select), ['Apple']);
+      });
+
+      test('getSelectLabels returns the option text', async () => {
+        assertEqual(await interactor().getSelectLabels(select), ['Apple']);
+      });
+    });
+
+    // Error-class conformance (ADR-010): interactor-level failures share one
+    // catchable hierarchy across every environment.
+    describe('error hierarchy', () => {
+      test('a mutation on a missing element throws ElementNotFoundError', async () => {
+        boundAutoWait(interactor());
+        const error = await captureError(() => interactor().click(absent));
+        assertEqual(error?.name, ElementNotFoundErrorId);
+        assertTrue(error instanceof InteractorErrorBase);
+      });
+
+      test('an unresolvable linked locator throws LocatorResolutionError', async () => {
+        // The linked locator's match target is absent, so it cannot be reduced to
+        // a CSS selector — surfacing #1051's dedicated error rather than a bare Error.
+        const brokenLinkedLocator = byLinkedElement()
+          .onLinkedElement(absent)
+          .extractAttribute('for')
+          .toMatchMyAttribute('id');
+        const error = await captureError(() => interactor().exists(brokenLinkedLocator));
+        assertEqual(error?.name, LocatorResolutionErrorId);
+        assertTrue(error instanceof InteractorErrorBase);
+      });
+    });
+  },
+};
+
+export const interactorConformanceSuites = [interactorConformanceSuite];

--- a/packages/internal-interactor-conformance/src/conformanceSuites.ts
+++ b/packages/internal-interactor-conformance/src/conformanceSuites.ts
@@ -111,6 +111,17 @@ export const interactorConformanceSuite: TestSuiteInfo<typeof conformanceScenePa
       test('getSelectLabels returns the option text', async () => {
         assertEqual(await interactor().getSelectLabels(select), ['Apple']);
       });
+
+      test('getSelectValues / getSelectLabels return undefined for a missing element', async () => {
+        assertEqual(await interactor().getSelectValues(absent), undefined);
+        assertEqual(await interactor().getSelectLabels(absent), undefined);
+      });
+
+      test('getSelectValues / getSelectLabels return undefined for a non-<select> element', async () => {
+        const notSelect = byDataTestId('not-input');
+        assertEqual(await interactor().getSelectValues(notSelect), undefined);
+        assertEqual(await interactor().getSelectLabels(notSelect), undefined);
+      });
     });
 
     // Error-class conformance (ADR-010): interactor-level failures share one

--- a/packages/internal-interactor-conformance/src/defineConformanceSuite.ts
+++ b/packages/internal-interactor-conformance/src/defineConformanceSuite.ts
@@ -1,0 +1,22 @@
+import { InteractionInterface, TestFrameworkMapper, testRunner } from '@atomic-testing/internal-test-runner';
+
+import { conformanceScenePart } from './conformanceFixture';
+import { interactorConformanceSuites } from './conformanceSuites';
+
+/**
+ * Register the interactor conformance suite (TCK) against a concrete
+ * environment. Reuses the shared `TestFrameworkMapper` (ADR-004) so the identical
+ * specs run under Jest and Playwright.
+ *
+ * @param frameworkMapper - The runner adapter (`jestTestAdapter` /
+ *   `playWrightTestFrameworkMapper`) that maps describe/test/assert onto the host
+ *   runner.
+ * @param interaction - Supplies the `TestEngine` under test (and, for e2e, the
+ *   navigation/`setContent` step) — i.e. which interactor the suite exercises.
+ */
+export function defineConformanceSuite(
+  frameworkMapper: TestFrameworkMapper,
+  interaction: InteractionInterface<typeof conformanceScenePart>
+): void {
+  testRunner(interactorConformanceSuites, frameworkMapper, interaction);
+}

--- a/packages/internal-interactor-conformance/src/index.ts
+++ b/packages/internal-interactor-conformance/src/index.ts
@@ -1,0 +1,3 @@
+export { ConformanceProbeDriver, conformanceFixtureHtml, conformanceScenePart } from './conformanceFixture';
+export { interactorConformanceSuite, interactorConformanceSuites } from './conformanceSuites';
+export { defineConformanceSuite } from './defineConformanceSuite';

--- a/packages/internal-interactor-conformance/tsconfig.json
+++ b/packages/internal-interactor-conformance/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "./build"
+  }
+}

--- a/packages/internal-interactor-conformance/tsdown.config.ts
+++ b/packages/internal-interactor-conformance/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsdown';
+
+import commonConfig from '../../tsdown.config.base.ts';
+
+export default defineConfig({
+  ...commonConfig,
+});

--- a/packages/playwright/etc/playwright.api.md
+++ b/packages/playwright/etc/playwright.api.md
@@ -12,7 +12,6 @@ import { EnterTextOption } from '@atomic-testing/core';
 import { FocusOption } from '@atomic-testing/core';
 import { HoverOption } from '@atomic-testing/core';
 import { Interactor } from '@atomic-testing/core';
-import { ITestEngineOption } from '@atomic-testing/core';
 import { MouseDownOption } from '@atomic-testing/core';
 import { MouseEnterOption } from '@atomic-testing/core';
 import { MouseLeaveOption } from '@atomic-testing/core';
@@ -30,7 +29,7 @@ import { WaitForOption } from '@atomic-testing/core';
 import { WaitUntilOption } from '@atomic-testing/core';
 
 // @public
-export function createTestEngine<T extends ScenePart>(page: Page, partDefinitions: T, _option?: ITestEngineOption): TestEngine<T>;
+export function createTestEngine<T extends ScenePart>(page: Page, partDefinitions: T): TestEngine<T>;
 
 // @public
 export class PlaywrightInteractor implements Interactor {

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -27,7 +27,7 @@ import {
   WaitForOption,
   WaitUntilOption,
 } from '@atomic-testing/core';
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 /**
  * Implementation of the {@link Interactor} interface using Playwright.
@@ -66,6 +66,32 @@ export class PlaywrightInteractor implements Interactor {
       }
       throw e;
     }
+  }
+
+  /**
+   * Resolve a locator for the READ path, returning the first matching element or
+   * `undefined` when nothing matches.
+   *
+   * This is the read counterpart to {@link runMutation}, aligning reads with
+   * `DOMInteractor` (jsdom is the contract — see ADR-006, #1047):
+   *
+   * - **Missing element:** a `count()` check answers instantly with `undefined`
+   *   instead of Playwright auto-waiting out the action timeout and throwing
+   *   `TimeoutError`. Callers translate `undefined` into the same
+   *   `undefined`/`false` a `querySelector` miss yields in the DOM.
+   * - **Multiple matches:** `.first()` mirrors `querySelector`'s first-match
+   *   semantics, avoiding Playwright's strict-mode violation.
+   *
+   * @param locator - Locator to resolve
+   * @returns The first matching {@link Locator}, or `undefined` if none match
+   */
+  private async firstMatch(locator: PartLocator): Promise<Optional<Locator>> {
+    const cssLocator = await locatorUtil.toCssSelector(locator, this);
+    const elLocator = this.page.locator(cssLocator);
+    if ((await elLocator.count()) === 0) {
+      return undefined;
+    }
+    return elLocator.first();
   }
 
   /**
@@ -185,14 +211,25 @@ export class PlaywrightInteractor implements Interactor {
   }
 
   /**
-   * Get the value of an `<input>` element.
+   * Get the value of an `<input>` or `<textarea>` element.
+   *
+   * Mirrors `DOMInteractor`: a missing element, or one that is neither `<input>`
+   * nor `<textarea>`, yields `undefined` rather than Playwright's auto-wait
+   * timeout or its "Node is not an <input>" throw (#1047).
    *
    * @param locator - Locator pointing to the input element.
-   * @returns The current value of the input or `undefined` if not present.
+   * @returns The current value of the input, or `undefined` if not applicable.
    */
   async getInputValue(locator: PartLocator): Promise<Optional<string>> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    return this.page.locator(cssLocator).inputValue();
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return undefined;
+    }
+    const nodeName = await el.evaluate(node => node.nodeName);
+    if (nodeName !== 'INPUT' && nodeName !== 'TEXTAREA') {
+      return undefined;
+    }
+    return el.inputValue();
   }
 
   /**
@@ -208,10 +245,12 @@ export class PlaywrightInteractor implements Interactor {
     const allOptions = await this.page.locator(cssLocator).all();
     const values: string[] = [];
     for (const option of allOptions) {
-      const value = await option.getAttribute('value');
-      if (value != null) {
-        values.push(value);
-      }
+      // Read the `value` IDL property, not the `value` attribute: per the HTML
+      // spec the property falls back to the option's text when no value attribute
+      // is present, matching DOMInteractor's `option.value`. Reading the attribute
+      // silently dropped value-less selected options (#1047).
+      const value = await option.evaluate(node => (node as HTMLOptionElement).value);
+      values.push(value);
     }
     return values;
   }
@@ -223,17 +262,19 @@ export class PlaywrightInteractor implements Interactor {
     const allOptions = await this.page.locator(cssLocator).all();
     const labels: string[] = [];
     for (const option of allOptions) {
-      const label = await option.textContent();
-      if (label != null) {
-        labels.push(label);
-      }
+      // Read the `text` IDL property, matching DOMInteractor's `option.text`
+      // (whitespace-collapsed, spec-defined) rather than raw `textContent` (#1047).
+      const label = await option.evaluate(node => (node as HTMLOptionElement).text);
+      labels.push(label);
     }
     return labels;
   }
 
   async getStyleValue(locator: PartLocator, propertyName: CssProperty): Promise<Optional<string>> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const elLocator = this.page.locator(cssLocator);
+    const elLocator = await this.firstMatch(locator);
+    if (elLocator == null) {
+      return undefined;
+    }
     const value = await elLocator.evaluate((element, prop) => {
       // Indexed access, not getPropertyValue: CssProperty is the camelCase
       // keyof CSSStyleDeclaration (e.g. 'pointerEvents'), which
@@ -422,26 +463,34 @@ export class PlaywrightInteractor implements Interactor {
     name: string,
     isMultiple?: boolean
   ): Promise<Optional<string> | readonly string[]> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const elLocator = this.page.locator(cssLocator);
     if (isMultiple) {
-      const locators = await elLocator.all();
+      const cssLocator = await locatorUtil.toCssSelector(locator, this);
+      const locators = await this.page.locator(cssLocator).all();
       const values: string[] = [];
-      for (const locator of locators) {
-        const value = await locator.getAttribute(name);
+      for (const matched of locators) {
+        const value = await matched.getAttribute(name);
         if (value != null) {
           values.push(value);
         }
       }
       return values;
     }
-    const value = await elLocator.getAttribute(name);
+    // Single-element read: mirror DOMInteractor — a missing element yields
+    // `undefined` (no auto-wait) and multiple matches resolve to the first (#1047).
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return undefined;
+    }
+    const value = await el.getAttribute(name);
     return value ?? undefined;
   }
 
   async getText(locator: PartLocator): Promise<Optional<string>> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const text = await this.page.locator(cssLocator).textContent();
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return undefined;
+    }
+    const text = await el.textContent();
     return text ?? undefined;
   }
 
@@ -472,15 +521,19 @@ export class PlaywrightInteractor implements Interactor {
   }
 
   async isChecked(locator: PartLocator): Promise<boolean> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const checked = await this.page.locator(cssLocator).isChecked();
-    return checked;
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return false;
+    }
+    return el.isChecked();
   }
 
   async isDisabled(locator: PartLocator): Promise<boolean> {
-    const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    const isDisabled = await this.page.locator(cssLocator).isDisabled();
-    return isDisabled;
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return false;
+    }
+    return el.isDisabled();
   }
 
   async isReadonly(locator: PartLocator): Promise<boolean> {

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -1,7 +1,6 @@
 import {
   BlurOption,
   BoundingRect,
-  byCssSelector,
   ClickOption,
   CssProperty,
   dateUtil,
@@ -239,35 +238,40 @@ export class PlaywrightInteractor implements Interactor {
    * @returns Array of selected option values or `undefined` when no option is selected.
    */
   async getSelectValues(locator: PartLocator): Promise<Optional<readonly string[]>> {
-    const optionLocator: PartLocator = byCssSelector('option:checked');
-    const selectedOptionLocator = locatorUtil.append(locator, optionLocator);
-    const cssLocator = await locatorUtil.toCssSelector(selectedOptionLocator, this);
-    const allOptions = await this.page.locator(cssLocator).all();
-    const values: string[] = [];
-    for (const option of allOptions) {
-      // Read the `value` IDL property, not the `value` attribute: per the HTML
-      // spec the property falls back to the option's text when no value attribute
-      // is present, matching DOMInteractor's `option.value`. Reading the attribute
-      // silently dropped value-less selected options (#1047).
-      const value = await option.evaluate(node => (node as HTMLOptionElement).value);
-      values.push(value);
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return undefined;
     }
-    return values;
+    const nodeName = await el.evaluate(node => node.nodeName);
+    if (nodeName !== 'SELECT') {
+      // Mirror DOMInteractor: a missing or non-`<select>` element yields
+      // `undefined`, not `[]` — otherwise callers read an absent select as
+      // "present but with no selection" (#1047).
+      return undefined;
+    }
+    // Read the `value` IDL property, not the `value` attribute: per the HTML
+    // spec the property falls back to the option's text when no value attribute
+    // is present, matching DOMInteractor's `option.value`. Reading the attribute
+    // silently dropped value-less selected options (#1047).
+    return el.evaluate(node =>
+      Array.from(node.querySelectorAll<HTMLOptionElement>('option:checked')).map(option => option.value)
+    );
   }
 
   async getSelectLabels(locator: PartLocator): Promise<Optional<readonly string[]>> {
-    const optionLocator: PartLocator = byCssSelector('option:checked');
-    const selectedOptionLocator = locatorUtil.append(locator, optionLocator);
-    const cssLocator = await locatorUtil.toCssSelector(selectedOptionLocator, this);
-    const allOptions = await this.page.locator(cssLocator).all();
-    const labels: string[] = [];
-    for (const option of allOptions) {
-      // Read the `text` IDL property, matching DOMInteractor's `option.text`
-      // (whitespace-collapsed, spec-defined) rather than raw `textContent` (#1047).
-      const label = await option.evaluate(node => (node as HTMLOptionElement).text);
-      labels.push(label);
+    const el = await this.firstMatch(locator);
+    if (el == null) {
+      return undefined;
     }
-    return labels;
+    const nodeName = await el.evaluate(node => node.nodeName);
+    if (nodeName !== 'SELECT') {
+      return undefined;
+    }
+    // Read the `text` IDL property, matching DOMInteractor's `option.text`
+    // (whitespace-collapsed, spec-defined) rather than raw `textContent` (#1047).
+    return el.evaluate(node =>
+      Array.from(node.querySelectorAll<HTMLOptionElement>('option:checked')).map(option => option.text)
+    );
   }
 
   async getStyleValue(locator: PartLocator, propertyName: CssProperty): Promise<Optional<string>> {

--- a/packages/playwright/src/createTestEngine.ts
+++ b/packages/playwright/src/createTestEngine.ts
@@ -1,4 +1,4 @@
-import { ITestEngineOption, ScenePart, TestEngine } from '@atomic-testing/core';
+import { ScenePart, TestEngine } from '@atomic-testing/core';
 import { Page } from '@playwright/test';
 
 import { PlaywrightInteractor } from './PlaywrightInteractor';
@@ -9,16 +9,9 @@ import { PlaywrightInteractor } from './PlaywrightInteractor';
  * @param page - Playwright page used for interaction.
  * @param partDefinitions - Scene part definitions describing the scene
  *   structure for the engine.
- * @param _option - Reserved for entry-point symmetry with the other adapters;
- *   currently ignored. `rootElement` is not applicable to Playwright, which drives
- *   a real browser page rather than mounting into a host element.
  * @returns A configured {@link TestEngine} ready for use.
  */
-export function createTestEngine<T extends ScenePart>(
-  page: Page,
-  partDefinitions: T,
-  _option?: ITestEngineOption
-): TestEngine<T> {
+export function createTestEngine<T extends ScenePart>(page: Page, partDefinitions: T): TestEngine<T> {
   const engine = new TestEngine([], new PlaywrightInteractor(page), {
     parts: partDefinitions,
   });

--- a/packages/vue-3/src/createTestEngine.ts
+++ b/packages/vue-3/src/createTestEngine.ts
@@ -1,6 +1,6 @@
 import { byAttribute, ScenePart, TestEngine } from '@atomic-testing/core';
 import { render } from '@testing-library/vue';
-import { App, Component, createApp, defineComponent } from 'vue';
+import { Component, createApp, defineComponent } from 'vue';
 
 import { VueSFCLikeComponent, VueTestEngineOption } from './types';
 import { VueInteractor } from './VueInteractor';
@@ -16,6 +16,22 @@ function isSFCLikeObject(component: any): component is VueSFCLikeComponent {
   return (
     component && typeof component === 'object' && 'template' in component && typeof component.template === 'string'
   );
+}
+
+/**
+ * Detect the single Vue-Test-Utils quirk the manual-mount fallback exists for:
+ * `@testing-library/vue`'s `render` delegates to `@vue/test-utils`' `mount`,
+ * which is a peer dependency not present in every environment (it is absent from
+ * this workspace). When it is missing, `render` throws
+ * `TypeError: ...mount... is not a function`.
+ *
+ * Only that quirk warrants the fallback; every other error from `render` is a
+ * genuine failure in the component under test and must propagate with its
+ * original stack rather than be masked by the fallback's different cleanup
+ * semantics (#1049).
+ */
+function isVueTestUtilsMountUnavailable(error: unknown): boolean {
+  return error instanceof TypeError && error.message.includes('mount') && error.message.includes('is not a function');
 }
 
 function createComponentFromSFCLike(sfcObj: VueSFCLikeComponent): Component {
@@ -57,9 +73,6 @@ export function createTestEngine<T extends ScenePart>(
   const rootId = getNextRootElementId();
   container.setAttribute(rootElementAttributeName, rootId);
 
-  let unmount: () => void;
-  let app: App;
-
   // Create component from SFC-like object if needed
   const compiledComponent = isSFCLikeObject(component)
     ? createComponentFromSFCLike(component)
@@ -67,6 +80,7 @@ export function createTestEngine<T extends ScenePart>(
 
   const plugins = option?.plugins ?? [];
 
+  let unmount: () => void;
   try {
     const renderResult = render(compiledComponent, {
       container,
@@ -83,9 +97,15 @@ export function createTestEngine<T extends ScenePart>(
       },
     });
     unmount = renderResult.unmount;
-  } catch (_error) {
-    // Fallback to manual Vue app creation if render fails
-    app = createApp(compiledComponent);
+  } catch (error) {
+    // Narrowly scoped fallback: only the missing-`@vue/test-utils` quirk (see
+    // isVueTestUtilsMountUnavailable) is handled by mounting the app directly.
+    // Any other error is a real render failure and is rethrown so its stack
+    // surfaces instead of being swallowed (#1049).
+    if (!isVueTestUtilsMountUnavailable(error)) {
+      throw error;
+    }
+    const app = createApp(compiledComponent);
     for (const plugin of plugins) {
       if (Array.isArray(plugin)) {
         const [pluginInstance, ...pluginOptions] = plugin;
@@ -95,11 +115,7 @@ export function createTestEngine<T extends ScenePart>(
       }
     }
     app.mount(container);
-    unmount = () => {
-      if (app) {
-        app.unmount();
-      }
-    };
+    unmount = () => app.unmount();
   }
 
   const cleanup = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1059,6 +1059,30 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
 
+  package-tests/internal-interactor-conformance-test:
+    devDependencies:
+      '@atomic-testing/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@atomic-testing/dom-core':
+        specifier: workspace:*
+        version: link:../../packages/dom-core
+      '@atomic-testing/internal-interactor-conformance':
+        specifier: workspace:*
+        version: link:../../packages/internal-interactor-conformance
+      '@atomic-testing/internal-test-runner':
+        specifier: workspace:*
+        version: link:../../packages/internal-test-runner
+      '@atomic-testing/internal-test-runner-jest-adapter':
+        specifier: workspace:*
+        version: link:../../packages/internal-test-runner-jest-adapter
+      '@atomic-testing/internal-test-runner-playwright-adapter':
+        specifier: workspace:*
+        version: link:../../packages/internal-test-runner-playwright-adapter
+      '@atomic-testing/playwright':
+        specifier: workspace:*
+        version: link:../../packages/playwright
+
   package-tests/storybook-test:
     devDependencies:
       '@atomic-testing/component-driver-html':
@@ -1621,6 +1645,15 @@ importers:
       '@testing-library/user-event':
         specifier: '>=14.0.0'
         version: 14.6.1(@testing-library/dom@10.4.1)
+
+  packages/internal-interactor-conformance:
+    dependencies:
+      '@atomic-testing/core':
+        specifier: workspace:*
+        version: link:../core
+      '@atomic-testing/internal-test-runner':
+        specifier: workspace:*
+        version: link:../internal-test-runner
 
   packages/internal-mui-x-test-fixture: {}
 


### PR DESCRIPTION
## Summary

This PR fixes four critical read-path defects in `PlaywrightInteractor` (#1047) and narrows low-level primitives on `ComponentDriver` to `protected` for the 1.0 API freeze (ADR-015, #1045).

### Read-Path Fixes (#1047)

`PlaywrightInteractor` now conforms to jsdom semantics (the contract per ADR-006):

1. **Missing element reads** — `getText`, `getAttribute`, `getInputValue`, and boolean state reads (`isChecked`, `isDisabled`, etc.) now return `undefined`/`false` instantly instead of auto-waiting to timeout. Implemented via new `firstMatch()` helper that checks element count before resolving.

2. **Multiple matches** — Locators matching multiple elements now resolve to the first match (like `querySelector`), avoiding Playwright's strict-mode violation.

3. **Non-input element reads** — `getInputValue` on a non-`<input>`/`<textarea>` element returns `undefined` instead of throwing Playwright's "Node is not an <input>" error.

4. **Value-less `<option>` elements** — `getSelectValues` and `getSelectLabels` now read the IDL properties (`value`, `text`) instead of attributes, so selected options without a `value` attribute fall back to their text content per HTML spec.

### ComponentDriver Primitives Narrowed to `protected` (ADR-015)

Raw low-level gestures (`mouseDown`, `mouseUp`, `mouseMove`, `mouseOver`, `mouseOut`, `mouseEnter`, `mouseLeave`, `contextMenu`, `activate`, `scrollBy`, `dragTo`, `drag`, `getBoundingRect`, `innerHTML`) are now `protected`. Only semantic actions (`click`, `hover`, `focus`, `pressKey`, `scrollIntoView`) and reads remain public.

Concrete drivers and test suites now call these primitives through the interactor: `this.interactor.<primitive>(this.parts.<child>.locator, …)`.

### New Interactor Conformance Suite (TCK)

Added `@atomic-testing/internal-interactor-conformance` — a framework-agnostic test suite proving every interactor honors the jsdom contract. The same specs run under Jest (DOMInteractor) and Playwright (PlaywrightInteractor), encoding the four #1047 fixes plus error-hierarchy conformance (ADR-010).

### Error Hierarchy (ADR-010)

- New `LocatorResolutionError` for unresolvable linked locators (#1051), completing the interactor-level error hierarchy.
- Both `ElementNotFoundError` and `LocatorResolutionError` extend `InteractorErrorBase` for consistent cross-environment catching.

### Utility Improvements

- `locatorUtil.toCssSelector` now returns `:root` (not `''`) for empty locator chains, fixing a CSS parse error in both jsdom and Chromium (#1048).
- Added `locatorUtil.test.ts` covering edge cases (empty chains, single locators, descendant chains, same-level locators).

### Documentation

- ADR-015 documents the narrowing rationale and asymmetric reversibility (widening is non-breaking; narrowing is breaking).
- Updated `core.api.md` to reflect `protected` visibility.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (core, dom-core, playwright, internal-interactor-conformance-test)
- [x] `pnpm test:e2e` (internal-interactor-conformance-test, component-driver-html-test, all three browsers)

## Breaking change

- [x] This PR introduces a breaking change (title uses `!`)

**Breaking:** `ComponentDriver`'s raw pointer/keyboard primitives are now `protected`. External callers invoking them directly on driver instances must migrate to calling the interactor with the driver's locator.

https://claude.ai/code/session_01L8Bs93NgWVvELarNCB1JgF