### PR TITLE
fix(docs): unbreak the API docs build broken by a bare HTML tag in TSDoc

### DIFF
--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      # The API docs are generated from package source TSDoc (TypeDoc), so a
+      # source-only change can break the docs build. Verify it on those PRs too,
+      # not just docs/** edits — otherwise the break only surfaces post-merge on
+      # deploy (see the bare-<input> MDX failure that motivated this).
+      - 'packages/**'
+      - '.github/workflows/doc-ci.yml'
 
 jobs:
   deploy:

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -214,7 +214,7 @@ export class PlaywrightInteractor implements Interactor {
    *
    * Mirrors `DOMInteractor`: a missing element, or one that is neither `<input>`
    * nor `<textarea>`, yields `undefined` rather than Playwright's auto-wait
-   * timeout or its "Node is not an <input>" throw (#1047).
+   * timeout or its `Node is not an <input>` throw (#1047).
    *
    * @param locator - Locator pointing to the input element.
    * @returns The current value of the input, or `undefined` if not applicable.


### PR DESCRIPTION
## Summary

After #1082 was squash-merged, the **Deploy to GitHub Pages** workflow failed at the *Build documentation* step ([run](https://github.com/atomic-testing/atomic-testing/actions/runs/28912243807/job/85771862264)):

> MDX compilation failed for `docs/docs/api/@atomic-testing/playwright/classes/PlaywrightInteractor.md` — Expected a closing tag for `<input>` before the end of `paragraph`.

**Root cause.** `getInputValue`'s TSDoc (added in #1047) contained a non-backticked HTML tag inside a quoted phrase (`"Node is not an <input>"`). TypeDoc renders it into the generated API markdown, where Docusaurus MDX parses the tag as JSX and fails. Two gaps let it reach `main`:
- The docs build is not part of the PR verification workflow (`buildui.yml`).
- Documentation CI (`doc-ci.yml`) only triggered on `docs/**` — but the API docs are generated from **package source** TSDoc, so a source-only change was never docs-verified on the PR.

**This PR**
- **`fix(playwright)`** — wraps the phrase in a code span, matching the `` `<input>` `` / `` `<textarea>` `` mentions in the same comment. Comment-only; no behavior or API change.
- **`ci`** — adds `packages/**` (and the workflow itself) to Documentation CI's path trigger, so a docs-breaking source change is caught on the PR instead of post-merge.

**Verified.** Full local `docs` build (`pnpm install . && pnpm build` in `docs/`) now **succeeds** — the exact step that failed on deploy. Swept the rest of the changed source for other bare tags; the remaining matches are all `//` line comments (which TypeDoc ignores) or existing code spans.

## Checks

- [x] `pnpm run check:type` (playwright; change is a TSDoc comment + workflow YAML)
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] Full `docs` build succeeds locally — the failing deploy step
- [ ] `pnpm test:dom` / `pnpm test:e2e` — n/a, no runtime change

## Breaking change

- [ ] This PR introduces a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Bs93NgWVvELarNCB1JgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Bs93NgWVvELarNCB1JgF)_