### PR TITLE
feat(mui-x-v9): picker/DataGrid/chart drivers on a new typeText keystroke primitive (#903, #904)

### DIFF
--- a/.claude/skills/backfill-driver-feature/SKILL.md
+++ b/.claude/skills/backfill-driver-feature/SKILL.md
@@ -133,6 +133,12 @@ selector, not the full chain.
   sliders) do you touch the `Interactor` interface — then you must implement it in
   **every** interactor (DOM/React/Vue/Playwright) and prove it via the HTML driver
   - `component-driver-html-test`. This is the expensive path; avoid if a locator works.
+- **Changing an existing primitive's behavior is riskier than adding one** — it
+  silently re-routes every driver that already calls it, not just the one you're
+  motivated by (a picker-motivated `pressKey` tweak broke Angular Material
+  `MatSelect`/`MatAutocomplete`). Grep all call sites, **gate the new behavior to the
+  specific case that needs it** rather than changing the default path, and add the
+  affected consumer packages to Phase 5.
 
 ## Phase 4 — Tests (shared suite, runs in both worlds)
 
@@ -144,6 +150,14 @@ with no label → `undefined`). The suite feeds both `.dom.test.ts` and `.e2e.te
 automatically — no per-adapter edits.
 
 ## Phase 5 — Verify (the non-negotiable part)
+
+**If you changed a shared `Interactor`/`DOMInteractor` primitive** (not just added a
+driver method), verification is not just this package: run the **full** suites — never
+a name-filtered subset (`vitest run Foo` skips the sibling `Bar` suite in the same
+package) — of **every** consumer package, **each per-major variant** (`-v20/21/22`,
+`-x-v6/7/8/9` are separate CI jobs), including the browser-mode Angular Material suites
+(`CHROMIUM_EXECUTABLE=/opt/pw-browsers/chromium npx vitest run`). "Green in the package
+I edited" is not "green in CI."
 
 **DOM (jsdom) — rebuild first.** Jest resolves workspace deps from **built
 `dist/`** (`jest.config.base.js` `moduleNameMapper` → `dist/index.cjs`), so source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,32 @@ trusting any dom/e2e result. (`tsgo` also reads the stale `.d.ts`, so cross-pack
 typecheck errors that name newly-added exports usually just mean "rebuild," not a
 real bug.)
 
+**Shared-primitive blast radius (re-verify consumers, not just what you touched):**
+a change to a method on `Interactor` / `DOMInteractor` — or any base every driver
+inherits — changes behavior for **every** consumer, not the driver that motivated it.
+A picker-motivated tweak to `pressKey` (routing focused presses through
+`userEvent.keyboard` for input-event fidelity) silently broke Angular Material
+`MatSelect` (open-on-`Enter`) and `MatAutocomplete` (close-on-`Escape`), because
+`userEvent.keyboard` delivers to `document.activeElement` where those handlers expect
+a direct `fireEvent.keyDown`. Before trusting such a change:
+
+- **Grep every call site** across `packages/` and reason about each — the caller you
+  are _not_ looking at is the one that breaks. Prefer to **gate the new behavior to
+  exactly the case that needs it** (a condition on the target, an opt-in option) over
+  changing the default path for existing callers.
+- **Run the full suites of the affected consumer packages**, not just the one you
+  edited. A name-filtered run (`jest Foo`, `vitest run Foo`) verifies a _subset_ — a
+  `MatAutocomplete` break sat in the same package whose `Select` suite was green.
+  **Per-major variants** (`-v20`/`-v21`/`-v22`, `-x-v6/7/8/9`) are **separate CI jobs**;
+  verifying one is not verifying the rest.
+- Angular Material suites are **browser-mode** and runnable locally —
+  `CHROMIUM_EXECUTABLE=/opt/pw-browsers/chromium npx vitest run` — so there's no excuse
+  for letting CI be the first place they run.
+- When a **rebase auto-merges an interactor override** onto an evolved base, a clean
+  merge can still be stale-patterned (a `typeText` override kept plain `act()` after
+  main moved to `runUserEvent`); reconcile overrides against their current sibling
+  methods.
+
 ### Running E2E Tests
 
 E2E tests require the dev server (rebuild the driver packages first — see the

--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -536,7 +536,7 @@ pnpm add @atomic-testing/component-driver-mui-x-v9
 
 | Driver                         | Description                                                                                     |
 | ------------------------------ | ----------------------------------------------------------------------------------------------- |
-| DataGridPremiumDriver          | Driver for DataGrid / DataGridPro / DataGridPremium (reads, sorting, filtering, selection, editing, pagination) |
+| DataGridPremiumDriver          | Driver for DataGrid / DataGridPro / DataGridPremium (reads, sorting, filtering, selection, editing, pagination, column pinning/resizing, row grouping & aggregation) |
 | DataGridHeaderRowDriver        | Driver for header rows in DataGrid                                                               |
 | DataGridDataRowDriver          | Driver for data rows in DataGrid                                                                 |
 | DesktopDatePickerDriver        | Driver for DesktopDatePicker (reads + keystroke/calendar writes on the v9 section field)         |
@@ -548,6 +548,7 @@ pnpm add @atomic-testing/component-driver-mui-x-v9
 | BarChartDriver                 | Driver for BarChart (legend/axis/data-point reads, hover + tooltip)                              |
 | LineChartDriver                | Driver for LineChart (legend/axis/mark reads, hover + tooltip)                                  |
 | PieChartDriver                 | Driver for PieChart (legend/slice reads, hover + tooltip)                                        |
+| ScatterChartDriver             | Driver for ScatterChart (legend/axis/marker reads, hover + tooltip)                              |
 | SimpleTreeViewDriver           | Driver for SimpleTreeView / RichTreeView (expand/collapse, read)                                 |
 
 </details>

--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -534,13 +534,21 @@ pnpm add @atomic-testing/component-driver-mui-x-v9
 </TabItem>
 </Tabs>
 
-| Driver                  | Description                                                      |
-| ----------------------- | ---------------------------------------------------------------- |
-| DataGridPremiumDriver   | Driver for DataGrid / DataGridPro / DataGridPremium component    |
-| DataGridHeaderRowDriver | Driver for header rows in DataGrid                               |
-| DataGridDataRowDriver   | Driver for data rows in DataGrid                                 |
-| DesktopDatePickerDriver | Read-capable driver for DesktopDatePicker (v9 section field)     |
-| SimpleTreeViewDriver    | Driver for SimpleTreeView / RichTreeView (expand/collapse, read) |
+| Driver                         | Description                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| DataGridPremiumDriver          | Driver for DataGrid / DataGridPro / DataGridPremium (reads, sorting, filtering, selection, editing, pagination) |
+| DataGridHeaderRowDriver        | Driver for header rows in DataGrid                                                               |
+| DataGridDataRowDriver          | Driver for data rows in DataGrid                                                                 |
+| DesktopDatePickerDriver        | Driver for DesktopDatePicker (reads + keystroke/calendar writes on the v9 section field)         |
+| DateTimePickerDriver           | Driver for the desktop DateTimePicker (keystroke writes incl. meridiem)                          |
+| TimePickerDriver               | Driver for the desktop TimePicker (keystroke writes incl. meridiem)                              |
+| MobileDatePickerDriver         | Driver for MobileDatePicker (writes through the modal entry dialog)                              |
+| MobileDatePickerDialogDriver   | Driver for the mobile picker's entry dialog (pick day, accept/cancel)                            |
+| DateRangePickerDriver          | Driver for the Pro DateRangePicker's single-input range field                                    |
+| BarChartDriver                 | Driver for BarChart (legend/axis/data-point reads, hover + tooltip)                              |
+| LineChartDriver                | Driver for LineChart (legend/axis/mark reads, hover + tooltip)                                  |
+| PieChartDriver                 | Driver for PieChart (legend/slice reads, hover + tooltip)                                        |
+| SimpleTreeViewDriver           | Driver for SimpleTreeView / RichTreeView (expand/collapse, read)                                 |
 
 </details>
 

--- a/docs/docs/guides/testing-in-storybook.md
+++ b/docs/docs/guides/testing-in-storybook.md
@@ -126,8 +126,10 @@ lives in this repo at `package-tests/storybook-test`.
 ## Limitations
 
 - Driver interactions backed by raw event dispatch rather than `userEvent` —
-  positional clicks, `pressKey`, mouse-move sequences, `drag`/`dragTo` — still
-  work, but are not recorded in the Interactions panel.
+  positional clicks, mouse-move sequences, `drag`/`dragTo`, and `pressKey`
+  against a target that cannot hold focus — still work, but are not recorded
+  in the Interactions panel. (`pressKey` on a focusable target and `typeText`
+  dispatch through `userEvent`, so they are recorded.)
 - Running stories in **jsdom** via `composeStories()` is a different
   environment (it sets `IS_REACT_ACT_ENVIRONMENT`, so the act-free design does
   not transfer) and is not covered by this package. Use the framework adapters

--- a/package-tests/component-driver-html-test/__tests__/TypeText.dom.test.ts
+++ b/package-tests/component-driver-html-test/__tests__/TypeText.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { typeTextExample, typeTextExampleTestSuite } from '../src/examples';
+
+testRunner(typeTextExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof typeTextExample.scene) => {
+    return createTestEngine(typeTextExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-html-test/__tests__/TypeText.e2e.test.ts
+++ b/package-tests/component-driver-html-test/__tests__/TypeText.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { typeTextExampleTestSuite } from '../src/examples';
+
+testRunner(typeTextExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-html-test/src/directory.tsx
+++ b/package-tests/component-driver-html-test/src/directory.tsx
@@ -23,6 +23,7 @@ import { rangeInputUIExample } from './examples/rangeInput/RangeInput.examples';
 import { scrollUIExample } from './examples/scroll/Scroll.examples';
 import { multipleSelectUIExample } from './examples/select/MultipleSelect.examples';
 import { singleSelectUIExample } from './examples/select/SingleSelect.examples';
+import { typeTextUIExample } from './examples/typeText/TypeText.examples';
 
 export const tocs: ExampleToc[] = [
   {
@@ -63,6 +64,11 @@ export const tocs: ExampleToc[] = [
     label: 'Keyboard Event',
     path: '/keyboard-event',
     ui: <ExampleList examples={[keyboardEventUIExample]} />,
+  },
+  {
+    label: 'Type Text',
+    path: '/type-text',
+    ui: <ExampleList examples={[typeTextUIExample]} />,
   },
   {
     label: 'By Role',

--- a/package-tests/component-driver-html-test/src/examples/index.ts
+++ b/package-tests/component-driver-html-test/src/examples/index.ts
@@ -13,5 +13,6 @@ export * from './radioButtonGroup';
 export * from './rangeInput';
 export * from './scroll';
 export * from './select';
+export * from './typeText';
 export * from './anchor';
 export * from './byRole';

--- a/package-tests/component-driver-html-test/src/examples/typeText/TypeText.examples.tsx
+++ b/package-tests/component-driver-html-test/src/examples/typeText/TypeText.examples.tsx
@@ -1,0 +1,51 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX, useCallback } from 'react';
+
+export const TypeTextExample = () => {
+  const [keydownCount, setKeydownCount] = React.useState<number>(0);
+  const [editableText, setEditableText] = React.useState<string>('');
+  const [editableInputEventCount, setEditableInputEventCount] = React.useState<number>(0);
+
+  const onInputKeyDown = useCallback(() => setKeydownCount(count => count + 1), []);
+
+  const onEditableInput = useCallback((event: React.FormEvent<HTMLDivElement>) => {
+    setEditableText(event.currentTarget.textContent ?? '');
+    setEditableInputEventCount(count => count + 1);
+  }, []);
+
+  return (
+    <React.Fragment>
+      <div>
+        <input data-testid='type-target' onKeyDown={onInputKeyDown} />
+      </div>
+      {/* Counts keydowns on the input so a test can assert typeText dispatched
+          exactly one keystroke per character — the property enterText's
+          value-fill path does not have. */}
+      <div data-testid='type-keydown-count'>{keydownCount}</div>
+      {/* A keystroke-driven editor: contenteditable has no `value` to fill, so
+          its committed text only changes through real key/input events — the
+          gap typeText exists to close. The explicit size keeps the empty
+          element visible so the browser engine will focus and type into it,
+          and tabIndex makes it focusable under jsdom, which does not treat a
+          bare contenteditable as a focusable area (real editors — e.g. the MUI
+          picker section spans — carry a tabindex for the same reason). */}
+      <div
+        data-testid='editable-target'
+        contentEditable
+        suppressContentEditableWarning
+        tabIndex={0}
+        onInput={onEditableInput}
+        style={{ minHeight: 24, width: 200, border: '1px solid #999' }}
+      />
+      {/* Mirrors the contenteditable text out of React state, proving the typed
+          characters arrived as input events the component could observe. */}
+      <div data-testid='editable-mirror'>{editableText}</div>
+      <div data-testid='editable-input-count'>{editableInputEventCount}</div>
+    </React.Fragment>
+  );
+};
+
+export const typeTextUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Type text',
+  ui: <TypeTextExample />,
+};

--- a/package-tests/component-driver-html-test/src/examples/typeText/TypeText.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/typeText/TypeText.suite.ts
@@ -1,0 +1,83 @@
+import { HTMLElementDriver, HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { typeTextUIExample } from './TypeText.examples';
+
+export const typeTextExampleScenePart = {
+  target: {
+    locator: byDataTestId('type-target'),
+    driver: HTMLTextInputDriver,
+  },
+  keydownCount: {
+    locator: byDataTestId('type-keydown-count'),
+    driver: HTMLElementDriver,
+  },
+  editable: {
+    locator: byDataTestId('editable-target'),
+    driver: HTMLElementDriver,
+  },
+  editableMirror: {
+    locator: byDataTestId('editable-mirror'),
+    driver: HTMLElementDriver,
+  },
+  editableInputCount: {
+    locator: byDataTestId('editable-input-count'),
+    driver: HTMLElementDriver,
+  },
+} satisfies ScenePart;
+
+export const typeTextExample: IExampleUnit<typeof typeTextExampleScenePart, JSX.Element> = {
+  ...typeTextUIExample,
+  scene: typeTextExampleScenePart,
+};
+
+export const typeTextExampleTestSuite: TestSuiteInfo<typeof typeTextExample.scene> = {
+  title: 'Type Text: typeText',
+  url: '/type-text',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual }) => {
+    describe(`${typeTextExample.title}`, () => {
+      const engine = useTestEngine(typeTextExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`typeText types every character into an empty input`, async () => {
+        await engine().parts.target.typeText('hello');
+        assertEqual(await engine().parts.target.getValue(), 'hello');
+      });
+
+      test(`each character arrives as its own keystroke`, async () => {
+        await engine().parts.target.typeText('hello');
+        assertEqual(await engine().parts.keydownCount.getText(), '5');
+      });
+
+      test(`sequential typeText calls append instead of replacing`, async () => {
+        await engine().parts.target.typeText('ab');
+        await engine().parts.target.typeText('cd');
+        assertEqual(await engine().parts.target.getValue(), 'abcd');
+      });
+
+      // Braces/brackets are descriptor syntax in the jsdom path's user-event
+      // dispatcher; this pins that both engines type them literally.
+      test(`braces and brackets are typed literally`, async () => {
+        await engine().parts.target.typeText('{a}[b]');
+        assertEqual(await engine().parts.target.getValue(), '{a}[b]');
+        assertEqual(await engine().parts.keydownCount.getText(), '6');
+      });
+
+      // The reason this primitive exists: a contenteditable editor has no value
+      // to fill, so only real per-character key/input events can change what
+      // the component observes (cf. the MUI X picker section field, #903).
+      test(`typeText drives a contenteditable editor through real input events`, async () => {
+        await engine().parts.editable.typeText('abc');
+        assertEqual(await engine().parts.editableMirror.getText(), 'abc');
+        assertEqual(await engine().parts.editableInputCount.getText(), '3');
+      });
+
+      test(`typeText with an empty string focuses but types nothing`, async () => {
+        await engine().parts.target.typeText('');
+        assertEqual(await engine().parts.target.getValue(), '');
+        assertEqual(await engine().parts.keydownCount.getText(), '0');
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-html-test/src/examples/typeText/index.ts
+++ b/package-tests/component-driver-html-test/src/examples/typeText/index.ts
@@ -1,0 +1,8 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { typeTextExample, typeTextExampleTestSuite } from './TypeText.suite';
+
+export { typeTextExample, typeTextExampleTestSuite };
+
+export const typeTextExamples = [typeTextExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/ChartInteraction.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/ChartInteraction.e2e.test.ts
@@ -1,0 +1,12 @@
+// E2E-only on purpose: chart hover/tooltip behavior needs a real layout engine, so this suite
+// has no .dom.test.ts counterpart — the documented exception for the e2e-primary chart family
+// (see #904 and the chart shims note in jest.setup.js).
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { chartInteractionTestSuite } from '../src/examples';
+
+testRunner(chartInteractionTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/Charts.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/Charts.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { chartsExample, chartsTestSuite } from '../src/examples';
+
+testRunner(chartsTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof chartsExample.scene) => {
+    return createTestEngine(chartsExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/Charts.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/Charts.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { chartsTestSuite } from '../src/examples';
+
+testRunner(chartsTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DateRangePicker.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DateRangePicker.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { dateRangePickerExample, dateRangePickerTestSuite } from '../src/examples';
+
+testRunner(dateRangePickerTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof dateRangePickerExample.scene) => {
+    return createTestEngine(dateRangePickerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DateRangePicker.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DateRangePicker.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { dateRangePickerTestSuite } from '../src/examples';
+
+testRunner(dateRangePickerTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DateTimePicker.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DateTimePicker.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { dateTimePickerExample, dateTimePickerTestSuite } from '../src/examples';
+
+testRunner(dateTimePickerTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof dateTimePickerExample.scene) => {
+    return createTestEngine(dateTimePickerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/DateTimePicker.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/DateTimePicker.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { dateTimePickerTestSuite } from '../src/examples';
+
+testRunner(dateTimePickerTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/GroupedDataGridPremium.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/GroupedDataGridPremium.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { groupedDataGridPremiumExample, groupedDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(groupedDataGridPremiumTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof groupedDataGridPremiumExample.scene) => {
+    return createTestEngine(groupedDataGridPremiumExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/GroupedDataGridPremium.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/GroupedDataGridPremium.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { groupedDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(groupedDataGridPremiumTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/InteractiveDataGrid.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/InteractiveDataGrid.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { interactiveDataGridPremiumExample, interactiveDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(interactiveDataGridPremiumTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof interactiveDataGridPremiumExample.scene) => {
+    return createTestEngine(interactiveDataGridPremiumExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/InteractiveDataGrid.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/InteractiveDataGrid.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { interactiveDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(interactiveDataGridPremiumTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/MobileDatePicker.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/MobileDatePicker.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { mobileDatePickerExample, mobileDatePickerTestSuite } from '../src/examples';
+
+testRunner(mobileDatePickerTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof mobileDatePickerExample.scene) => {
+    return createTestEngine(mobileDatePickerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/MobileDatePicker.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/MobileDatePicker.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { mobileDatePickerTestSuite } from '../src/examples';
+
+testRunner(mobileDatePickerTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/TimePicker.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/TimePicker.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { timePickerExample, timePickerTestSuite } from '../src/examples';
+
+testRunner(timePickerTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof timePickerExample.scene) => {
+    return createTestEngine(timePickerExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/TimePicker.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/TimePicker.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { timePickerTestSuite } from '../src/examples';
+
+testRunner(timePickerTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/jest.setup.js
+++ b/package-tests/component-driver-mui-x-v9-test/jest.setup.js
@@ -3,6 +3,37 @@
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;
 
+// ---- @mui/x-charts jsdom shims (see #904) ----
+// Charts are e2e-primary: geometry (hover targets, tooltip positioning, text
+// measurement) needs a real layout engine. These shims only make the charts
+// RENDER under jsdom so the structural reads (legend, axis labels, data-point
+// counts) stay portable; anything geometric is asserted e2e-only.
+
+// jest's jsdom environment does not expose Node's structuredClone global,
+// which @mui/x-charts calls while initializing its store. v8 serialization
+// covers the same structured-clone semantics.
+if (typeof global.structuredClone !== 'function') {
+  const v8 = require('v8');
+  global.structuredClone = value => v8.deserialize(v8.serialize(value));
+}
+
+// jsdom has no ResizeObserver; charts observe their container to size the
+// drawing area. The example charts pass explicit width/height, so a silent
+// no-op observer suffices.
+if (typeof global.ResizeObserver !== 'function') {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// jsdom's SVG elements lack getBBox (charts measure axis/legend text with it).
+// A zero-rect keeps rendering alive; real measurements are e2e-only.
+if (typeof SVGElement !== 'undefined' && typeof SVGElement.prototype.getBBox !== 'function') {
+  SVGElement.prototype.getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 });
+}
+
 // Capture the real console.error BEFORE spying so the mock can delegate to it.
 // Calling the spied `console.error` from inside the mock would recurse infinitely.
 const originalConsoleError = console.error;

--- a/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
@@ -2,6 +2,7 @@ import { ExampleList, ExampleToc } from '@atomic-testing/internal-react-example'
 
 import { basicChartsUIExample } from './examples/charts/Charts.examples';
 import { basicDataGridPremiumUIExample } from './examples/datagridpremium/BasicDataGridPremium.examples';
+import { groupedDataGridPremiumUIExample } from './examples/datagridpremium/GroupedDataGridPremium.examples';
 import { interactiveDataGridPremiumUIExample } from './examples/datagridpremium/InteractiveDataGridPremium.examples';
 import { basicDateRangePickerUIExample } from './examples/datepicker/DateRangePicker.examples';
 import { basicDateTimePickerUIExample } from './examples/datepicker/DateTimePicker.examples';
@@ -25,6 +26,11 @@ export const tocs: ExampleToc[] = [
     label: 'Interactive DataGrid Premium',
     path: '/datagridinteractive',
     ui: <ExampleList examples={[interactiveDataGridPremiumUIExample]} />,
+  },
+  {
+    label: 'Grouped DataGrid Premium',
+    path: '/datagridgrouped',
+    ui: <ExampleList examples={[groupedDataGridPremiumUIExample]} />,
   },
   {
     label: 'Desktop Date Picker',

--- a/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
@@ -1,19 +1,55 @@
 import { ExampleList, ExampleToc } from '@atomic-testing/internal-react-example';
 
+import { basicChartsUIExample } from './examples/charts/Charts.examples';
 import { basicDataGridPremiumUIExample } from './examples/datagridpremium/BasicDataGridPremium.examples';
+import { interactiveDataGridPremiumUIExample } from './examples/datagridpremium/InteractiveDataGridPremium.examples';
+import { basicDateRangePickerUIExample } from './examples/datepicker/DateRangePicker.examples';
+import { basicDateTimePickerUIExample } from './examples/datepicker/DateTimePicker.examples';
 import { basicDesktopDatePickerUIExample } from './examples/datepicker/DesktopDatePicker.examples';
+import { basicMobileDatePickerUIExample } from './examples/datepicker/MobileDatePicker.examples';
+import { basicTimePickerUIExample } from './examples/datepicker/TimePicker.examples';
 import { basicSimpleTreeViewUIExample } from './examples/treeview/SimpleTreeView.examples';
 
 export const tocs: ExampleToc[] = [
+  {
+    label: 'Charts',
+    path: '/charts',
+    ui: <ExampleList examples={[basicChartsUIExample]} />,
+  },
   {
     label: 'DataGrid Premium',
     path: '/datagridpremium',
     ui: <ExampleList examples={[basicDataGridPremiumUIExample]} />,
   },
   {
+    label: 'Interactive DataGrid Premium',
+    path: '/datagridinteractive',
+    ui: <ExampleList examples={[interactiveDataGridPremiumUIExample]} />,
+  },
+  {
     label: 'Desktop Date Picker',
     path: '/datepicker',
     ui: <ExampleList examples={[basicDesktopDatePickerUIExample]} />,
+  },
+  {
+    label: 'Date Time Picker',
+    path: '/datetimepicker',
+    ui: <ExampleList examples={[basicDateTimePickerUIExample]} />,
+  },
+  {
+    label: 'Time Picker',
+    path: '/timepicker',
+    ui: <ExampleList examples={[basicTimePickerUIExample]} />,
+  },
+  {
+    label: 'Mobile Date Picker',
+    path: '/mobiledatepicker',
+    ui: <ExampleList examples={[basicMobileDatePickerUIExample]} />,
+  },
+  {
+    label: 'Date Range Picker',
+    path: '/daterangepicker',
+    ui: <ExampleList examples={[basicDateRangePickerUIExample]} />,
   },
   {
     label: 'Simple Tree View',

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/ChartInteraction.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/ChartInteraction.suite.ts
@@ -46,6 +46,13 @@ export const chartInteractionTestSuite: TestSuiteInfo<typeof chartsExample.scene
       assertTrue(text!.includes('20'));
     });
 
+    test('hovering a scatter marker raises the item tooltip for its series', async () => {
+      await engine().parts.scatterChart.hoverDataPoint(1, 0);
+      const text = await waitForTooltip(() => engine().parts.scatterChart.getTooltipText());
+      assertTrue(text != null);
+      assertTrue(text!.includes('Group A'));
+    });
+
     // The tooltip is a single portaled element shared by every chart on the page, so "cleared"
     // cannot be asserted per-chart; asserting that its content follows the hovered slice pins
     // the same pointer-tracking behavior without that ambiguity.

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/ChartInteraction.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/ChartInteraction.suite.ts
@@ -1,0 +1,65 @@
+import { TestSuiteInfo } from '@atomic-testing/internal-test-runner';
+import { useTestEngine } from '@atomic-testing/internal-test-runner';
+
+import { chartsExample } from './Charts.suite';
+
+// Tooltips render asynchronously after the hover (popper mount + positioning), so poll briefly
+// instead of asserting on the first read.
+async function waitForTooltip(
+  getText: () => Promise<string | undefined>,
+  timeoutMs: number = 5000
+): Promise<string | undefined> {
+  const startedAt = Date.now();
+  let text = await getText();
+  while (text == null && Date.now() - startedAt < timeoutMs) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    text = await getText();
+  }
+  return text;
+}
+
+/**
+ * The geometry-dependent chart interactions: hovering a data point and reading the tooltip.
+ * E2E-ONLY — jsdom has no layout engine, so pointer coordinates never resolve to a chart item
+ * there; this suite deliberately has no `.dom.test.ts` adapter (the documented exception for
+ * the e2e-primary chart family, #904).
+ */
+export const chartInteractionTestSuite: TestSuiteInfo<typeof chartsExample.scene> = {
+  title: 'Chart interactions',
+  url: '/charts',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertTrue, assertEqual }) => {
+    const engine = useTestEngine(chartsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('hovering a bar raises the axis tooltip for its category', async () => {
+      await engine().parts.barChart.hoverDataPoint(1);
+      const text = await waitForTooltip(() => engine().parts.barChart.getTooltipText());
+      assertTrue(text != null);
+      assertTrue(text!.includes('Q2'));
+      assertTrue(text!.includes('Series A'));
+    });
+
+    test('hovering a pie slice raises the item tooltip with its label and value', async () => {
+      await engine().parts.pieChart.hoverDataPoint(1);
+      const text = await waitForTooltip(() => engine().parts.pieChart.getTooltipText());
+      assertTrue(text != null);
+      assertTrue(text!.includes('Beta'));
+      assertTrue(text!.includes('20'));
+    });
+
+    // The tooltip is a single portaled element shared by every chart on the page, so "cleared"
+    // cannot be asserted per-chart; asserting that its content follows the hovered slice pins
+    // the same pointer-tracking behavior without that ambiguity.
+    test('tooltip follows the hovered data point', async () => {
+      await engine().parts.pieChart.hoverDataPoint(0);
+      const first = await waitForTooltip(() => engine().parts.pieChart.getTooltipText());
+      assertTrue(first != null);
+      assertTrue(first!.includes('Alpha'));
+      await engine().parts.pieChart.hoverDataPoint(2);
+      const second = await waitForTooltip(async () => {
+        const text = await engine().parts.pieChart.getTooltipText();
+        return text != null && text.includes('Gamma') ? text : undefined;
+      });
+      assertEqual(second != null && second.includes('Gamma'), true);
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.examples.tsx
@@ -2,6 +2,7 @@ import { IExampleUIUnit } from '@atomic-testing/core';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { PieChart } from '@mui/x-charts/PieChart';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import React, { JSX } from 'react';
 
 // Explicit width/height gives the charts a drawing area without ResizeObserver measurements —
@@ -42,6 +43,35 @@ export const BasicCharts: React.FunctionComponent = () => {
                 { id: 0, value: 10, label: 'Alpha' },
                 { id: 1, value: 20, label: 'Beta' },
                 { id: 2, value: 15, label: 'Gamma' },
+              ],
+            },
+          ]}
+        />
+      </div>
+      <div data-testid='basic-scatter-chart'>
+        <ScatterChart
+          width={500}
+          height={300}
+          skipAnimation
+          series={[
+            {
+              label: 'Group A',
+              data: [
+                { x: 1, y: 2, id: 'a0' },
+                { x: 2, y: 5, id: 'a1' },
+                { x: 3, y: 3, id: 'a2' },
+                { x: 4, y: 6, id: 'a3' },
+                { x: 5, y: 4, id: 'a4' },
+              ],
+            },
+            {
+              label: 'Group B',
+              data: [
+                { x: 1, y: 4, id: 'b0' },
+                { x: 2, y: 1, id: 'b1' },
+                { x: 3, y: 6, id: 'b2' },
+                { x: 4, y: 2, id: 'b3' },
+                { x: 5, y: 5, id: 'b4' },
               ],
             },
           ]}

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.examples.tsx
@@ -1,0 +1,61 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { PieChart } from '@mui/x-charts/PieChart';
+import React, { JSX } from 'react';
+
+// Explicit width/height gives the charts a drawing area without ResizeObserver measurements —
+// required under jsdom (no layout engine) and harmless in a browser. skipAnimation keeps mark
+// geometry deterministic for e2e reads.
+export const BasicCharts: React.FunctionComponent = () => {
+  return (
+    <React.Fragment>
+      <div data-testid='basic-bar-chart'>
+        <BarChart
+          width={500}
+          height={300}
+          skipAnimation
+          xAxis={[{ data: ['Q1', 'Q2', 'Q3', 'Q4'], scaleType: 'band' }]}
+          series={[
+            { data: [4, 3, 5, 2], label: 'Series A' },
+            { data: [1, 6, 3, 4], label: 'Series B' },
+          ]}
+        />
+      </div>
+      <div data-testid='basic-line-chart'>
+        <LineChart
+          width={500}
+          height={300}
+          skipAnimation
+          xAxis={[{ data: [1, 2, 3, 4] }]}
+          series={[{ data: [2, 5, 3, 7], label: 'Trend', showMark: true }]}
+        />
+      </div>
+      <div data-testid='basic-pie-chart'>
+        <PieChart
+          width={400}
+          height={300}
+          skipAnimation
+          series={[
+            {
+              data: [
+                { id: 0, value: 10, label: 'Alpha' },
+                { id: 1, value: 20, label: 'Beta' },
+                { id: 2, value: 15, label: 'Gamma' },
+              ],
+            },
+          ]}
+        />
+      </div>
+    </React.Fragment>
+  );
+};
+
+/**
+ * Basic BarChart/LineChart/PieChart examples from MUI's website
+ * @see https://mui.com/x/react-charts/
+ */
+export const basicChartsUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic Charts',
+  ui: <BasicCharts />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.suite.ts
@@ -1,0 +1,67 @@
+import { BarChartDriver, LineChartDriver, PieChartDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicChartsUIExample } from './Charts.examples';
+
+export const chartsExampleScenePart = {
+  barChart: {
+    locator: byDataTestId('basic-bar-chart'),
+    driver: BarChartDriver,
+  },
+  lineChart: {
+    locator: byDataTestId('basic-line-chart'),
+    driver: LineChartDriver,
+  },
+  pieChart: {
+    locator: byDataTestId('basic-pie-chart'),
+    driver: PieChartDriver,
+  },
+} satisfies ScenePart;
+
+export const chartsExample: IExampleUnit<typeof chartsExampleScenePart, JSX.Element> = {
+  ...basicChartsUIExample,
+  scene: chartsExampleScenePart,
+};
+
+/**
+ * The structural chart reads — legend, series labels, axis labels, data-point counts — which
+ * are portable between jsdom (with the chart shims in jest.setup.js) and real browsers.
+ * Geometry-dependent behavior (hover → tooltip) lives in the e2e-only interaction suite.
+ */
+export const chartsTestSuite: TestSuiteInfo<typeof chartsExampleScenePart> = {
+  title: 'Charts',
+  url: '/charts',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    const engine = useTestEngine(chartsExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('bar chart legend lists both series', async () => {
+      assertEqual(await engine().parts.barChart.getLegendItems(), ['Series A', 'Series B']);
+      assertEqual(await engine().parts.barChart.getSeriesLabels(), ['Series A', 'Series B']);
+    });
+
+    test('bar chart x-axis renders the band labels', async () => {
+      assertEqual(await engine().parts.barChart.getAxisLabels('x'), ['Q1', 'Q2', 'Q3', 'Q4']);
+    });
+
+    test('bar chart renders one bar per category, per series', async () => {
+      assertEqual(await engine().parts.barChart.getDataPointCount(0), 4);
+      assertEqual(await engine().parts.barChart.getDataPointCount(1), 4);
+    });
+
+    test('line chart renders one mark per data point', async () => {
+      assertEqual(await engine().parts.lineChart.getSeriesLabels(), ['Trend']);
+      assertEqual(await engine().parts.lineChart.getDataPointCount(), 4);
+    });
+
+    test('pie chart legend lists the slices and renders one arc each', async () => {
+      assertEqual(await engine().parts.pieChart.getLegendItems(), ['Alpha', 'Beta', 'Gamma']);
+      assertEqual(await engine().parts.pieChart.getDataPointCount(), 3);
+    });
+
+    test('no tooltip is shown before any pointer interaction', async () => {
+      assertEqual(await engine().parts.barChart.getTooltipText(), undefined);
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/Charts.suite.ts
@@ -1,4 +1,9 @@
-import { BarChartDriver, LineChartDriver, PieChartDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import {
+  BarChartDriver,
+  LineChartDriver,
+  PieChartDriver,
+  ScatterChartDriver,
+} from '@atomic-testing/component-driver-mui-x-v9';
 import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
 import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
 import { JSX } from 'react';
@@ -17,6 +22,10 @@ export const chartsExampleScenePart = {
   pieChart: {
     locator: byDataTestId('basic-pie-chart'),
     driver: PieChartDriver,
+  },
+  scatterChart: {
+    locator: byDataTestId('basic-scatter-chart'),
+    driver: ScatterChartDriver,
   },
 } satisfies ScenePart;
 
@@ -58,6 +67,16 @@ export const chartsTestSuite: TestSuiteInfo<typeof chartsExampleScenePart> = {
     test('pie chart legend lists the slices and renders one arc each', async () => {
       assertEqual(await engine().parts.pieChart.getLegendItems(), ['Alpha', 'Beta', 'Gamma']);
       assertEqual(await engine().parts.pieChart.getDataPointCount(), 3);
+    });
+
+    test('scatter chart legend lists both series', async () => {
+      assertEqual(await engine().parts.scatterChart.getLegendItems(), ['Group A', 'Group B']);
+      assertEqual(await engine().parts.scatterChart.getSeriesLabels(), ['Group A', 'Group B']);
+    });
+
+    test('scatter chart renders one marker per point, per series', async () => {
+      assertEqual(await engine().parts.scatterChart.getDataPointCount(0), 5);
+      assertEqual(await engine().parts.scatterChart.getDataPointCount(1), 5);
     });
 
     test('no tooltip is shown before any pointer interaction', async () => {

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/charts/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/charts/index.ts
@@ -1,0 +1,12 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { chartInteractionTestSuite } from './ChartInteraction.suite';
+import { chartsExample, chartsTestSuite } from './Charts.suite';
+
+export { chartInteractionTestSuite, chartsExample, chartsTestSuite };
+
+export const chartsExamples: IExampleUnit<ScenePart, JSX.Element>[] = [chartsExample] satisfies IExampleUnit<
+  ScenePart,
+  JSX.Element
+>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/GroupedDataGridPremium.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/GroupedDataGridPremium.examples.tsx
@@ -1,0 +1,40 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { basicGridColumnConfig, gridData } from '@atomic-testing/internal-mui-x-test-fixture';
+import Box from '@mui/material/Box';
+import { DataGridPremium, GridColDef } from '@mui/x-data-grid-premium';
+import React, { JSX } from 'react';
+
+// Columns 0-8 of the shared fixture include `status` (the grouping column) and `quantity` (the
+// aggregated column). `status` is grouped over `commodity` because the fixture has only four
+// distinct statuses across these rows — low cardinality gives a handful of multi-child groups to
+// expand/collapse, whereas `commodity` is nearly unique per row and would yield mostly singletons.
+const groupedColumns = basicGridColumnConfig.slice(0, 9) as GridColDef[];
+
+export const groupedGridRows = gridData.slice(0, 20);
+
+export const GroupedDataGridPremium: React.FunctionComponent = () => {
+  return (
+    <Box sx={{ height: 600, minWidth: 900, width: '100%' }} data-testid='grouped-grid-premium'>
+      <DataGridPremium
+        columns={groupedColumns}
+        rows={groupedGridRows}
+        initialState={{
+          columns: { columnVisibilityModel: { id: false } },
+          rowGrouping: { model: ['status'] },
+          aggregation: { model: { quantity: 'sum' } },
+        }}
+      />
+    </Box>
+  );
+};
+
+/**
+ * DataGridPremium demonstrating the Premium row-grouping and aggregation features: rows are
+ * grouped by `status` (groups start collapsed) with a `sum` aggregation on `quantity` shown in
+ * the grand-total footer row.
+ * @see https://mui.com/x/react-data-grid/row-grouping/
+ */
+export const groupedDataGridPremiumUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Grouped DataGridPremium',
+  ui: <GroupedDataGridPremium />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/GroupedDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/GroupedDataGridPremium.suite.ts
@@ -1,0 +1,63 @@
+import { DataGridPremiumDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { groupedDataGridPremiumUIExample, groupedGridRows } from './GroupedDataGridPremium.examples';
+
+export const groupedDataGridPremiumExampleScenePart = {
+  grid: {
+    locator: byDataTestId('grouped-grid-premium'),
+    driver: DataGridPremiumDriver,
+  },
+} satisfies ScenePart;
+
+export const groupedDataGridPremiumExample: IExampleUnit<typeof groupedDataGridPremiumExampleScenePart, JSX.Element> = {
+  ...groupedDataGridPremiumUIExample,
+  scene: groupedDataGridPremiumExampleScenePart,
+};
+
+// Expected values are derived from the shared static fixture, so the assertions stay correct if
+// the fixture data ever changes: one group per distinct status, and the sum aggregation over
+// every row's quantity.
+const expectedGroupCount = new Set(groupedGridRows.map(row => row.status)).size;
+const expectedQuantitySum = groupedGridRows.reduce((sum, row) => sum + Number(row.quantity), 0);
+
+/** Parse a grid-formatted number (thousands separators etc.) back to a plain number. */
+const parseGridNumber = (text: string | null): number => Number((text ?? '').replace(/[^\d.-]/g, ''));
+
+export const groupedDataGridPremiumTestSuite: TestSuiteInfo<typeof groupedDataGridPremiumExampleScenePart> = {
+  title: 'Grouped DataGridPremium',
+  url: '/datagridgrouped',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(groupedDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('renders one group header per distinct status, all collapsed', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(await engine().parts.grid.getGroupRowCount(), expectedGroupCount);
+      assertFalse(await engine().parts.grid.isGroupExpanded(0));
+    });
+
+    // Rendered row count is compared as a delta rather than an absolute: the grand-total footer
+    // and virtualization make the absolute count environment-dependent, but expanding a group
+    // reveals its child rows in both jsdom and a real browser (the small dataset and tall grid
+    // keep every revealed row within the viewport, so nothing is virtualized away here).
+    test('expandGroup reveals child rows, collapseGroup hides them again', async () => {
+      await engine().parts.grid.waitForLoad();
+      const collapsedRowCount = await engine().parts.grid.getRowCount();
+
+      await engine().parts.grid.expandGroup(0);
+      assertTrue(await engine().parts.grid.isGroupExpanded(0));
+      assertTrue((await engine().parts.grid.getRowCount()) > collapsedRowCount);
+
+      await engine().parts.grid.collapseGroup(0);
+      assertFalse(await engine().parts.grid.isGroupExpanded(0));
+      assertEqual(await engine().parts.grid.getRowCount(), collapsedRowCount);
+    });
+
+    test('getAggregationValue reports the sum of the quantity column', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(parseGridNumber(await engine().parts.grid.getAggregationValue('quantity')), expectedQuantitySum);
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.examples.tsx
@@ -1,0 +1,49 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { basicGridColumnConfig, gridData } from '@atomic-testing/internal-mui-x-test-fixture';
+import Box from '@mui/material/Box';
+import { DataGridPremium, GridColDef } from '@mui/x-data-grid-premium';
+import React, { JSX } from 'react';
+
+// The shared fixture marks every column non-editable; the editing tests need one editable
+// column, so commodity is flipped here.
+const interactiveColumns = (basicGridColumnConfig.slice(0, 5) as GridColDef[]).map(col => ({
+  ...col,
+  editable: col.field === 'commodity',
+}));
+
+export const interactiveGridRows = gridData.slice(0, 30);
+
+export const InteractiveDataGridPremium: React.FunctionComponent = () => {
+  return (
+    <React.Fragment>
+      <Box sx={{ height: 480, minWidth: 900, width: '100%' }} data-testid='interactive-grid-premium'>
+        <DataGridPremium
+          columns={interactiveColumns}
+          rows={interactiveGridRows}
+          showToolbar
+          checkboxSelection
+          pagination
+          pageSizeOptions={[10, 25]}
+          initialState={{
+            columns: { columnVisibilityModel: { id: false } },
+            pagination: { paginationModel: { pageSize: 10 } },
+          }}
+        />
+      </Box>
+      {/* A grid with no rows, for the empty-state overlay. */}
+      <Box sx={{ height: 300, minWidth: 900, width: '100%' }} data-testid='empty-grid-premium'>
+        <DataGridPremium columns={interactiveColumns} rows={[]} />
+      </Box>
+    </React.Fragment>
+  );
+};
+
+/**
+ * DataGridPremium with its interactive surface enabled: toolbar (quick filter, filter panel),
+ * checkbox selection, an editable column, and pagination.
+ * @see https://mui.com/x/react-data-grid/
+ */
+export const interactiveDataGridPremiumUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Interactive DataGridPremium',
+  ui: <InteractiveDataGridPremium />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
@@ -144,6 +144,44 @@ export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interacti
       const after = await engine().parts.grid.getHeaderText();
       assertFalse(after.includes('Trader Name'));
     });
+
+    test('pinColumn left keeps the column rendered, unpinColumn restores it', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(await engine().parts.grid.isColumnPinned('desk'), null);
+      await engine().parts.grid.pinColumn('desk', 'left');
+      assertEqual(await engine().parts.grid.isColumnPinned('desk'), 'left');
+      // A pinned column stays rendered and readable.
+      assertEqual(
+        await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'desk' }),
+        String(interactiveGridRows[0].desk)
+      );
+      await engine().parts.grid.unpinColumn('desk');
+      assertEqual(await engine().parts.grid.isColumnPinned('desk'), null);
+    });
+
+    test('pinColumn right pins to the right edge', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.pinColumn('desk', 'right');
+      assertEqual(await engine().parts.grid.isColumnPinned('desk'), 'right');
+      assertEqual(
+        await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'desk' }),
+        String(interactiveGridRows[0].desk)
+      );
+    });
+
+    // Resizing is mouse-driven, so the width only actually changes with a real layout engine.
+    // Under jsdom every bounding box is zero, so the resize is a no-op there and reaching this
+    // point without throwing is the jsdom-side assertion; in a real browser the drag widens the
+    // header, asserted via the growing bounding box.
+    test('resizeColumn widens the column header', async () => {
+      await engine().parts.grid.waitForLoad();
+      const before = await engine().parts.grid.getColumnWidth('desk');
+      await engine().parts.grid.resizeColumn('desk', 80);
+      const after = await engine().parts.grid.getColumnWidth('desk');
+      if (before > 0) {
+        assertTrue(after > before);
+      }
+    });
     //#endregion
 
     //#region Page size and overlays

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
@@ -1,0 +1,180 @@
+import { DataGridPremiumDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { interactiveDataGridPremiumUIExample, interactiveGridRows } from './InteractiveDataGridPremium.examples';
+
+export const interactiveDataGridPremiumExampleScenePart = {
+  grid: {
+    locator: byDataTestId('interactive-grid-premium'),
+    driver: DataGridPremiumDriver,
+  },
+  emptyGrid: {
+    locator: byDataTestId('empty-grid-premium'),
+    driver: DataGridPremiumDriver,
+  },
+} satisfies ScenePart;
+
+export const interactiveDataGridPremiumExample: IExampleUnit<
+  typeof interactiveDataGridPremiumExampleScenePart,
+  JSX.Element
+> = {
+  ...interactiveDataGridPremiumUIExample,
+  scene: interactiveDataGridPremiumExampleScenePart,
+};
+
+// Expected values are computed from the shared static fixture, so the assertions stay correct
+// if the fixture data ever changes.
+const quickFilterText = 'Frozen Concentrated';
+const quickFilterMatchCount = interactiveGridRows.filter(row => String(row.commodity).includes(quickFilterText)).length;
+const filterDesk = String(interactiveGridRows[0].desk);
+const deskFilterMatchCount = interactiveGridRows.filter(row => String(row.desk).includes(filterDesk)).length;
+
+export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interactiveDataGridPremiumExampleScenePart> = {
+  title: 'Interactive DataGridPremium',
+  url: '/datagridinteractive',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(interactiveDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    //#region Sorting
+    test('columns start unsorted', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(await engine().parts.grid.getSortDirection('desk'), null);
+    });
+
+    test('sortByColumn asc orders the rows ascending', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.sortByColumn('desk', 'asc');
+      assertEqual(await engine().parts.grid.getSortDirection('desk'), 'asc');
+      const first = await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'desk' });
+      const second = await engine().parts.grid.getCellText({ rowIndex: 1, columnField: 'desk' });
+      assertTrue(first <= second);
+    });
+
+    test('sortByColumn desc orders the rows descending', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.sortByColumn('desk', 'desc');
+      assertEqual(await engine().parts.grid.getSortDirection('desk'), 'desc');
+      const first = await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'desk' });
+      const second = await engine().parts.grid.getCellText({ rowIndex: 1, columnField: 'desk' });
+      assertTrue(first >= second);
+    });
+
+    test('sortByColumn null returns the column to unsorted', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.sortByColumn('desk', 'asc');
+      await engine().parts.grid.sortByColumn('desk', null);
+      assertEqual(await engine().parts.grid.getSortDirection('desk'), null);
+    });
+    //#endregion
+
+    //#region Filtering
+    test('setQuickFilter narrows the rows to the matching commodity', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.setQuickFilter(quickFilterText);
+      await engine().parts.grid.waitForRowCount(quickFilterMatchCount);
+      const text = await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'commodity' });
+      assertTrue(text.includes(quickFilterText));
+    });
+
+    test('setColumnFilter filters by the chosen column', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.setColumnFilter('desk', filterDesk);
+      await engine().parts.grid.waitForRowCount(deskFilterMatchCount);
+      assertEqual(await engine().parts.grid.getCellText({ rowIndex: 0, columnField: 'desk' }), filterDesk);
+      await engine().parts.grid.closeFilterPanel();
+    });
+    //#endregion
+
+    //#region Selection
+    test('selectRow selects a single row', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertFalse(await engine().parts.grid.isRowSelected(1));
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), 0);
+      await engine().parts.grid.selectRow(1);
+      assertTrue(await engine().parts.grid.isRowSelected(1));
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), 1);
+    });
+
+    test('deselectRow removes a row from the selection', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.selectRow(1);
+      await engine().parts.grid.selectRow(2);
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), 2);
+      await engine().parts.grid.deselectRow(1);
+      assertFalse(await engine().parts.grid.isRowSelected(1));
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), 1);
+    });
+
+    test('selectAllRows and deselectAllRows toggle the whole dataset', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.selectAllRows();
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), interactiveGridRows.length);
+      await engine().parts.grid.deselectAllRows();
+      assertEqual(await engine().parts.grid.getSelectedRowCount(), 0);
+    });
+    //#endregion
+
+    //#region Editing
+    test('setCellValue and commitCellEdit persist a new cell value', async () => {
+      await engine().parts.grid.waitForLoad();
+      const cell = { rowIndex: 0, columnField: 'commodity' } as const;
+      await engine().parts.grid.setCellValue(cell, 'Gold');
+      await engine().parts.grid.commitCellEdit(cell);
+      assertEqual(await engine().parts.grid.getCellText(cell), 'Gold');
+    });
+
+    test('cancelCellEdit discards the pending value', async () => {
+      await engine().parts.grid.waitForLoad();
+      const cell = { rowIndex: 0, columnField: 'commodity' } as const;
+      const original = await engine().parts.grid.getCellText(cell);
+      await engine().parts.grid.setCellValue(cell, 'Discarded');
+      await engine().parts.grid.cancelCellEdit(cell);
+      assertEqual(await engine().parts.grid.getCellText(cell), original);
+    });
+    //#endregion
+
+    //#region Column management
+    test('hideColumn removes the column through its menu', async () => {
+      await engine().parts.grid.waitForLoad();
+      const before = await engine().parts.grid.getHeaderText();
+      assertTrue(before.includes('Trader Name'));
+      await engine().parts.grid.hideColumn('traderName');
+      const after = await engine().parts.grid.getHeaderText();
+      assertFalse(after.includes('Trader Name'));
+    });
+    //#endregion
+
+    //#region Page size and overlays
+    // The page size is asserted through the pagination state, not the rendered row count: a
+    // real browser virtualizes to the viewport (~11 rows here) while jsdom renders the whole
+    // page, so a rendered-count assertion cannot hold in both environments.
+    test('setPageSize changes the rows per page', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(await engine().parts.grid.getPageSize(), 10);
+      await engine().parts.grid.setPageSize(25);
+      assertEqual(await engine().parts.grid.getPageSize(), 25);
+      assertEqual(await engine().parts.grid.getPaginationDescription(), '1–25 of 30');
+    });
+
+    test('isEmpty reflects the no-rows overlay', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertFalse(await engine().parts.grid.isEmpty());
+      assertTrue(await engine().parts.emptyGrid.isEmpty());
+    });
+    //#endregion
+
+    //#region Virtualization
+    test('scrollRowIntoView reaches a row outside the initial viewport', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.setPageSize(25);
+      await engine().parts.grid.scrollRowIntoView(20);
+      assertEqual(
+        await engine().parts.grid.getCellText({ rowIndex: 20, columnField: 'desk' }),
+        String(interactiveGridRows[20].desk)
+      );
+    });
+    //#endregion
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
@@ -2,6 +2,7 @@ import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 import { JSX } from 'react';
 
 import { basicDataGridPremiumExample, basicDataGridPremiumTestSuite } from './BasicDataGridPremium.suite';
+import { groupedDataGridPremiumExample, groupedDataGridPremiumTestSuite } from './GroupedDataGridPremium.suite';
 import {
   interactiveDataGridPremiumExample,
   interactiveDataGridPremiumTestSuite,
@@ -9,7 +10,9 @@ import {
 
 export { basicDataGridPremiumExample, basicDataGridPremiumTestSuite };
 export { interactiveDataGridPremiumExample, interactiveDataGridPremiumTestSuite };
+export { groupedDataGridPremiumExample, groupedDataGridPremiumTestSuite };
 export const dataGridPremiumExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicDataGridPremiumExample,
   interactiveDataGridPremiumExample,
+  groupedDataGridPremiumExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
@@ -2,8 +2,14 @@ import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 import { JSX } from 'react';
 
 import { basicDataGridPremiumExample, basicDataGridPremiumTestSuite } from './BasicDataGridPremium.suite';
+import {
+  interactiveDataGridPremiumExample,
+  interactiveDataGridPremiumTestSuite,
+} from './InteractiveDataGridPremium.suite';
 
 export { basicDataGridPremiumExample, basicDataGridPremiumTestSuite };
+export { interactiveDataGridPremiumExample, interactiveDataGridPremiumTestSuite };
 export const dataGridPremiumExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicDataGridPremiumExample,
+  interactiveDataGridPremiumExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateRangePicker.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateRangePicker.examples.tsx
@@ -1,0 +1,25 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import React, { JSX } from 'react';
+
+export const BasicDateRangePicker: React.FunctionComponent = () => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <div data-testid='basic-date-range-picker'>
+        <DateRangePicker defaultValue={[new Date(2026, 5, 27), new Date(2026, 6, 4)]} />
+      </div>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Basic DateRangePicker (Pro) example from MUI's website, using the default
+ * single-input range field.
+ * @see https://mui.com/x/react-date-pickers/date-range-picker/
+ */
+export const basicDateRangePickerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic DateRangePicker',
+  ui: <BasicDateRangePicker />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateRangePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateRangePicker.suite.ts
@@ -1,0 +1,68 @@
+import { DateRangePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicDateRangePickerUIExample } from './DateRangePicker.examples';
+
+export const dateRangePickerExampleScenePart = {
+  picker: {
+    locator: byDataTestId('basic-date-range-picker'),
+    driver: DateRangePickerDriver,
+  },
+} satisfies ScenePart;
+
+export const dateRangePickerExample: IExampleUnit<typeof dateRangePickerExampleScenePart, JSX.Element> = {
+  ...basicDateRangePickerUIExample,
+  scene: dateRangePickerExampleScenePart,
+};
+
+export const dateRangePickerTestSuite: TestSuiteInfo<typeof dateRangePickerExampleScenePart> = {
+  title: 'DateRangePicker',
+  url: '/daterangepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+    const engine = useTestEngine(dateRangePickerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('getValueText returns both dates joined by the range separator', async () => {
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026 – 07/04/2026');
+    });
+
+    test('getValue reads both sides of the range from the hidden input', async () => {
+      const value = await engine().parts.picker.getValue();
+      assertEqual(value?.start?.getFullYear(), 2026);
+      assertEqual(value?.start?.getMonth(), 5); // June (0-based)
+      assertEqual(value?.start?.getDate(), 27);
+      assertEqual(value?.end?.getMonth(), 6); // July
+      assertEqual(value?.end?.getDate(), 4);
+    });
+
+    test('setValue types both dates, auto-advancing across the range separator', async () => {
+      await engine().parts.picker.setValue({ start: new Date(2025, 11, 25), end: new Date(2026, 0, 15) });
+      assertEqual(await engine().parts.picker.getValueText(), '12/25/2025 – 01/15/2026');
+    });
+
+    test('setValue(null) clears the whole field', async () => {
+      await engine().parts.picker.setValue(null);
+      assertEqual(await engine().parts.picker.getValueText(), undefined);
+      assertEqual(await engine().parts.picker.getValue(), null);
+    });
+
+    test('setValue after clearing re-enters a range', async () => {
+      await engine().parts.picker.setValue(null);
+      await engine().parts.picker.setValue({ start: new Date(2026, 1, 1), end: new Date(2026, 1, 14) });
+      assertEqual(await engine().parts.picker.getValueText(), '02/01/2026 – 02/14/2026');
+    });
+
+    test('setValue rejects a one-sided range', async () => {
+      let threw = false;
+      try {
+        await engine().parts.picker.setValue({ start: new Date(2026, 1, 1), end: null });
+      } catch {
+        threw = true;
+      }
+      assertTrue(threw);
+      // The field is untouched by the rejected write.
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026 – 07/04/2026');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateTimePicker.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateTimePicker.examples.tsx
@@ -1,0 +1,28 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DesktopDateTimePicker } from '@mui/x-date-pickers/DesktopDateTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import React, { JSX } from 'react';
+
+export const BasicDateTimePicker: React.FunctionComponent = () => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <div data-testid='basic-datetime-picker'>
+        <DesktopDateTimePicker defaultValue={new Date(2026, 5, 27, 14, 30)} />
+      </div>
+      {/* Second instance with a different value to prove locator disambiguation. */}
+      <div data-testid='second-datetime-picker'>
+        <DesktopDateTimePicker defaultValue={new Date(2020, 0, 15, 9, 5)} />
+      </div>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Basic desktop DateTimePicker example from MUI's website
+ * @see https://mui.com/x/react-date-pickers/date-time-picker/
+ */
+export const basicDateTimePickerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic DateTimePicker',
+  ui: <BasicDateTimePicker />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateTimePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DateTimePicker.suite.ts
@@ -1,0 +1,77 @@
+import { DateTimePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicDateTimePickerUIExample } from './DateTimePicker.examples';
+
+export const dateTimePickerExampleScenePart = {
+  picker: {
+    locator: byDataTestId('basic-datetime-picker'),
+    driver: DateTimePickerDriver,
+  },
+  secondPicker: {
+    locator: byDataTestId('second-datetime-picker'),
+    driver: DateTimePickerDriver,
+  },
+} satisfies ScenePart;
+
+export const dateTimePickerExample: IExampleUnit<typeof dateTimePickerExampleScenePart, JSX.Element> = {
+  ...basicDateTimePickerUIExample,
+  scene: dateTimePickerExampleScenePart,
+};
+
+export const dateTimePickerTestSuite: TestSuiteInfo<typeof dateTimePickerExampleScenePart> = {
+  title: 'DateTimePicker',
+  url: '/datetimepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    const engine = useTestEngine(dateTimePickerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('getValueText returns the raw locale-formatted string', async () => {
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026 02:30 PM');
+    });
+
+    test('getValue reads date and time from the hidden input', async () => {
+      const value = await engine().parts.picker.getValue();
+      assertEqual(value?.getFullYear(), 2026);
+      assertEqual(value?.getMonth(), 5); // June (0-based)
+      assertEqual(value?.getDate(), 27);
+      assertEqual(value?.getHours(), 14);
+      assertEqual(value?.getMinutes(), 30);
+    });
+
+    test('two pickers are disambiguated - each reads its own value', async () => {
+      const first = await engine().parts.picker.getValue();
+      const second = await engine().parts.secondPicker.getValue();
+      assertEqual(first?.getFullYear(), 2026);
+      assertEqual(second?.getFullYear(), 2020);
+      assertEqual(second?.getHours(), 9);
+      assertEqual(second?.getMinutes(), 5);
+    });
+
+    test('setValue types a full datetime over the previous value', async () => {
+      await engine().parts.picker.setValue(new Date(2025, 11, 25, 21, 30));
+      assertEqual(await engine().parts.picker.getValueText(), '12/25/2025 09:30 PM');
+    });
+
+    // Midnight exercises the 24h→12h edge: hour 0 types as 12 with the 'a' meridiem keystroke.
+    test('setValue handles midnight (12 AM)', async () => {
+      await engine().parts.picker.setValue(new Date(2026, 0, 5, 0, 15));
+      assertEqual(await engine().parts.picker.getValueText(), '01/05/2026 12:15 AM');
+    });
+
+    test('setValue(null) clears the field', async () => {
+      await engine().parts.picker.setValue(null);
+      assertEqual(await engine().parts.picker.getValueText(), undefined);
+      assertEqual(await engine().parts.picker.getValue(), null);
+      // The other picker is untouched.
+      assertEqual(await engine().parts.secondPicker.getValueText(), '01/15/2020 09:05 AM');
+    });
+
+    test('setValue after clearing re-enters a value', async () => {
+      await engine().parts.picker.setValue(null);
+      await engine().parts.picker.setValue(new Date(2026, 2, 3, 8, 45));
+      assertEqual(await engine().parts.picker.getValueText(), '03/03/2026 08:45 AM');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/DesktopDatePicker.suite.ts
@@ -48,10 +48,29 @@ export const desktopDatePickerTestSuite: TestSuiteInfo<typeof desktopDatePickerE
       assertEqual(second?.getDate(), 15);
     });
 
-    test('setValue selects a day in the currently shown month', async () => {
-      // Default value is June 2026, so the popup opens on the target month directly.
+    test('setValue types the date into the section field', async () => {
       await engine().parts.picker.setValue(new Date(2026, 5, 30));
       assertEqual(await engine().parts.picker.getValueText(), '06/30/2026');
+    });
+
+    // Typing replaces the whole value, so no month paging is involved even across years.
+    test('setValue types a date in a different year', async () => {
+      await engine().parts.picker.setValue(new Date(2025, 11, 25));
+      assertEqual(await engine().parts.picker.getValueText(), '12/25/2025');
+    });
+
+    test('setValue(null) clears the field', async () => {
+      await engine().parts.picker.setValue(null);
+      assertEqual(await engine().parts.picker.getValueText(), undefined);
+      assertEqual(await engine().parts.picker.getValue(), null);
+      // The other picker is untouched.
+      assertEqual(await engine().parts.secondPicker.getValueText(), '01/15/2020');
+    });
+
+    test('setValue after clearing re-enters a value', async () => {
+      await engine().parts.picker.setValue(null);
+      await engine().parts.picker.setValue(new Date(2026, 0, 15));
+      assertEqual(await engine().parts.picker.getValueText(), '01/15/2026');
     });
 
     test('pickDate pages forward across months', async () => {

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/MobileDatePicker.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/MobileDatePicker.examples.tsx
@@ -1,0 +1,28 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+import React, { JSX } from 'react';
+
+export const BasicMobileDatePicker: React.FunctionComponent = () => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <div data-testid='basic-mobile-date-picker'>
+        <MobileDatePicker defaultValue={new Date(2026, 5, 27)} />
+      </div>
+      {/* Second instance with a different value to prove locator disambiguation. */}
+      <div data-testid='second-mobile-date-picker'>
+        <MobileDatePicker defaultValue={new Date(2020, 0, 15)} />
+      </div>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Basic MobileDatePicker example from MUI's website
+ * @see https://mui.com/x/react-date-pickers/date-picker/
+ */
+export const basicMobileDatePickerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic MobileDatePicker',
+  ui: <BasicMobileDatePicker />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/MobileDatePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/MobileDatePicker.suite.ts
@@ -1,0 +1,72 @@
+import { MobileDatePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicMobileDatePickerUIExample } from './MobileDatePicker.examples';
+
+export const mobileDatePickerExampleScenePart = {
+  picker: {
+    locator: byDataTestId('basic-mobile-date-picker'),
+    driver: MobileDatePickerDriver,
+  },
+  secondPicker: {
+    locator: byDataTestId('second-mobile-date-picker'),
+    driver: MobileDatePickerDriver,
+  },
+} satisfies ScenePart;
+
+export const mobileDatePickerExample: IExampleUnit<typeof mobileDatePickerExampleScenePart, JSX.Element> = {
+  ...basicMobileDatePickerUIExample,
+  scene: mobileDatePickerExampleScenePart,
+};
+
+export const mobileDatePickerTestSuite: TestSuiteInfo<typeof mobileDatePickerExampleScenePart> = {
+  title: 'MobileDatePicker',
+  url: '/mobiledatepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    const engine = useTestEngine(mobileDatePickerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('getValue reads the default value from the hidden input', async () => {
+      const value = await engine().parts.picker.getValue();
+      assertEqual(value?.getFullYear(), 2026);
+      assertEqual(value?.getMonth(), 5); // June (0-based)
+      assertEqual(value?.getDate(), 27);
+    });
+
+    test('getValueText returns the raw locale-formatted string', async () => {
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026');
+    });
+
+    test('two pickers are disambiguated - each reads its own value', async () => {
+      const first = await engine().parts.picker.getValue();
+      const second = await engine().parts.secondPicker.getValue();
+      assertEqual(first?.getFullYear(), 2026);
+      assertEqual(second?.getFullYear(), 2020);
+    });
+
+    test('setValue picks a day in the current month via the entry dialog', async () => {
+      await engine().parts.picker.setValue(new Date(2026, 5, 15));
+      assertEqual(await engine().parts.picker.getValueText(), '06/15/2026');
+    });
+
+    test('setValue pages the dialog calendar across months', async () => {
+      await engine().parts.picker.setValue(new Date(2026, 8, 3));
+      assertEqual(await engine().parts.picker.getValueText(), '09/03/2026');
+    });
+
+    test('cancel dismisses the dialog without committing the picked day', async () => {
+      const dialog = await engine().parts.picker.openEntryDialog();
+      await dialog.pickDay(new Date(2026, 5, 20));
+      await dialog.cancel();
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026');
+    });
+
+    test('setValue operates each picker independently', async () => {
+      await engine().parts.secondPicker.setValue(new Date(2020, 0, 20));
+      assertEqual(await engine().parts.secondPicker.getValueText(), '01/20/2020');
+      // The first picker is untouched.
+      assertEqual(await engine().parts.picker.getValueText(), '06/27/2026');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/TimePicker.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/TimePicker.examples.tsx
@@ -1,0 +1,28 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import React, { JSX } from 'react';
+
+export const BasicTimePicker: React.FunctionComponent = () => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <div data-testid='basic-time-picker'>
+        <DesktopTimePicker defaultValue={new Date(2026, 5, 27, 14, 30)} />
+      </div>
+      {/* Second instance with a different value to prove locator disambiguation. */}
+      <div data-testid='second-time-picker'>
+        <DesktopTimePicker defaultValue={new Date(2026, 5, 27, 9, 5)} />
+      </div>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Basic desktop TimePicker example from MUI's website
+ * @see https://mui.com/x/react-date-pickers/time-picker/
+ */
+export const basicTimePickerUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Basic TimePicker',
+  ui: <BasicTimePicker />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/TimePicker.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/TimePicker.suite.ts
@@ -1,0 +1,72 @@
+import { TimePickerDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { basicTimePickerUIExample } from './TimePicker.examples';
+
+export const timePickerExampleScenePart = {
+  picker: {
+    locator: byDataTestId('basic-time-picker'),
+    driver: TimePickerDriver,
+  },
+  secondPicker: {
+    locator: byDataTestId('second-time-picker'),
+    driver: TimePickerDriver,
+  },
+} satisfies ScenePart;
+
+export const timePickerExample: IExampleUnit<typeof timePickerExampleScenePart, JSX.Element> = {
+  ...basicTimePickerUIExample,
+  scene: timePickerExampleScenePart,
+};
+
+export const timePickerTestSuite: TestSuiteInfo<typeof timePickerExampleScenePart> = {
+  title: 'TimePicker',
+  url: '/timepicker',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+    const engine = useTestEngine(timePickerExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('getValueText returns the raw locale-formatted string', async () => {
+      assertEqual(await engine().parts.picker.getValueText(), '02:30 PM');
+    });
+
+    test('getValue reads the time-of-day from the hidden input', async () => {
+      const value = await engine().parts.picker.getValue();
+      assertEqual(value?.getHours(), 14);
+      assertEqual(value?.getMinutes(), 30);
+    });
+
+    test('two pickers are disambiguated - each reads its own value', async () => {
+      const first = await engine().parts.picker.getValue();
+      const second = await engine().parts.secondPicker.getValue();
+      assertEqual(first?.getHours(), 14);
+      assertEqual(second?.getHours(), 9);
+      assertEqual(second?.getMinutes(), 5);
+    });
+
+    test('setValue types a PM time over the previous value', async () => {
+      await engine().parts.picker.setValue(new Date(1970, 0, 1, 16, 45));
+      assertEqual(await engine().parts.picker.getValueText(), '04:45 PM');
+    });
+
+    test('setValue types an AM time, flipping the meridiem section', async () => {
+      await engine().parts.picker.setValue(new Date(1970, 0, 1, 7, 5));
+      assertEqual(await engine().parts.picker.getValueText(), '07:05 AM');
+    });
+
+    test('setValue(null) clears the field', async () => {
+      await engine().parts.picker.setValue(null);
+      assertEqual(await engine().parts.picker.getValueText(), undefined);
+      assertEqual(await engine().parts.picker.getValue(), null);
+      // The other picker is untouched.
+      assertEqual(await engine().parts.secondPicker.getValueText(), '09:05 AM');
+    });
+
+    test('setValue after clearing re-enters a value', async () => {
+      await engine().parts.picker.setValue(null);
+      await engine().parts.picker.setValue(new Date(1970, 0, 1, 12, 0));
+      assertEqual(await engine().parts.picker.getValueText(), '12:00 PM');
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datepicker/index.ts
@@ -1,9 +1,22 @@
 import { IExampleUnit, ScenePart } from '@atomic-testing/core';
 import { JSX } from 'react';
 
+import { dateRangePickerExample, dateRangePickerTestSuite } from './DateRangePicker.suite';
+import { dateTimePickerExample, dateTimePickerTestSuite } from './DateTimePicker.suite';
 import { desktopDatePickerExample, desktopDatePickerTestSuite } from './DesktopDatePicker.suite';
+import { mobileDatePickerExample, mobileDatePickerTestSuite } from './MobileDatePicker.suite';
+import { timePickerExample, timePickerTestSuite } from './TimePicker.suite';
 
+export { dateRangePickerExample, dateRangePickerTestSuite };
+export { dateTimePickerExample, dateTimePickerTestSuite };
 export { desktopDatePickerExample, desktopDatePickerTestSuite };
+export { mobileDatePickerExample, mobileDatePickerTestSuite };
+export { timePickerExample, timePickerTestSuite };
+
 export const datePickerExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   desktopDatePickerExample,
+  dateTimePickerExample,
+  timePickerExample,
+  mobileDatePickerExample,
+  dateRangePickerExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/index.ts
@@ -1,3 +1,4 @@
+export * from './charts';
 export * from './datagridpremium';
 export * from './datepicker';
 export * from './treeview';

--- a/packages/angular-core/etc/angular-core.api.md
+++ b/packages/angular-core/etc/angular-core.api.md
@@ -83,6 +83,8 @@ export class AngularInteractor extends DOMInteractor {
     // (undocumented)
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
     // (undocumented)
+    typeText(locator: PartLocator, text: string): Promise<void>;
+    // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
     // (undocumented)
     waitUntilComponentState(locator: PartLocator, option?: Partial<Readonly<WaitForOption>>): Promise<void>;

--- a/packages/angular-core/src/AngularInteractor.ts
+++ b/packages/angular-core/src/AngularInteractor.ts
@@ -56,6 +56,11 @@ export class AngularInteractor extends DOMInteractor {
     await this.settle();
   }
 
+  override async typeText(locator: PartLocator, text: string): Promise<void> {
+    await super.typeText(locator, text);
+    await this.settle();
+  }
+
   override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
     await super.setRangeValue(locator, value);
     await this.settle();

--- a/packages/component-driver-mui-x-v9/src/components/charts/BarChartDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/BarChartDriver.ts
@@ -1,0 +1,23 @@
+import { ChartDriverBase } from './ChartDriverBase';
+
+/**
+ * Driver for the MUI X v9 BarChart.
+ *
+ * Bars render as `rect.MuiBarChart-element` siblings inside one `g.MuiBarChart-series` group per
+ * series (groups in series order); bars carry no index attribute, so both series and bar are
+ * addressed positionally.
+ * @see https://mui.com/x/react-charts/bars/
+ */
+export class BarChartDriver extends ChartDriverBase {
+  protected seriesDataPointsSelector(seriesIndex: number): string {
+    return `.MuiBarChart-series:nth-of-type(${seriesIndex + 1}) rect.MuiBarChart-element`;
+  }
+
+  protected dataPointSelector(seriesIndex: number, dataIndex: number): string {
+    return `${this.seriesDataPointsSelector(seriesIndex)}:nth-of-type(${dataIndex + 1})`;
+  }
+
+  get driverName(): string {
+    return 'MuiV9BarChart';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/charts/ChartDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/ChartDriverBase.ts
@@ -1,0 +1,139 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssSelector,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  listHelper,
+  locatorUtil,
+  Optional,
+  PartLocator,
+} from '@atomic-testing/core';
+
+// MUI X v9 charts render an `aria-hidden` SVG surface plus an HTML legend. The SVG marks carry
+// `Mui<Chart>Chart-*` classes and `data-series`/`data-index` hooks; the charts' accessibility
+// layer is a set of hidden voiceover nodes for screen readers only, so the class hooks remain
+// the structural handles (verified against @mui/x-charts 9.7 — see #904).
+//
+// Charts are e2e-primary: structural reads (legend, axis labels, data-point counts) work in both
+// jsdom (with the chart shims in the test package's jest setup) and real browsers, while anything
+// geometric — hover targets resolving to a tooltip, mark positions — needs a real layout engine
+// and is only meaningful e2e.
+
+const legendItemLocator = byCssSelector('.MuiChartsLegend-root .MuiChartsLegend-item');
+
+// The tooltip is portaled to <body>; only one chart tooltip is open at a time.
+const tooltipLocator = byCssSelector('.MuiChartsTooltip-root', 'Root');
+
+function axisTickContainerLocator(axis: 'x' | 'y'): PartLocator {
+  return byCssSelector(`.MuiChartsAxis-direction${axis.toUpperCase()} .MuiChartsAxis-tickContainer`);
+}
+
+/**
+ * Base driver for the `@mui/x-charts` v9 chart family. Concrete drivers only differ in how a
+ * chart type marks its data points in the SVG surface.
+ */
+export abstract class ChartDriverBase extends ComponentDriver {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, option);
+  }
+
+  /**
+   * CSS (relative to the chart root) selecting one series' data-point marks, without an index.
+   */
+  protected abstract seriesDataPointsSelector(seriesIndex: number): string;
+
+  /**
+   * CSS (relative to the chart root) selecting a single data-point mark.
+   */
+  protected abstract dataPointSelector(seriesIndex: number, dataIndex: number): string;
+
+  /**
+   * The legend's item labels, in render order — one per series (or per slice for pie charts).
+   */
+  async getLegendItems(): Promise<string[]> {
+    const labels: string[] = [];
+    for await (const item of listHelper.getListItemIterator(
+      this,
+      locatorUtil.append(this.locator, legendItemLocator),
+      HTMLElementDriver
+    )) {
+      const text = await item.getText();
+      labels.push((text ?? '').trim());
+    }
+    return labels;
+  }
+
+  /**
+   * The series labels as shown in the legend. Charts expose series names nowhere else in
+   * portable DOM, so this reads the same items as {@link getLegendItems}.
+   */
+  async getSeriesLabels(): Promise<string[]> {
+    return this.getLegendItems();
+  }
+
+  /**
+   * The tick labels of the given axis, in render order. Unlabeled ticks are skipped — band
+   * scales render an extra edge tick that carries no label.
+   *
+   * @param axis Which axis to read; defaults to `'x'`.
+   */
+  async getAxisLabels(axis: 'x' | 'y' = 'x'): Promise<string[]> {
+    const labels: string[] = [];
+    for await (const tick of listHelper.getListItemIterator(
+      this,
+      locatorUtil.append(this.locator, axisTickContainerLocator(axis)),
+      HTMLElementDriver
+    )) {
+      const text = ((await tick.getText()) ?? '').trim();
+      if (text.length > 0) {
+        labels.push(text);
+      }
+    }
+    return labels;
+  }
+
+  /**
+   * The number of data-point marks a series renders (bars, line marks, or pie slices).
+   *
+   * @param seriesIndex The series to count; defaults to the first series.
+   */
+  async getDataPointCount(seriesIndex: number = 0): Promise<number> {
+    return listHelper.getListItemCount(
+      this,
+      locatorUtil.append(this.locator, byCssSelector(this.seriesDataPointsSelector(seriesIndex)))
+    );
+  }
+
+  /**
+   * Hover the pointer over a data-point mark, e.g. to raise the chart tooltip.
+   *
+   * jsdom has no layout engine, so no tooltip geometry exists there — the hover dispatches but
+   * tooltip assertions are E2E-only.
+   *
+   * @param dataIndex The data point's index within its series.
+   * @param seriesIndex The series holding the point; defaults to the first series.
+   */
+  async hoverDataPoint(dataIndex: number, seriesIndex: number = 0): Promise<void> {
+    const pointLocator = locatorUtil.append(
+      this.locator,
+      byCssSelector(this.dataPointSelector(seriesIndex, dataIndex))
+    );
+    if (!(await this.interactor.exists(pointLocator))) {
+      throw new Error(`${this.driverName}: no data point at series ${seriesIndex}, index ${dataIndex}`);
+    }
+    await this.interactor.hover(pointLocator);
+  }
+
+  /**
+   * The chart tooltip's text, or `undefined` while no tooltip is shown. Raise it first with
+   * {@link hoverDataPoint} (E2E-only — see its jsdom caveat).
+   */
+  async getTooltipText(): Promise<Optional<string>> {
+    if (!(await this.interactor.exists(tooltipLocator))) {
+      return undefined;
+    }
+    const text = await this.interactor.getText(tooltipLocator);
+    return text ?? undefined;
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/charts/LineChartDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/LineChartDriver.ts
@@ -1,0 +1,23 @@
+import { ChartDriverBase } from './ChartDriverBase';
+
+/**
+ * Driver for the MUI X v9 LineChart.
+ *
+ * Data points render as `circle.MuiLineChart-mark[data-index]` inside one clip group per series
+ * under `g.MuiLineChart-markPlot` — only when the series has `showMark` enabled; a mark-less
+ * line has no per-point DOM to count or hover.
+ * @see https://mui.com/x/react-charts/lines/
+ */
+export class LineChartDriver extends ChartDriverBase {
+  protected seriesDataPointsSelector(seriesIndex: number): string {
+    return `.MuiLineChart-markPlot g:nth-of-type(${seriesIndex + 1}) circle.MuiLineChart-mark`;
+  }
+
+  protected dataPointSelector(seriesIndex: number, dataIndex: number): string {
+    return `.MuiLineChart-markPlot g:nth-of-type(${seriesIndex + 1}) circle.MuiLineChart-mark[data-index="${dataIndex}"]`;
+  }
+
+  get driverName(): string {
+    return 'MuiV9LineChart';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/charts/PieChartDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/PieChartDriver.ts
@@ -1,0 +1,23 @@
+import { ChartDriverBase } from './ChartDriverBase';
+
+/**
+ * Driver for the MUI X v9 PieChart.
+ *
+ * Slices render as `path.MuiPieChart-arc[data-index]` inside one `g.MuiPieChart-series` group
+ * per series. A pie's legend lists one item per slice (not per series), so
+ * {@link ChartDriverBase.getLegendItems} returns the slice labels.
+ * @see https://mui.com/x/react-charts/pie/
+ */
+export class PieChartDriver extends ChartDriverBase {
+  protected seriesDataPointsSelector(seriesIndex: number): string {
+    return `.MuiPieChart-series:nth-of-type(${seriesIndex + 1}) path.MuiPieChart-arc`;
+  }
+
+  protected dataPointSelector(seriesIndex: number, dataIndex: number): string {
+    return `.MuiPieChart-series:nth-of-type(${seriesIndex + 1}) path.MuiPieChart-arc[data-index="${dataIndex}"]`;
+  }
+
+  get driverName(): string {
+    return 'MuiV9PieChart';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/charts/ScatterChartDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/ScatterChartDriver.ts
@@ -1,0 +1,25 @@
+import { ChartDriverBase } from './ChartDriverBase';
+
+/**
+ * Driver for the MUI X v9 ScatterChart.
+ *
+ * Points render as `circle.MuiScatterChart-marker` siblings inside one `g.MuiScatterChart-series`
+ * group per series (groups in series order); markers carry no index attribute, so both series and
+ * marker are addressed positionally. The legend's own swatch (`circle.MuiChartsLabelMark-fill`)
+ * lives outside the series groups, so scoping the selector to `.MuiScatterChart-series` keeps it
+ * out of the data-point count.
+ * @see https://mui.com/x/react-charts/scatter/
+ */
+export class ScatterChartDriver extends ChartDriverBase {
+  protected seriesDataPointsSelector(seriesIndex: number): string {
+    return `.MuiScatterChart-series:nth-of-type(${seriesIndex + 1}) circle.MuiScatterChart-marker`;
+  }
+
+  protected dataPointSelector(seriesIndex: number, dataIndex: number): string {
+    return `${this.seriesDataPointsSelector(seriesIndex)}:nth-of-type(${dataIndex + 1})`;
+  }
+
+  get driverName(): string {
+    return 'MuiV9ScatterChart';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/charts/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/index.ts
@@ -2,3 +2,4 @@ export * from './BarChartDriver';
 export * from './ChartDriverBase';
 export * from './LineChartDriver';
 export * from './PieChartDriver';
+export * from './ScatterChartDriver';

--- a/packages/component-driver-mui-x-v9/src/components/charts/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/charts/index.ts
@@ -1,0 +1,4 @@
+export * from './BarChartDriver';
+export * from './ChartDriverBase';
+export * from './LineChartDriver';
+export * from './PieChartDriver';

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -1,5 +1,6 @@
 import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
 import {
+  byAttribute,
   byCssClass,
   byCssSelector,
   byRole,
@@ -39,6 +40,51 @@ const parts = {
 } satisfies ScenePart;
 
 const dataRowLocator = byCssSelector('[role=row][data-rowindex]');
+
+// Toolbar controls are identified by their icon's `data-testid` (`:has()` is supported by both
+// jsdom's selector engine and every Playwright browser) — the buttons' aria-labels interpolate
+// localized text, so the icon is the stable, locale-independent handle.
+const quickFilterTriggerLocator = byCssSelector('.MuiDataGrid-toolbar button:has([data-testid="SearchIcon"])');
+const quickFilterInputLocator = byCssSelector('input[role="searchbox"]');
+const filterPanelTriggerLocator = byCssSelector('.MuiDataGrid-toolbar button:has([data-testid="FilterListIcon"])');
+
+// The filter panel, select dropdowns, and column menu are portaled to <body>, so they are
+// addressed from the document Root. Only one of each is open at a time.
+const filterPanelLocator = byCssSelector('.MuiDataGrid-panel', 'Root');
+const filterPanelColumnComboboxLocator = byCssSelector(
+  '.MuiDataGrid-panel .MuiDataGrid-filterFormColumnInput [role="combobox"]',
+  'Root'
+);
+const filterPanelOperatorComboboxLocator = byCssSelector(
+  '.MuiDataGrid-panel .MuiDataGrid-filterFormOperatorInput [role="combobox"]',
+  'Root'
+);
+const filterPanelValueInputLocator = byCssSelector(
+  '.MuiDataGrid-panel .MuiDataGrid-filterFormValueInput input',
+  'Root'
+);
+const selectListboxLocator = byCssSelector('[role="listbox"]', 'Root');
+const columnMenuLocator = byCssSelector('[role="menu"]', 'Root');
+const hideColumnMenuItemLocator = byCssSelector('[role="menu"] li:has([data-testid="VisibilityOffIcon"])', 'Root');
+
+// Both the page-size select's input-base wrapper and its inner combobox carry
+// `MuiTablePagination-select`; the role pins the combobox element itself.
+const pageSizeComboboxLocator = byCssSelector('.MuiTablePagination-select[role="combobox"]');
+
+const selectedRowCountLocator = byCssClass('MuiDataGrid-selectedRowCount');
+const headerCheckboxLocator = byCssSelector('[role=columnheader][data-field="__check__"] input[type="checkbox"]');
+const virtualScrollerLocator = byCssClass('MuiDataGrid-virtualScroller');
+const overlayWrapperLocator = byCssClass('MuiDataGrid-overlayWrapper');
+
+/** `aria-sort` attribute values mapped to the driver's sort-direction vocabulary. */
+const ariaSortToDirection: Record<string, 'asc' | 'desc' | null> = {
+  ascending: 'asc',
+  descending: 'desc',
+  none: null,
+};
+
+/** Rough row-height estimate used to size virtualization scroll steps. */
+const estimatedRowHeightPx = 40;
 
 /**
  * Driver for the Material UI v9 DataGridPremium component.
@@ -175,6 +221,426 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
     const columnIdentifier = 'columnIndex' in query ? query.columnIndex : query.columnField;
     throw new Error(`Cell at row:${query.rowIndex} column:${columnIdentifier} does not exist`);
   }
+
+  //#region Locator helpers
+  private rowLocator(rowIndex: number): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector(`[role=row][data-rowindex="${rowIndex}"]`));
+  }
+
+  private columnHeaderLocator(field: string): PartLocator {
+    return locatorUtil.append(this.locator, byCssSelector(`[role=columnheader][data-field="${field}"]`));
+  }
+
+  private cellLocator(query: DataGridCellQuery): PartLocator {
+    const cellSelector =
+      'columnIndex' in query
+        ? byAttribute('data-colindex', String(query.columnIndex))
+        : byAttribute('data-field', query.columnField);
+    return locatorUtil.append(this.rowLocator(query.rowIndex), cellSelector);
+  }
+
+  private describeCell(query: DataGridCellQuery): string {
+    const columnIdentifier = 'columnIndex' in query ? query.columnIndex : query.columnField;
+    return `row:${query.rowIndex} column:${columnIdentifier}`;
+  }
+
+  /**
+   * Open a MUI Select dropdown and choose the option carrying the given `data-value`. The
+   * dropdown portals its listbox to <body>; waiting for it to close keeps the portal from
+   * overlaying whatever the caller interacts with next.
+   */
+  private async selectFromMuiSelect(comboboxLocator: PartLocator, value: string, timeoutMs: number): Promise<void> {
+    await this.interactor.click(comboboxLocator);
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(selectListboxLocator),
+      terminateCondition: true,
+      timeoutMs,
+    });
+    await this.interactor.click(
+      byCssSelector(`[role="listbox"] [role="option"][data-value="${value}"]`, 'Root') as PartLocator
+    );
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(selectListboxLocator),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+  //#endregion Locator helpers
+
+  //#region Sorting
+  /**
+   * The current sort direction of a column, read from its header's `aria-sort`:
+   * `'asc'`, `'desc'`, or `null` when the column is unsorted.
+   */
+  async getSortDirection(field: string): Promise<'asc' | 'desc' | null> {
+    const ariaSort = await this.interactor.getAttribute(this.columnHeaderLocator(field), 'aria-sort');
+    if (ariaSort == null) {
+      throw new Error(`${this.driverName}: column "${field}" is not currently rendered`);
+    }
+    return ariaSortToDirection[ariaSort] ?? null;
+  }
+
+  /**
+   * Sort by the given column by clicking its header until the requested direction is active.
+   * The default sorting order cycles unsorted → asc → desc, so at most three clicks are needed;
+   * a direction the grid never reaches (e.g. removed via a custom `sortingOrder`) throws.
+   *
+   * @param field The column's field name.
+   * @param direction The direction to reach; `null` returns the column to unsorted.
+   */
+  async sortByColumn(field: string, direction: 'asc' | 'desc' | null = 'asc'): Promise<void> {
+    const titleLocator = locatorUtil.append(
+      this.locator,
+      byCssSelector(`[role=columnheader][data-field="${field}"] .MuiDataGrid-columnHeaderTitleContainer`)
+    );
+    for (let click = 0; click < 3; click++) {
+      if ((await this.getSortDirection(field)) === direction) {
+        return;
+      }
+      await this.interactor.click(titleLocator);
+    }
+    if ((await this.getSortDirection(field)) === direction) {
+      return;
+    }
+    throw new Error(
+      `${this.driverName}: sorting column "${field}" never reached direction ${JSON.stringify(direction)}`
+    );
+  }
+  //#endregion Sorting
+
+  //#region Filtering
+  /**
+   * Type into the toolbar's quick filter (expanding it first — v9 collapses the search input
+   * behind its toolbar trigger). Requires the grid's `showToolbar`. Filtering applies after the
+   * grid's input debounce; pair with {@link waitForRowCount} for deterministic assertions.
+   */
+  async setQuickFilter(text: string): Promise<void> {
+    const input = locatorUtil.append(this.locator, quickFilterInputLocator);
+    const trigger = locatorUtil.append(this.locator, quickFilterTriggerLocator);
+    if (await this.interactor.exists(trigger)) {
+      await this.interactor.click(trigger);
+    }
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(input),
+      terminateCondition: true,
+      timeoutMs: 10000,
+    });
+    await this.interactor.enterText(input, text);
+  }
+
+  /**
+   * Wait until the number of rendered data rows equals `expected` — the deterministic follow-up
+   * to debounced operations such as {@link setQuickFilter} and {@link setColumnFilter}.
+   */
+  async waitForRowCount(expected: number, timeoutMs: number = 10000): Promise<void> {
+    const count = await this.waitUntil({
+      probeFn: () => this.getRowCount(),
+      terminateCondition: expected,
+      timeoutMs,
+    });
+    if (count !== expected) {
+      throw new Error(`${this.driverName}: expected ${expected} rows but found ${count} after ${timeoutMs}ms`);
+    }
+  }
+
+  /**
+   * Open the toolbar's filter panel (no-op when already open). Requires `showToolbar`.
+   */
+  async openFilterPanel(timeoutMs: number = 10000): Promise<void> {
+    if (await this.interactor.exists(filterPanelLocator)) {
+      return;
+    }
+    await this.interactor.click(locatorUtil.append(this.locator, filterPanelTriggerLocator));
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(filterPanelLocator),
+      terminateCondition: true,
+      timeoutMs,
+    });
+  }
+
+  /**
+   * Dismiss the filter panel (no-op when closed). The applied filter stays active.
+   */
+  async closeFilterPanel(timeoutMs: number = 10000): Promise<void> {
+    if (!(await this.interactor.exists(filterPanelLocator))) {
+      return;
+    }
+    await this.interactor.pressKey(filterPanelLocator, 'Escape');
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(filterPanelLocator),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+
+  /**
+   * Apply a single-column filter through the filter panel: pick the column (the panel defaults
+   * to the grid's first column, which may even be hidden), optionally pick the operator, and
+   * type the filter value. The panel is left open, mirroring the user flow; filtering applies
+   * after the grid's input debounce — pair with {@link waitForRowCount}.
+   *
+   * @param field The column's field name.
+   * @param value The filter value to type.
+   * @param operator Optional operator `data-value` (e.g. `'contains'`, `'equals'`, `'>'`).
+   */
+  async setColumnFilter(field: string, value: string, operator?: string, timeoutMs: number = 10000): Promise<void> {
+    await this.openFilterPanel(timeoutMs);
+    await this.selectFromMuiSelect(filterPanelColumnComboboxLocator, field, timeoutMs);
+    if (operator != null) {
+      await this.selectFromMuiSelect(filterPanelOperatorComboboxLocator, operator, timeoutMs);
+    }
+    await this.interactor.enterText(filterPanelValueInputLocator, value);
+  }
+  //#endregion Filtering
+
+  //#region Row selection
+  /**
+   * Whether the row at the given index is selected (`aria-selected` on the row element).
+   */
+  async isRowSelected(rowIndex: number): Promise<boolean> {
+    const ariaSelected = await this.interactor.getAttribute(this.rowLocator(rowIndex), 'aria-selected');
+    return ariaSelected === 'true';
+  }
+
+  /**
+   * Select the row at the given index via its selection checkbox (no-op when already selected).
+   * Requires the grid's `checkboxSelection`.
+   */
+  async selectRow(rowIndex: number): Promise<void> {
+    if (!(await this.isRowSelected(rowIndex))) {
+      await this.toggleRowCheckbox(rowIndex);
+    }
+  }
+
+  /**
+   * Deselect the row at the given index via its selection checkbox (no-op when not selected).
+   */
+  async deselectRow(rowIndex: number): Promise<void> {
+    if (await this.isRowSelected(rowIndex)) {
+      await this.toggleRowCheckbox(rowIndex);
+    }
+  }
+
+  private async toggleRowCheckbox(rowIndex: number): Promise<void> {
+    await this.interactor.click(locatorUtil.append(this.rowLocator(rowIndex), byCssSelector('input[type="checkbox"]')));
+  }
+
+  /**
+   * Select every row via the header checkbox (no-op when all are already selected).
+   */
+  async selectAllRows(): Promise<void> {
+    const headerCheckbox = locatorUtil.append(this.locator, headerCheckboxLocator);
+    if (!(await this.interactor.isChecked(headerCheckbox))) {
+      await this.interactor.click(headerCheckbox);
+    }
+  }
+
+  /**
+   * Deselect every row via the header checkbox. From the indeterminate state (some rows
+   * selected) the first click selects all, so up to two clicks may be needed.
+   */
+  async deselectAllRows(): Promise<void> {
+    const headerCheckbox = locatorUtil.append(this.locator, headerCheckboxLocator);
+    for (let click = 0; click < 2 && (await this.getSelectedRowCount()) > 0; click++) {
+      await this.interactor.click(headerCheckbox);
+    }
+  }
+
+  /**
+   * The number of selected rows, parsed from the footer's "n rows selected" summary (which the
+   * grid only renders while at least one row is selected — its absence means 0). Unlike counting
+   * `aria-selected` rows, the summary also covers selected rows that virtualization has not
+   * rendered.
+   */
+  async getSelectedRowCount(): Promise<number> {
+    const summaryLocator = locatorUtil.append(this.locator, selectedRowCountLocator);
+    if (!(await this.interactor.exists(summaryLocator))) {
+      return 0;
+    }
+    const text = (await this.interactor.getText(summaryLocator)) ?? '';
+    const match = /([\d,]+)/.exec(text);
+    return match == null ? 0 : Number(match[1].replace(/,/g, ''));
+  }
+  //#endregion Row selection
+
+  //#region Cell editing
+  /**
+   * Put the cell into edit mode: click it (moving the grid's focus there) and press Enter — the
+   * grid's keyboard path into editing. The column must be `editable`.
+   */
+  async startCellEdit(query: DataGridCellQuery, timeoutMs: number = 10000): Promise<void> {
+    const cell = this.cellLocator(query);
+    if (!(await this.interactor.exists(cell))) {
+      throw new Error(`${this.driverName}: cell at ${this.describeCell(query)} does not exist`);
+    }
+    await this.interactor.click(cell);
+    await this.interactor.pressKey(cell, 'Enter');
+    const editing = await this.waitUntil({
+      probeFn: () => this.isCellEditing(query),
+      terminateCondition: true,
+      timeoutMs,
+    });
+    if (!editing) {
+      throw new Error(
+        `${this.driverName}: cell at ${this.describeCell(query)} never entered edit mode — is the column marked editable?`
+      );
+    }
+  }
+
+  /**
+   * Whether the cell is currently in edit mode.
+   */
+  async isCellEditing(query: DataGridCellQuery): Promise<boolean> {
+    return this.interactor.hasCssClass(this.cellLocator(query), 'MuiDataGrid-cell--editing');
+  }
+
+  /**
+   * Replace the value in the cell's editor, entering edit mode first if needed. The value is not
+   * committed until {@link commitCellEdit} (or discarded by {@link cancelCellEdit}).
+   */
+  async setCellValue(query: DataGridCellQuery, value: string, timeoutMs: number = 10000): Promise<void> {
+    if (!(await this.isCellEditing(query))) {
+      await this.startCellEdit(query, timeoutMs);
+    }
+    await this.interactor.enterText(this.editingInputLocator(query), value);
+  }
+
+  /**
+   * Commit the pending cell edit with Enter and wait for edit mode to end.
+   */
+  async commitCellEdit(query: DataGridCellQuery, timeoutMs: number = 10000): Promise<void> {
+    await this.interactor.pressKey(this.editingInputLocator(query), 'Enter');
+    await this.waitUntil({
+      probeFn: () => this.isCellEditing(query),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+
+  /**
+   * Discard the pending cell edit with Escape and wait for edit mode to end.
+   */
+  async cancelCellEdit(query: DataGridCellQuery, timeoutMs: number = 10000): Promise<void> {
+    await this.interactor.pressKey(this.editingInputLocator(query), 'Escape');
+    await this.waitUntil({
+      probeFn: () => this.isCellEditing(query),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+
+  private editingInputLocator(query: DataGridCellQuery): PartLocator {
+    return locatorUtil.append(this.cellLocator(query), byCssSelector('input'));
+  }
+  //#endregion Cell editing
+
+  //#region Column management
+  /**
+   * Open the column's menu. The menu trigger only shows on header hover, so the header is
+   * hovered first.
+   */
+  async openColumnMenu(field: string, timeoutMs: number = 10000): Promise<void> {
+    const header = this.columnHeaderLocator(field);
+    await this.interactor.hover(header);
+    await this.interactor.click(locatorUtil.append(header, byCssSelector('.MuiDataGrid-menuIcon button')));
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(columnMenuLocator),
+      terminateCondition: true,
+      timeoutMs,
+    });
+  }
+
+  /**
+   * Hide the column through its column menu ("Hide column" — identified by its icon, so the
+   * entry stays locale-independent) and wait for the header to leave the DOM. Re-showing a
+   * hidden column goes through the "Manage columns" panel, which this driver does not cover.
+   */
+  async hideColumn(field: string, timeoutMs: number = 10000): Promise<void> {
+    await this.openColumnMenu(field, timeoutMs);
+    await this.interactor.click(hideColumnMenuItemLocator);
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(this.columnHeaderLocator(field)),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+  //#endregion Column management
+
+  //#region Page size and overlays
+  /**
+   * The rows-per-page currently selected in the footer's page-size select.
+   */
+  async getPageSize(): Promise<number> {
+    const text = await this.interactor.getText(locatorUtil.append(this.locator, pageSizeComboboxLocator));
+    return Number(text);
+  }
+
+  /**
+   * Change the rows-per-page through the footer's page-size select. The size must be one of the
+   * grid's `pageSizeOptions`.
+   */
+  async setPageSize(size: number, timeoutMs: number = 10000): Promise<void> {
+    await this.selectFromMuiSelect(locatorUtil.append(this.locator, pageSizeComboboxLocator), String(size), timeoutMs);
+    const applied = await this.waitUntil({
+      probeFn: () => this.getPageSize(),
+      terminateCondition: size,
+      timeoutMs,
+    });
+    if (applied !== size) {
+      throw new Error(`${this.driverName}: page size never became ${size} (still ${applied})`);
+    }
+  }
+
+  /**
+   * Whether the grid is showing an empty-state overlay (e.g. "No rows") — an overlay wrapper is
+   * mounted and the grid is not merely loading.
+   */
+  async isEmpty(): Promise<boolean> {
+    const overlayExists = await this.interactor.exists(locatorUtil.append(this.locator, overlayWrapperLocator));
+    if (!overlayExists) {
+      return false;
+    }
+    return !(await this.isLoading());
+  }
+  //#endregion Page size and overlays
+
+  //#region Virtualization
+  /**
+   * Bring a virtualized row into the rendered window by paging the grid's virtual scroller
+   * toward it, then scroll it into the viewport. Rows outside the current page cannot be
+   * reached — change pages instead. jsdom has no layout engine, so there the grid renders the
+   * whole page and this resolves immediately; genuine scrolling behavior is E2E-only.
+   */
+  async scrollRowIntoView(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
+    const row = this.rowLocator(rowIndex);
+    const scroller = locatorUtil.append(this.locator, virtualScrollerLocator);
+    const gridRowLocator = locatorUtil.append(this.locator, dataRowLocator);
+    const found = await this.waitUntil({
+      probeFn: async () => {
+        if (await this.interactor.exists(row)) {
+          return true;
+        }
+        // Step the scroller toward the target, sized by how far the rendered window is from it.
+        const renderedIndexes = (await this.interactor.getAttribute(gridRowLocator, 'data-rowindex', true)).map(Number);
+        if (renderedIndexes.length > 0) {
+          const nearestRendered =
+            rowIndex > Math.max(...renderedIndexes) ? Math.max(...renderedIndexes) : Math.min(...renderedIndexes);
+          const stepPx = (rowIndex - nearestRendered) * estimatedRowHeightPx;
+          await this.interactor.scrollBy(scroller, { x: 0, y: stepPx });
+        }
+        return this.interactor.exists(row);
+      },
+      terminateCondition: true,
+      timeoutMs,
+    });
+    if (!found) {
+      throw new Error(
+        `${this.driverName}: row ${rowIndex} never rendered — it may be outside the current page or filtered out`
+      );
+    }
+    await this.interactor.scrollIntoView(row);
+  }
+  //#endregion Virtualization
 
   //#region Footer
   /**

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -67,6 +67,34 @@ const selectListboxLocator = byCssSelector('[role="listbox"]', 'Root');
 const columnMenuLocator = byCssSelector('[role="menu"]', 'Root');
 const hideColumnMenuItemLocator = byCssSelector('[role="menu"] li:has([data-testid="VisibilityOffIcon"])', 'Root');
 
+// Pin/unpin column-menu entries. "Pin to left"/"Pin to right" carry distinct pushpin icons, so
+// they follow the icon-`data-testid` convention. "Unpin" is the outlier — it renders with an
+// *empty* icon slot (no `svg[data-testid]`), so it is addressed as the one menu item whose
+// `.MuiListItemIcon-root` holds an empty `<span>`. That empty-icon shape appears only for Unpin,
+// and only while a column is pinned, keeping the locator both unique and locale-independent.
+const pinLeftMenuItemLocator = byCssSelector('[role="menu"] li:has([data-testid="PushPinLeftIcon"])', 'Root');
+const pinRightMenuItemLocator = byCssSelector('[role="menu"] li:has([data-testid="PushPinRightIcon"])', 'Root');
+const unpinMenuItemLocator = byCssSelector('[role="menu"] li:has(.MuiListItemIcon-root > span:empty)', 'Root');
+
+// A pinned column header carries a side-specific modifier class; the body cells mirror it, but the
+// header is the single, stable read.
+const pinnedLeftHeaderClass = 'MuiDataGrid-columnHeader--pinnedLeft';
+const pinnedRightHeaderClass = 'MuiDataGrid-columnHeader--pinnedRight';
+
+// Row grouping: group-header rows are the only rows carrying `aria-expanded` (data rows and the
+// aggregation footer row do not), so that attribute is the structural handle for counting and
+// reading their expand/collapse state. Each group row's toggle button lives in its grouping cell.
+const groupHeaderRowLocator = byCssSelector('[role="row"][aria-expanded]');
+const groupToggleLocator = byCssSelector('.MuiDataGrid-groupingCriteriaCellToggle button');
+
+// The grand-total aggregation row is pinned to the grid bottom with a fixed generated id; its
+// per-column cells hold the aggregated values.
+const aggregationFooterRowLocator = byCssSelector('[role="row"][data-id="auto-generated-group-footer-root"]');
+
+// The resize handle within a column header. MUI drives resizing with mouse events on this
+// separator (not HTML5 drag-and-drop), so the portable pixel-delta `drag` primitive can move it.
+const resizeSeparatorSelector = '.MuiDataGrid-columnSeparator--resizable';
+
 // Both the page-size select's input-base wrapper and its inner combobox carry
 // `MuiTablePagination-select`; the role pins the combobox element itself.
 const pageSizeComboboxLocator = byCssSelector('.MuiTablePagination-select[role="combobox"]');
@@ -564,7 +592,185 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
       timeoutMs,
     });
   }
+
+  /**
+   * Which side the column is pinned to (`'left'`/`'right'`), or `null` when it is not pinned,
+   * read from the column header's side-specific modifier class.
+   */
+  async isColumnPinned(field: string): Promise<'left' | 'right' | null> {
+    const header = this.columnHeaderLocator(field);
+    if (await this.interactor.hasCssClass(header, pinnedLeftHeaderClass)) {
+      return 'left';
+    }
+    if (await this.interactor.hasCssClass(header, pinnedRightHeaderClass)) {
+      return 'right';
+    }
+    return null;
+  }
+
+  /**
+   * Pin the column to the given side through its column menu ("Pin to left"/"Pin to right",
+   * identified by icon so the entry stays locale-independent). No-op when the column is already
+   * pinned to that side — the menu omits that side's entry in that state. Requires a Pro/Premium
+   * grid (the community DataGrid has no column pinning).
+   *
+   * @param field The column's field name.
+   * @param side The side to pin to.
+   */
+  async pinColumn(field: string, side: 'left' | 'right', timeoutMs: number = 10000): Promise<void> {
+    if ((await this.isColumnPinned(field)) === side) {
+      return;
+    }
+    await this.openColumnMenu(field, timeoutMs);
+    await this.interactor.click(side === 'left' ? pinLeftMenuItemLocator : pinRightMenuItemLocator);
+    const pinned = await this.waitUntil({
+      probeFn: () => this.isColumnPinned(field),
+      terminateCondition: side,
+      timeoutMs,
+    });
+    if (pinned !== side) {
+      throw new Error(`${this.driverName}: column "${field}" never pinned to ${side}`);
+    }
+  }
+
+  /**
+   * Unpin the column through its column menu ("Unpin"). No-op when the column is not pinned.
+   *
+   * @param field The column's field name.
+   */
+  async unpinColumn(field: string, timeoutMs: number = 10000): Promise<void> {
+    if ((await this.isColumnPinned(field)) === null) {
+      return;
+    }
+    await this.openColumnMenu(field, timeoutMs);
+    await this.interactor.click(unpinMenuItemLocator);
+    const pinned = await this.waitUntil({
+      probeFn: () => this.isColumnPinned(field),
+      terminateCondition: null,
+      timeoutMs,
+    });
+    if (pinned !== null) {
+      throw new Error(`${this.driverName}: column "${field}" never unpinned (still ${pinned})`);
+    }
+  }
+
+  /**
+   * Resize the column by dragging its header's resize separator by `deltaPx` (positive widens,
+   * negative narrows). MUI drives resizing with mouse events on the separator, so this uses the
+   * portable pixel-delta drag.
+   *
+   * jsdom has no layout engine, so the drag has no positional outcome there and the width does not
+   * change — this only exercises the code path under jsdom; the actual resize is E2E-only.
+   *
+   * @param field The column's field name.
+   * @param deltaPx Horizontal pixels to drag the separator by.
+   */
+  async resizeColumn(field: string, deltaPx: number): Promise<void> {
+    const header = this.columnHeaderLocator(field);
+    if (!(await this.interactor.exists(header))) {
+      throw new Error(`${this.driverName}: column "${field}" is not currently rendered`);
+    }
+    const separator = locatorUtil.append(header, byCssSelector(resizeSeparatorSelector));
+    await this.interactor.drag(separator, { x: deltaPx, y: 0 });
+  }
+
+  /**
+   * The rendered pixel width of the column's header — the observable outcome of
+   * {@link resizeColumn}. Reads the header's bounding box, so it is only meaningful E2E (jsdom
+   * reports a zero-size box).
+   *
+   * @param field The column's field name.
+   */
+  async getColumnWidth(field: string): Promise<number> {
+    const rect = await this.interactor.getBoundingRect(this.columnHeaderLocator(field));
+    return rect.width;
+  }
   //#endregion Column management
+
+  //#region Row grouping and aggregation
+  /**
+   * The number of group-header rows currently rendered. Group headers are the only rows carrying
+   * `aria-expanded`, and this counts every match (not just the virtualization window's first run),
+   * so it stays correct with groups expanded or collapsed. Requires the grid's `rowGrouping`.
+   */
+  async getGroupRowCount(): Promise<number> {
+    const groupRows = await this.interactor.getAttribute(
+      locatorUtil.append(this.locator, groupHeaderRowLocator),
+      'aria-expanded',
+      true
+    );
+    return groupRows.length;
+  }
+
+  /**
+   * Whether the group header at the given row index is expanded, from its `aria-expanded`. Groups
+   * are addressed by row index — the same addressing as {@link getRow}/{@link getCell} — so the
+   * caveat is identical: expanding a group shifts the indices of the rows below it. Throws when the
+   * row at that index is not a group header.
+   *
+   * @param rowIndex The rendered `data-rowindex` of the group header row.
+   */
+  async isGroupExpanded(rowIndex: number): Promise<boolean> {
+    const ariaExpanded = await this.interactor.getAttribute(this.rowLocator(rowIndex), 'aria-expanded');
+    if (ariaExpanded == null) {
+      throw new Error(`${this.driverName}: row ${rowIndex} is not a group header row`);
+    }
+    return ariaExpanded === 'true';
+  }
+
+  /**
+   * Expand the group header at the given row index by clicking its toggle (no-op when already
+   * expanded). See {@link isGroupExpanded} for the row-index addressing caveat.
+   */
+  async expandGroup(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
+    await this.setGroupExpansion(rowIndex, true, timeoutMs);
+  }
+
+  /**
+   * Collapse the group header at the given row index by clicking its toggle (no-op when already
+   * collapsed). See {@link isGroupExpanded} for the row-index addressing caveat.
+   */
+  async collapseGroup(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
+    await this.setGroupExpansion(rowIndex, false, timeoutMs);
+  }
+
+  private async setGroupExpansion(rowIndex: number, expanded: boolean, timeoutMs: number): Promise<void> {
+    if ((await this.isGroupExpanded(rowIndex)) === expanded) {
+      return;
+    }
+    await this.interactor.click(locatorUtil.append(this.rowLocator(rowIndex), groupToggleLocator));
+    const reached = await this.waitUntil({
+      probeFn: () => this.isGroupExpanded(rowIndex),
+      terminateCondition: expanded,
+      timeoutMs,
+    });
+    if (reached !== expanded) {
+      throw new Error(
+        `${this.driverName}: group at row ${rowIndex} never became ${expanded ? 'expanded' : 'collapsed'}`
+      );
+    }
+  }
+
+  /**
+   * The aggregated value shown for a column in the grid's grand-total footer row (e.g. the sum of
+   * a quantity column), as displayed text — `null` when that column has no aggregation. Requires
+   * the grid's `aggregation` model. The text is grid-formatted (e.g. thousands separators); parse
+   * it on the caller side if a number is needed.
+   *
+   * @param field The aggregated column's field name.
+   */
+  async getAggregationValue(field: string): Promise<string | null> {
+    const footerCell = locatorUtil.append(
+      locatorUtil.append(this.locator, aggregationFooterRowLocator),
+      byCssSelector(`[role="gridcell"][data-field="${field}"]`)
+    );
+    if (!(await this.interactor.exists(footerCell))) {
+      return null;
+    }
+    const text = await this.interactor.getText(footerCell);
+    return text == null || text.trim().length === 0 ? null : text.trim();
+  }
+  //#endregion Row grouping and aggregation
 
   //#region Page size and overlays
   /**

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DateRangePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DateRangePickerDriver.ts
@@ -1,0 +1,30 @@
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+
+import { dateRangeToTextEntry, textEntryToDateRange } from './dateUtil';
+import { PickerFieldDriverBase } from './PickerFieldDriverBase';
+import { DatePickerCharacteristic, DateRange } from './types';
+
+/**
+ * Driver for the MUI X v9 (Pro) DateRangePicker with its default single-input field.
+ *
+ * The field is one section list holding both dates' sections separated by a dash, mirrored by
+ * one hidden input (e.g. `"06/27/2026 – 07/04/2026"`) — so the section-field mechanics of
+ * {@link PickerFieldDriverBase} apply unchanged with a {@link DateRange} value. `setValue` types
+ * the start date's digits then the end date's (auto-advance carries typing across the range
+ * separator) and requires both sides; pass `null` to clear the whole field.
+ * @see https://mui.com/x/react-date-pickers/date-range-picker/
+ */
+export class DateRangePickerDriver extends PickerFieldDriverBase<DateRange> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic<DateRange> = {
+      valueToTextEntry: dateRangeToTextEntry,
+      textEntryToValue: textEntryToDateRange,
+      defaultFormat: 'mm/dd/yyyy – mm/dd/yyyy',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  get driverName(): string {
+    return 'MuiV9DateRangePicker';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DateTimePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DateTimePickerDriver.ts
@@ -1,0 +1,29 @@
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+
+import { dateTimeToTextEntry, textEntryToDateTime } from './dateUtil';
+import { PickerFieldDriverBase } from './PickerFieldDriverBase';
+import { DatePickerCharacteristic } from './types';
+
+/**
+ * Driver for the MUI X v9 desktop DateTimePicker.
+ *
+ * Reads and writes go through the section field ({@link PickerFieldDriverBase}): `setValue`
+ * types the date digits, then the time digits, then the meridiem letter (`a`/`p`) — MUI
+ * auto-advances across the date/time boundary. The popup (calendar + digital clock) is a
+ * multi-step surface, so the keystroke path is the write path here.
+ * @see https://mui.com/x/react-date-pickers/date-time-picker/
+ */
+export class DateTimePickerDriver extends PickerFieldDriverBase<Date> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: dateTimeToTextEntry,
+      textEntryToValue: textEntryToDateTime,
+      defaultFormat: 'mm/dd/yyyy hh:mm (a|p)m',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  get driverName(): string {
+    return 'MuiV9DateTimePicker';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriver.ts
@@ -1,12 +1,13 @@
 import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
 
-import { textEntryToDate } from './dateUtil';
+import { dateToTextEntry, textEntryToDate } from './dateUtil';
 import { DesktopDatePickerDriverBase } from './DesktopDatePickerDriverBase';
 import { DatePickerCharacteristic } from './types';
 
 export class DesktopDatePickerDriver extends DesktopDatePickerDriverBase {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: dateToTextEntry,
       textEntryToValue: textEntryToDate,
       defaultFormat: 'mm/dd/yyyy',
     };

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/DesktopDatePickerDriverBase.ts
@@ -1,152 +1,67 @@
-import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
-import {
-  byCssClass,
-  byCssSelector,
-  ComponentDriver,
-  IComponentDriverOption,
-  Interactor,
-  locatorUtil,
-  Optional,
-  PartLocator,
-  ScenePart,
-} from '@atomic-testing/core';
+import { byCssSelector, IComponentDriverOption, Interactor, locatorUtil, PartLocator } from '@atomic-testing/core';
 
+import { clickCalendarDay, navigateCalendarToMonth, waitForDayGrid } from './calendarNavigation';
+import { openPickerButtonLocator, PickerFieldDriverBase } from './PickerFieldDriverBase';
 import { DatePickerCharacteristic } from './types';
 
-// Since MUI X v6 the desktop pickers no longer use a plain editable <input>. The visible field
-// is a `PickersSectionList`: a `role="group"` of `contenteditable` `role="spinbutton"` section
-// spans (`.MuiPickersSectionList-sectionContent`, one per Month/Day/Year). A single hidden,
-// `aria-hidden` `<input class="MuiPickersInputBase-input">` mirrors the committed value as a
-// locale-formatted string for form submission — the stable, portable READ path.
-//
-// The WRITE path goes through the calendar popup, not the section field: typing into a section
-// is not portable (the Playwright interactor's `fill` replaces innerText, which MUI ignores, and
-// the DOM interactor's `pressKey` dispatches only `keydown`/`keyup` with no `input` event), but a
-// mouse click behaves identically across engines. So `setValue` opens the popup, walks to the
-// target month, and clicks the day cell. See {@link DesktopDatePickerDriverBase.setValue}.
-const parts = {
-  // The hidden input mirrors the committed value as a formatted string (e.g. "06/27/2026").
-  valueInput: {
-    locator: byCssClass('MuiPickersInputBase-input'),
-    driver: HTMLTextInputDriver,
-  },
-} satisfies ScenePart;
-
-// The open ("Choose date") adornment button carries a stable, locale-independent marker attribute
-// (its `aria-label` interpolates the selected date, so it is not a reliable handle).
-const openButtonLocator = byCssSelector('[data-mui-picker-open-button="true"]');
-
-// The calendar popup is portaled to <body>, so its parts are addressed from the document Root, not
-// as descendants of the picker. Only one picker popup is open at a time, so the singular root is
+// The calendar popup is portaled to <body>, so it is addressed from the document Root, not as a
+// descendant of the picker. Only one picker popup is open at a time, so the singular root is
 // unambiguous while open.
-const popupRoot = '.MuiPickerPopper-root';
-const popupLocator = byCssSelector(popupRoot, 'Root');
-const calendarHeaderLabelLocator = byCssSelector(`${popupRoot} .MuiPickersCalendarHeader-label`, 'Root');
-const previousMonthLocator = byCssSelector(`${popupRoot} .MuiPickersArrowSwitcher-previousIconButton`, 'Root');
-const nextMonthLocator = byCssSelector(`${popupRoot} .MuiPickersArrowSwitcher-nextIconButton`, 'Root');
-// In-month day cells are <button>s carrying a `data-timestamp`; out-of-month cells are filler
-// <div>s without one. Excluding `dayOutsideMonth` keeps the set to days 1..N even when a consumer
-// turns on `showDaysOutsideCurrentMonth`, so the buttons line up with day-of-month by position.
-const inMonthDayButtonsLocator = byCssSelector(
-  `${popupRoot} .MuiPickerDay-root[data-timestamp]:not(.MuiPickerDay-dayOutsideMonth)`,
-  'Root'
-);
-// While the month slide animates, MUI keeps the outgoing month grids mounted (marked
-// `slideExit`) alongside the incoming one, so the day-cell list briefly spans several months.
-// Waiting for no exiting grid to remain collapses the view back to a single month before any day
-// is read. (Under jsdom there is no animation, so this never matches and the wait is a no-op.)
-const exitingMonthGridLocator = byCssSelector(`${popupRoot} .MuiPickersSlideTransition-slideExit`, 'Root');
+const popupRootCss = '.MuiPickerPopper-root';
+const popupLocator = byCssSelector(popupRootCss, 'Root');
 
-function dayByTimestampLocator(timestamp: string): PartLocator {
-  return byCssSelector(`${popupRoot} .MuiPickerDay-root[data-timestamp="${timestamp}"]`, 'Root');
-}
-
-// Collapse a year+month to a single comparable ordinal so month deltas are a subtraction.
-function toMonthOrdinal(year: number, monthIndex: number): number {
-  return year * 12 + monthIndex;
-}
-
-// The header label (e.g. "June 2026") is parsed in the driver's own JS runtime — never in the
-// browser — so this `Date` parse runs on V8 in both the DOM and Playwright paths and needs no
-// cross-engine guarantee. Assumes the default (English) locale, matching this driver family's
-// other English defaults (e.g. the `mm/dd/yyyy` format fallback).
-function parseHeaderMonthOrdinal(label: string): number | null {
-  const parsed = new Date(label);
-  return Number.isNaN(parsed.getTime()) ? null : toMonthOrdinal(parsed.getFullYear(), parsed.getMonth());
-}
-
-export abstract class DesktopDatePickerDriverBase extends ComponentDriver<typeof parts> {
+/**
+ * Base driver for the desktop pickers: the section field mechanics (typed-keystroke
+ * `setValue`, hidden-input reads) come from {@link PickerFieldDriverBase}; this base adds the
+ * calendar popup as a pointer-driven alternative write path ({@link pickDate}) — open the
+ * popup, page to the target month, click the day cell — the way a mouse user would.
+ */
+export abstract class DesktopDatePickerDriverBase extends PickerFieldDriverBase<Date> {
   constructor(
     locator: PartLocator,
     interactor: Interactor,
-    protected characteristic: DatePickerCharacteristic,
+    characteristic: DatePickerCharacteristic<Date>,
     option?: Partial<IComponentDriverOption>
   ) {
-    super(locator, interactor, {
-      ...option,
-      parts,
-    });
+    super(locator, interactor, characteristic, option);
   }
 
   /**
-   * The committed value parsed into a `Date`, or `null` when the field is empty.
-   * Reads the hidden input that mirrors the field's locale-formatted value.
-   */
-  async getValue(): Promise<Date | null> {
-    const text = await this.getValueText();
-    if (text == null) {
-      return null;
-    }
-    const format = await this.getFormat();
-    return this.characteristic.textEntryToValue(text, format);
-  }
-
-  /**
-   * The raw locale-formatted text shown by the field (e.g. "06/27/2026"), or `undefined`
-   * when the field is empty.
-   */
-  async getValueText(): Promise<Optional<string>> {
-    await this.enforcePartExistence('valueInput');
-    const value = await this.interactor.getInputValue(this.parts.valueInput.locator);
-    return value != null && value.length > 0 ? value : undefined;
-  }
-
-  /**
-   * The v5 driver read the field's `placeholder` to discover the format, but the v9 section
-   * field has no placeholder attribute. The format is carried implicitly by the section spans,
-   * so fall back to the driver's declared default format.
-   */
-  async getFormat(defaultFormat: string = this.characteristic.defaultFormat): Promise<string> {
-    return defaultFormat;
-  }
-
-  /**
-   * Set the picker's committed value to `value` by operating the calendar popup the way a user
-   * would: open it, page to the target month, and click the day cell. Returns `true` once the day
-   * is clicked.
+   * Select a calendar date by operating the popup the way a user would: open it, page to the
+   * target month, and click the day cell. Accepts an ISO `yyyy-mm-dd` calendar date; the parts
+   * are read as a local date (no timezone shift), so the day clicked is exactly the one named.
    *
-   * Only the year/month/day of `value` are used — any time component is ignored. Clearing (setting
-   * an empty value) is not handled here; the default desktop picker has no clear affordance.
+   * This is the pointer-driven alternative to the keystroke-driven {@link setValue}.
+   *
+   * @param isoDate A `yyyy-mm-dd` string, e.g. `'2026-06-27'`.
+   */
+  async pickDate(isoDate: string): Promise<boolean> {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+    if (match == null) {
+      throw new Error(`${this.driverName}: pickDate expects a 'yyyy-mm-dd' date, received '${isoDate}'`);
+    }
+    const [, year, month, day] = match;
+    return this.pickDayViaCalendar(new Date(Number(year), Number(month) - 1, Number(day)));
+  }
+
+  /**
+   * Open the popup, page to `value`'s month, and click its day cell. Only the year/month/day of
+   * `value` are used — any time component is ignored.
    *
    * @param value The date to select.
    * @param timeoutMs Budget for the popup to open and the day grid to render. Defaults to 10s.
    */
-  async setValue(value: Date, timeoutMs: number = 10000): Promise<boolean> {
+  protected async pickDayViaCalendar(value: Date, timeoutMs: number = 10000): Promise<boolean> {
     await this.openCalendar(timeoutMs);
-    await this.navigateToMonth(value.getFullYear(), value.getMonth(), timeoutMs);
-
-    // Day cells render in DOM order as days 1..N, so the day-of-month indexes straight into the
-    // timestamp list. Reading the timestamp from the DOM (rather than recomputing it) keeps the
-    // selection free of any timezone assumption about how the picker stamps each day.
-    const timestamps = await this.interactor.getAttribute(inMonthDayButtonsLocator, 'data-timestamp', true);
-    const targetTimestamp = timestamps[value.getDate() - 1];
-    if (targetTimestamp == null) {
-      throw new Error(
-        `${this.driverName}: day ${value.getDate()} is not available in the displayed month (found ${timestamps.length} days)`
-      );
-    }
-
-    await this.interactor.click(dayByTimestampLocator(targetTimestamp));
+    await navigateCalendarToMonth(
+      this.interactor,
+      popupRootCss,
+      value.getFullYear(),
+      value.getMonth(),
+      timeoutMs,
+      this.driverName
+    );
+    await clickCalendarDay(this.interactor, popupRootCss, value.getDate(), this.driverName);
     // Selecting a day closes the popup (closeOnSelect). Best-effort wait so a lingering popup does
     // not overlay later interactions; the value is already committed by the click regardless.
     await this.waitUntil({
@@ -158,77 +73,12 @@ export abstract class DesktopDatePickerDriverBase extends ComponentDriver<typeof
   }
 
   /**
-   * Convenience wrapper over {@link setValue} that accepts an ISO `yyyy-mm-dd` calendar date. The
-   * parts are read as a local date (no timezone shift), so the day clicked is exactly the one named.
-   *
-   * @param isoDate A `yyyy-mm-dd` string, e.g. `'2026-06-27'`.
-   */
-  async pickDate(isoDate: string): Promise<boolean> {
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
-    if (match == null) {
-      throw new Error(`${this.driverName}: pickDate expects a 'yyyy-mm-dd' date, received '${isoDate}'`);
-    }
-    const [, year, month, day] = match;
-    return this.setValue(new Date(Number(year), Number(month) - 1, Number(day)));
-  }
-
-  /**
    * Open the calendar popup (no-op when already open) and wait until its day grid has rendered.
    */
   protected async openCalendar(timeoutMs: number = 10000): Promise<void> {
     if (!(await this.interactor.exists(popupLocator))) {
-      await this.interactor.click(locatorUtil.append(this.locator, openButtonLocator));
+      await this.interactor.click(locatorUtil.append(this.locator, openPickerButtonLocator));
     }
-    // The day grid mounts a tick after the popup, so wait for an actual day cell, not just the popup.
-    await this.waitUntil({
-      probeFn: () => this.interactor.exists(inMonthDayButtonsLocator),
-      terminateCondition: true,
-      timeoutMs,
-    });
-  }
-
-  /**
-   * Page the open calendar to the given year/month by clicking the previous/next-month arrows. The
-   * displayed month is re-read from the header each step, so the walk converges regardless of arrow
-   * animation, and is bounded so an unreachable target (e.g. blocked by `minDate`/`maxDate`) fails
-   * fast instead of looping forever.
-   */
-  protected async navigateToMonth(year: number, monthIndex: number, timeoutMs: number = 10000): Promise<void> {
-    const target = toMonthOrdinal(year, monthIndex);
-    // A calendar spans at most a couple of decades of practical navigation; cap well above that.
-    const maxSteps = 24 * 30;
-    for (let step = 0; step < maxSteps; step++) {
-      const label = await this.interactor.getText(calendarHeaderLabelLocator);
-      const displayed = label != null ? parseHeaderMonthOrdinal(label) : null;
-      if (displayed == null) {
-        throw new Error(`${this.driverName}: could not read the calendar month from header "${label}"`);
-      }
-      if (displayed === target) {
-        // The header flips to the target immediately, but outgoing grids may still be sliding out;
-        // wait for them to leave so the caller reads day cells from the target month alone.
-        await this.waitForCalendarSettled(timeoutMs);
-        return;
-      }
-      await this.interactor.click(displayed < target ? nextMonthLocator : previousMonthLocator);
-      // Let the day grid for the new month mount before the next header read.
-      await this.waitUntil({
-        probeFn: () => this.interactor.exists(inMonthDayButtonsLocator),
-        terminateCondition: true,
-        timeoutMs,
-      });
-    }
-    throw new Error(`${this.driverName}: month ${year}-${String(monthIndex + 1).padStart(2, '0')} was not reachable`);
-  }
-
-  /**
-   * Wait until no month grid is mid-exit, i.e. the calendar shows a single settled month. No-op in
-   * non-animating environments (jsdom), where exiting grids never appear.
-   */
-  protected async waitForCalendarSettled(timeoutMs: number = 5000): Promise<void> {
-    await this.waitUntil({
-      probeFn: () => this.interactor.exists(exitingMonthGridLocator),
-      terminateCondition: false,
-      timeoutMs,
-    });
+    await waitForDayGrid(this.interactor, popupRootCss, timeoutMs);
   }
 }

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/MobileDatePickerDialogDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/MobileDatePickerDialogDriver.ts
@@ -1,0 +1,81 @@
+import { HTMLButtonDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssSelector,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { clickCalendarDay, navigateCalendarToMonth, waitForDayGrid } from './calendarNavigation';
+
+// The mobile picker's entry dialog is portaled to <body> as a modal `[role="dialog"]` hosting the
+// same calendar DOM as the desktop popup, plus an action bar. Only one picker dialog is open at a
+// time, so every locator is addressed from the document Root.
+const dialogRootCss = '[role="dialog"]';
+
+const parts = {
+  // The action bar renders Cancel then OK, in that order, as its only buttons.
+  cancelButton: {
+    locator: byCssSelector(`${dialogRootCss} .MuiDialogActions-root button:nth-of-type(1)`, 'Root'),
+    driver: HTMLButtonDriver,
+  },
+  okButton: {
+    locator: byCssSelector(`${dialogRootCss} .MuiDialogActions-root button:nth-of-type(2)`, 'Root'),
+    driver: HTMLButtonDriver,
+  },
+} satisfies ScenePart;
+
+/**
+ * Driver for the modal entry dialog a MUI X v9 mobile picker opens. Day selection reuses the
+ * shared calendar machinery (month paging header + day grid); the selection only commits to the
+ * field when the dialog's OK action is accepted.
+ * @see https://mui.com/x/react-date-pickers/date-picker/
+ */
+export class MobileDatePickerDialogDriver extends ComponentDriver<typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  /**
+   * Page the dialog's calendar to `value`'s month and click its day cell. Only the
+   * year/month/day of `value` are used. The choice is not committed until {@link accept} runs.
+   *
+   * @param value The date to select.
+   * @param timeoutMs Budget for the day grid to render and the month paging to settle.
+   */
+  async pickDay(value: Date, timeoutMs: number = 10000): Promise<void> {
+    await waitForDayGrid(this.interactor, dialogRootCss, timeoutMs);
+    await navigateCalendarToMonth(
+      this.interactor,
+      dialogRootCss,
+      value.getFullYear(),
+      value.getMonth(),
+      timeoutMs,
+      this.driverName
+    );
+    await clickCalendarDay(this.interactor, dialogRootCss, value.getDate(), this.driverName);
+  }
+
+  /**
+   * Commit the dialog's current selection to the field (the OK action).
+   */
+  async accept(): Promise<void> {
+    await this.parts.okButton.click();
+  }
+
+  /**
+   * Dismiss the dialog without committing the selection (the Cancel action).
+   */
+  async cancel(): Promise<void> {
+    await this.parts.cancelButton.click();
+  }
+
+  get driverName(): string {
+    return 'MuiV9MobileDatePickerDialog';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/MobileDatePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/MobileDatePickerDriver.ts
@@ -1,0 +1,79 @@
+import { byCssSelector, IComponentDriverOption, Interactor, locatorUtil, PartLocator } from '@atomic-testing/core';
+
+import { dateToTextEntry, textEntryToDate } from './dateUtil';
+import { MobileDatePickerDialogDriver } from './MobileDatePickerDialogDriver';
+import { openPickerButtonLocator, PickerFieldDriverBase } from './PickerFieldDriverBase';
+import { DatePickerCharacteristic } from './types';
+
+const dialogLocator = byCssSelector('[role="dialog"]', 'Root');
+
+/**
+ * Driver for the MUI X v9 MobileDatePicker.
+ *
+ * The mobile field renders the same section list + hidden mirror input as the desktop pickers,
+ * so reads come from {@link PickerFieldDriverBase} unchanged. Writes differ: on a real (touch)
+ * browser, pointer interaction with the mobile field opens the modal entry dialog rather than
+ * focusing a section, so `setValue` drives the dialog — open it, pick the day on its calendar,
+ * accept — instead of typing keystrokes.
+ * @see https://mui.com/x/react-date-pickers/date-picker/
+ */
+export class MobileDatePickerDriver extends PickerFieldDriverBase<Date> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: dateToTextEntry,
+      textEntryToValue: textEntryToDate,
+      defaultFormat: 'mm/dd/yyyy',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  /**
+   * Set the picker's committed value by operating the entry dialog: open it, page its calendar
+   * to the target month, click the day cell, and accept. Only the year/month/day of `value` are
+   * used.
+   *
+   * Clearing is not supported: the mobile dialog renders only Cancel/OK actions by default (no
+   * Clear), and the field itself rejects keystrokes on mobile.
+   *
+   * @param value The date to select.
+   */
+  override async setValue(value: Date | null): Promise<boolean> {
+    if (value == null) {
+      throw new Error(
+        `${this.driverName}: clearing is not supported — the mobile entry dialog has no Clear action by default`
+      );
+    }
+    const dialog = await this.openEntryDialog();
+    await dialog.pickDay(value);
+    await dialog.accept();
+    await this.waitForEntryDialogClose();
+    return true;
+  }
+
+  /**
+   * Open the entry dialog (no-op when already open) and return its driver.
+   */
+  async openEntryDialog(): Promise<MobileDatePickerDialogDriver> {
+    if (!(await this.interactor.exists(dialogLocator))) {
+      await this.interactor.click(locatorUtil.append(this.locator, openPickerButtonLocator));
+      await this.waitUntil({
+        probeFn: () => this.interactor.exists(dialogLocator),
+        terminateCondition: true,
+        timeoutMs: 10000,
+      });
+    }
+    return new MobileDatePickerDialogDriver(dialogLocator, this.interactor, this.commutableOption);
+  }
+
+  protected async waitForEntryDialogClose(timeoutMs: number = 10000): Promise<void> {
+    await this.waitUntil({
+      probeFn: () => this.interactor.exists(dialogLocator),
+      terminateCondition: false,
+      timeoutMs,
+    });
+  }
+
+  get driverName(): string {
+    return 'MuiV9MobileDatePicker';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/PickerFieldDriverBase.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/PickerFieldDriverBase.ts
@@ -1,0 +1,146 @@
+import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
+import {
+  byCssClass,
+  byCssSelector,
+  ComponentDriver,
+  IComponentDriverOption,
+  IInputDriver,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { DatePickerCharacteristic } from './types';
+
+// Since MUI X v6 the pickers no longer use a plain editable <input>. The visible field is a
+// `PickersSectionList`: a `role="group"` of `contenteditable` `role="spinbutton"` section spans
+// (`.MuiPickersSectionList-sectionContent`, one per date/time part) plus a single hidden,
+// `aria-hidden` `<input class="MuiPickersInputBase-input">` that mirrors the committed value as a
+// locale-formatted string for form submission — the stable, portable READ path.
+//
+// The WRITE path types real keystrokes into the section field via `Interactor.typeText`: typing a
+// section's full digit width overwrites its previous value and auto-advances to the next section,
+// so a full value is one concatenated digit stream (see `dateUtil`). Clearing selects all sections
+// (Ctrl+A puts the field into its "all sections selected" state, moving focus to the sections
+// container) and presses Backspace — both delivered with editing fidelity by `Interactor.pressKey`.
+const parts = {
+  // The hidden input mirrors the committed value as a formatted string (e.g. "06/27/2026").
+  valueInput: {
+    locator: byCssClass('MuiPickersInputBase-input'),
+    driver: HTMLTextInputDriver,
+  },
+} satisfies ScenePart;
+
+// The keyboard entry point: the first section's content span. Pinned to `data-sectionindex="0"`
+// so the locator stays unique — every other section would match the content-span class too.
+const firstSectionLocator = byCssSelector('[data-sectionindex="0"] .MuiPickersSectionList-sectionContent');
+
+// The sections container owns focus while the field is in its "all sections selected" state
+// (after Ctrl+A), when the individual section spans are temporarily not rendered.
+const sectionsContainerLocator = byCssClass('MuiPickersInputBase-sectionsContainer');
+
+/**
+ * The open-picker adornment button. It carries a stable, locale-independent marker attribute
+ * (its `aria-label` interpolates the selected date, so it is not a reliable handle). Both the
+ * desktop pickers (popper popup) and the mobile pickers (modal dialog) render it.
+ */
+export const openPickerButtonLocator = byCssSelector('[data-mui-picker-open-button="true"]');
+
+/**
+ * Base driver for every MUI X v9 picker built on the section field (`PickersSectionList`):
+ * desktop/mobile date pickers, datetime picker, time picker, and the single-input date range
+ * field. Reads go through the hidden mirror input; writes type real keystrokes into the section
+ * spans. The value type is generic so the range picker can share the exact same field mechanics
+ * with a `DateRange` value.
+ */
+export abstract class PickerFieldDriverBase<TValue = Date>
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<TValue | null>
+{
+  constructor(
+    locator: PartLocator,
+    interactor: Interactor,
+    protected characteristic: DatePickerCharacteristic<TValue>,
+    option?: Partial<IComponentDriverOption>
+  ) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+    });
+  }
+
+  /**
+   * The committed value parsed from the hidden mirror input, or `null` when the field is empty.
+   */
+  async getValue(): Promise<TValue | null> {
+    const text = await this.getValueText();
+    if (text == null) {
+      return null;
+    }
+    const format = await this.getFormat();
+    return this.characteristic.textEntryToValue(text, format);
+  }
+
+  /**
+   * The raw locale-formatted text shown by the field (e.g. "06/27/2026"), or `undefined`
+   * when the field is empty.
+   */
+  async getValueText(): Promise<Optional<string>> {
+    await this.enforcePartExistence('valueInput');
+    const value = await this.interactor.getInputValue(this.parts.valueInput.locator);
+    return value != null && value.length > 0 ? value : undefined;
+  }
+
+  /**
+   * The v5 driver read the field's `placeholder` to discover the format, but the v9 section
+   * field has no placeholder attribute. The format is carried implicitly by the section spans,
+   * so fall back to the driver's declared default format.
+   */
+  async getFormat(defaultFormat: string = this.characteristic.defaultFormat): Promise<string> {
+    return defaultFormat;
+  }
+
+  /**
+   * Set the field's committed value by typing real keystrokes into the section field, or clear
+   * it when `value` is `null`. Typing a section's full digit width overwrites whatever it held,
+   * so no clearing happens before typing a non-null value.
+   *
+   * @param value The value to type, or `null` to clear the field.
+   */
+  async setValue(value: TValue | null): Promise<boolean> {
+    if (value == null) {
+      await this.clearField();
+      return true;
+    }
+    const format = await this.getFormat();
+    await this.typeIntoField(this.characteristic.valueToTextEntry(value, format));
+    return true;
+  }
+
+  /**
+   * Click the first section and type the given keystroke stream; MUI advances the focused
+   * section automatically as each section's digits commit.
+   */
+  protected async typeIntoField(text: string): Promise<void> {
+    const firstSection = locatorUtil.append(this.locator, firstSectionLocator);
+    await this.interactor.click(firstSection);
+    await this.interactor.typeText(firstSection, text);
+  }
+
+  /**
+   * Clear every section: select all sections (Ctrl+A) and press Backspace. Focus moves to the
+   * sections container in the select-all state, so the deletion targets the container. Ends by
+   * blurring the field, which leaves the select-all editing state and re-renders the placeholder
+   * sections so a subsequent {@link setValue} can target the first section again.
+   */
+  protected async clearField(): Promise<void> {
+    const firstSection = locatorUtil.append(this.locator, firstSectionLocator);
+    const sectionsContainer = locatorUtil.append(this.locator, sectionsContainerLocator);
+    await this.interactor.click(firstSection);
+    await this.interactor.pressKey(firstSection, 'a', { ctrl: true });
+    await this.interactor.pressKey(sectionsContainer, 'Backspace');
+    await this.interactor.blur(sectionsContainer);
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/TimePickerDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/TimePickerDriver.ts
@@ -1,0 +1,29 @@
+import { IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+
+import { textEntryToTime, timeToTextEntry } from './dateUtil';
+import { PickerFieldDriverBase } from './PickerFieldDriverBase';
+import { DatePickerCharacteristic } from './types';
+
+/**
+ * Driver for the MUI X v9 desktop TimePicker.
+ *
+ * Reads and writes go through the section field ({@link PickerFieldDriverBase}): `setValue`
+ * types the 12-hour time digits then the meridiem letter (`a`/`p`), which is the single
+ * keystroke the meridiem section accepts. The returned `Date` is anchored on 1970-01-01 —
+ * only the time-of-day carries meaning.
+ * @see https://mui.com/x/react-date-pickers/time-picker/
+ */
+export class TimePickerDriver extends PickerFieldDriverBase<Date> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
+    const characteristic: DatePickerCharacteristic = {
+      valueToTextEntry: timeToTextEntry,
+      textEntryToValue: textEntryToTime,
+      defaultFormat: 'hh:mm (a|p)m',
+    };
+    super(locator, interactor, characteristic, option);
+  }
+
+  get driverName(): string {
+    return 'MuiV9TimePicker';
+  }
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/calendarNavigation.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/calendarNavigation.ts
@@ -1,0 +1,144 @@
+import { byCssSelector, Interactor, PartLocator } from '@atomic-testing/core';
+
+// Shared machinery for driving a MUI X day-calendar surface (day grid + month
+// paging header). The same calendar DOM renders in two hosts — the desktop
+// pickers' popper popup (`.MuiPickerPopper-root`) and the mobile pickers' modal
+// dialog (`[role="dialog"]`) — so every helper takes the host's root CSS
+// selector and addresses the calendar from the document Root (both hosts
+// portal to <body>). Only one picker surface is open at a time, so the
+// singular root is unambiguous while open.
+
+/**
+ * In-month day cells are `<button>`s carrying a `data-timestamp`; out-of-month
+ * cells are filler `<div>`s without one. Excluding `dayOutsideMonth` keeps the
+ * set to days 1..N even when a consumer turns on `showDaysOutsideCurrentMonth`,
+ * so the buttons line up with day-of-month by position.
+ */
+export function dayGridLocator(hostRootCss: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickerDay-root[data-timestamp]:not(.MuiPickerDay-dayOutsideMonth)`, 'Root');
+}
+
+function headerLabelLocator(hostRootCss: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickersCalendarHeader-label`, 'Root');
+}
+
+function previousMonthLocator(hostRootCss: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickersArrowSwitcher-previousIconButton`, 'Root');
+}
+
+function nextMonthLocator(hostRootCss: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickersArrowSwitcher-nextIconButton`, 'Root');
+}
+
+// While the month slide animates, MUI keeps the outgoing month grids mounted
+// (marked `slideExit`) alongside the incoming one, so the day-cell list briefly
+// spans several months. (Under jsdom there is no animation, so the marker never
+// matches and waits on it are no-ops.)
+function exitingMonthGridLocator(hostRootCss: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickersSlideTransition-slideExit`, 'Root');
+}
+
+function dayByTimestampLocator(hostRootCss: string, timestamp: string): PartLocator {
+  return byCssSelector(`${hostRootCss} .MuiPickerDay-root[data-timestamp="${timestamp}"]`, 'Root');
+}
+
+// Collapse a year+month to a single comparable ordinal so month deltas are a subtraction.
+function toMonthOrdinal(year: number, monthIndex: number): number {
+  return year * 12 + monthIndex;
+}
+
+// The header label (e.g. "June 2026") is parsed in the driver's own JS runtime — never in the
+// browser — so this `Date` parse runs on V8 in both the DOM and Playwright paths and needs no
+// cross-engine guarantee. Assumes the default (English) locale, matching this driver family's
+// other English defaults (e.g. the `mm/dd/yyyy` format fallback).
+function parseHeaderMonthOrdinal(label: string): number | null {
+  const parsed = new Date(label);
+  return Number.isNaN(parsed.getTime()) ? null : toMonthOrdinal(parsed.getFullYear(), parsed.getMonth());
+}
+
+/**
+ * Wait until the host's day grid has rendered. The grid mounts a tick after the
+ * host surface itself, so waiting on the host root alone is not enough.
+ */
+export async function waitForDayGrid(interactor: Interactor, hostRootCss: string, timeoutMs: number): Promise<void> {
+  await interactor.waitUntil({
+    probeFn: () => interactor.exists(dayGridLocator(hostRootCss)),
+    terminateCondition: true,
+    timeoutMs,
+  });
+}
+
+/**
+ * Wait until no month grid is mid-exit, i.e. the calendar shows a single settled month. No-op in
+ * non-animating environments (jsdom), where exiting grids never appear.
+ */
+export async function waitForCalendarSettled(
+  interactor: Interactor,
+  hostRootCss: string,
+  timeoutMs: number
+): Promise<void> {
+  await interactor.waitUntil({
+    probeFn: () => interactor.exists(exitingMonthGridLocator(hostRootCss)),
+    terminateCondition: false,
+    timeoutMs,
+  });
+}
+
+/**
+ * Page the open calendar to the given year/month by clicking the previous/next-month arrows. The
+ * displayed month is re-read from the header each step, so the walk converges regardless of arrow
+ * animation, and is bounded so an unreachable target (e.g. blocked by `minDate`/`maxDate`) fails
+ * fast instead of looping forever.
+ */
+export async function navigateCalendarToMonth(
+  interactor: Interactor,
+  hostRootCss: string,
+  year: number,
+  monthIndex: number,
+  timeoutMs: number,
+  driverName: string
+): Promise<void> {
+  const target = toMonthOrdinal(year, monthIndex);
+  // A calendar spans at most a couple of decades of practical navigation; cap well above that.
+  const maxSteps = 24 * 30;
+  for (let step = 0; step < maxSteps; step++) {
+    const label = await interactor.getText(headerLabelLocator(hostRootCss));
+    const displayed = label != null ? parseHeaderMonthOrdinal(label) : null;
+    if (displayed == null) {
+      throw new Error(`${driverName}: could not read the calendar month from header "${label}"`);
+    }
+    if (displayed === target) {
+      // The header flips to the target immediately, but outgoing grids may still be sliding out;
+      // wait for them to leave so the caller reads day cells from the target month alone.
+      await waitForCalendarSettled(interactor, hostRootCss, timeoutMs);
+      return;
+    }
+    await interactor.click(displayed < target ? nextMonthLocator(hostRootCss) : previousMonthLocator(hostRootCss));
+    // Let the day grid for the new month mount before the next header read.
+    await waitForDayGrid(interactor, hostRootCss, timeoutMs);
+  }
+  throw new Error(`${driverName}: month ${year}-${String(monthIndex + 1).padStart(2, '0')} was not reachable`);
+}
+
+/**
+ * Click the day cell for the given day-of-month in the currently displayed month.
+ *
+ * Day cells render in DOM order as days 1..N, so the day-of-month indexes straight into the
+ * timestamp list. Reading the timestamp from the DOM (rather than recomputing it) keeps the
+ * selection free of any timezone assumption about how the picker stamps each day.
+ */
+export async function clickCalendarDay(
+  interactor: Interactor,
+  hostRootCss: string,
+  dayOfMonth: number,
+  driverName: string
+): Promise<void> {
+  const timestamps = await interactor.getAttribute(dayGridLocator(hostRootCss), 'data-timestamp', true);
+  const targetTimestamp = timestamps[dayOfMonth - 1];
+  if (targetTimestamp == null) {
+    throw new Error(
+      `${driverName}: day ${dayOfMonth} is not available in the displayed month (found ${timestamps.length} days)`
+    );
+  }
+  await interactor.click(dayByTimestampLocator(hostRootCss, targetTimestamp));
+}

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/dateUtil.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/dateUtil.ts
@@ -1,11 +1,17 @@
+import { DateRange } from './types';
+
+function padLeftZeroes(value: number, digits: number): string {
+  return String(value).padStart(digits, '0');
+}
+
 /**
- * Parse a desktop date picker's committed value — the hidden input's locale-formatted string
+ * Parse a picker's committed value — the hidden input's locale-formatted string
  * (e.g. "06/27/2026") — into a Date, or null when the field is empty or the value cannot be
  * parsed. The explicit Invalid-Date guard avoids leaking `new Date('…')`'s implementation-defined
  * behaviour for malformed input.
  *
- * The write direction (typing a value into the section field) and the time/datetime/range
- * converters are deferred until the keystroke-based write path lands.
+ * Like the v5 converters these assume the driver family's default (English/US) formats; the
+ * `format` argument is reserved for locale-aware parsing.
  */
 export function textEntryToDate(text: string, _format: string): Date | null {
   if (text.length < 6) {
@@ -13,4 +19,94 @@ export function textEntryToDate(text: string, _format: string): Date | null {
   }
   const parsed = new Date(text);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * The keystroke stream that types a calendar date into a `MM/DD/YYYY` section field:
+ * zero-padded month and day digits then the four year digits (e.g. `12252025`). Typing a
+ * section's full digit width overwrites its previous value and auto-advances, so the streams
+ * need no separators.
+ */
+export function dateToTextEntry(date: Date, _format: string): string {
+  return `${padLeftZeroes(date.getMonth() + 1, 2)}${padLeftZeroes(date.getDate(), 2)}${padLeftZeroes(date.getFullYear(), 4)}`;
+}
+
+/**
+ * The keystroke stream that types a 12-hour time into an `hh:mm aa` section field: zero-padded
+ * hour and minute digits, then the meridiem section's single accepted letter (`a`/`p`).
+ */
+export function timeToTextEntry(date: Date, _format: string): string {
+  const hours24 = date.getHours();
+  const hours12 = ((hours24 + 11) % 12) + 1;
+  const meridiemKey = hours24 < 12 ? 'a' : 'p';
+  return `${padLeftZeroes(hours12, 2)}${padLeftZeroes(date.getMinutes(), 2)}${meridiemKey}`;
+}
+
+/**
+ * The keystroke stream for a `MM/DD/YYYY hh:mm aa` datetime section field — the date stream
+ * followed by the time stream (auto-advance carries typing across the date/time boundary).
+ */
+export function dateTimeToTextEntry(date: Date, format: string): string {
+  return `${dateToTextEntry(date, format)}${timeToTextEntry(date, format)}`;
+}
+
+/**
+ * Parse a time field's committed text (e.g. "09:30 AM") into a Date anchored on 1970-01-01
+ * local time — only the time-of-day carries meaning. Returns null for empty/unparsable text.
+ */
+export function textEntryToTime(text: string, _format: string): Date | null {
+  const match = /^(\d{1,2}):(\d{2})\s*([AP])M?$/i.exec(text.trim());
+  if (match == null) {
+    return null;
+  }
+  const [, hourText, minuteText, meridiem] = match;
+  let hours = Number(hourText) % 12;
+  if (meridiem.toUpperCase() === 'P') {
+    hours += 12;
+  }
+  return new Date(1970, 0, 1, hours, Number(minuteText));
+}
+
+/**
+ * Parse a datetime field's committed text (e.g. "12/25/2025 09:30 PM") into a Date, or null
+ * when empty/unparsable. V8's parser accepts this en-US shape directly, so the same
+ * Invalid-Date guard as {@link textEntryToDate} suffices.
+ */
+export function textEntryToDateTime(text: string, _format: string): Date | null {
+  if (text.length < 12) {
+    return null;
+  }
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+// The range field joins its two dates with a spaced dash whose character varies by locale
+// data (en dash today); accept en/em dashes and a plain hyphen.
+const rangeSeparatorPattern = /\s+[–—-]\s+/;
+
+/**
+ * The keystroke stream for a single-input date range field — the start date's digits followed
+ * by the end date's (auto-advance carries typing across the range separator). Both sides must
+ * be present: the section field offers no way to type one side while skipping the other.
+ */
+export function dateRangeToTextEntry(range: DateRange, format: string): string {
+  if (range.start == null || range.end == null) {
+    throw new Error('dateRangeToTextEntry requires both start and end dates; to clear the field set the value to null');
+  }
+  return `${dateToTextEntry(range.start, format)}${dateToTextEntry(range.end, format)}`;
+}
+
+/**
+ * Parse a range field's committed text (e.g. "12/25/2025 – 01/15/2026") into a {@link DateRange},
+ * or null when the text does not contain a two-sided range.
+ */
+export function textEntryToDateRange(text: string, format: string): DateRange | null {
+  const segments = text.split(rangeSeparatorPattern);
+  if (segments.length !== 2) {
+    return null;
+  }
+  return {
+    start: textEntryToDate(segments[0].trim(), format),
+    end: textEntryToDate(segments[1].trim(), format),
+  };
 }

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/index.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/index.ts
@@ -1,4 +1,10 @@
 export * as dateUtil from './dateUtil';
+export * from './DateRangePickerDriver';
+export * from './DateTimePickerDriver';
 export * from './DesktopDatePickerDriver';
 export * from './DesktopDatePickerDriverBase';
+export * from './MobileDatePickerDialogDriver';
+export * from './MobileDatePickerDriver';
+export * from './PickerFieldDriverBase';
+export * from './TimePickerDriver';
 export * from './types';

--- a/packages/component-driver-mui-x-v9/src/components/datepicker/types.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datepicker/types.ts
@@ -1,7 +1,28 @@
-export interface DatePickerCharacteristic {
-  textEntryToValue: (text: string, format: string) => Date | null;
+export interface DatePickerCharacteristic<TValue = Date> {
+  /**
+   * Convert a value into the keystroke stream typed into the picker's section
+   * field — digit runs per section plus the meridiem letter, e.g. `12252025`
+   * for 12/25/2025 or `0930p` for 9:30 PM. MUI auto-advances to the next
+   * section as each section's digits commit, so the streams concatenate.
+   */
+  valueToTextEntry: (value: TValue, format: string) => string;
+  /**
+   * Parse the committed, locale-formatted field text (the hidden input's
+   * mirrored value, e.g. "06/27/2026") back into a value, or `null` when the
+   * text is empty or unparsable.
+   */
+  textEntryToValue: (text: string, format: string) => TValue | null;
   /**
    * Format hint displayed in the input field
    */
   defaultFormat: string;
+}
+
+/**
+ * The value of a date range picker. Either side is `null` while that side of
+ * the range is not committed.
+ */
+export interface DateRange {
+  start: Date | null;
+  end: Date | null;
 }

--- a/packages/component-driver-mui-x-v9/src/index.ts
+++ b/packages/component-driver-mui-x-v9/src/index.ts
@@ -1,3 +1,4 @@
+export * from './components/charts';
 export * from './components/datagrid';
 export * from './components/datepicker';
 export * from './components/treeview';

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -123,6 +123,7 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
     runtimeCssSelector(): Promise<string>;
     protected scrollBy(delta: Point): Promise<void>;
     scrollIntoView(): Promise<void>;
+    typeText(text: string): Promise<void>;
     // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
     waitUntilComponentState(option?: Partial<Readonly<WaitForOption>>): Promise<void>;
@@ -383,6 +384,7 @@ export interface Interactor {
     selectOptionValue(locator: PartLocator, values: string[]): Promise<void>;
     setInputFiles(locator: PartLocator, files: string | string[]): Promise<void>;
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
+    typeText(locator: PartLocator, text: string): Promise<void>;
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
     waitUntilComponentState(locator: PartLocator, option?: Partial<Readonly<WaitForOption>>): Promise<void>;
 }

--- a/packages/core/src/drivers/ComponentDriver.ts
+++ b/packages/core/src/drivers/ComponentDriver.ts
@@ -224,6 +224,15 @@ export abstract class ComponentDriver<T extends ScenePart = {}> implements IComp
   }
 
   /**
+   * Type text into the component as real per-character keystrokes, inserting at
+   * the current caret without clearing. See {@link Interactor.typeText}.
+   * @param text The literal text to type, one keystroke per character
+   */
+  async typeText(text: string): Promise<void> {
+    return this.interactor.typeText(this.locator, text);
+  }
+
+  /**
    * Dispatch a right-click / `contextmenu` event on the component. See {@link Interactor.contextMenu}.
    */
   protected async contextMenu(): Promise<void> {

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -80,14 +80,15 @@ export interface Interactor {
    * event so components that key off `KeyboardEvent.key` are exercised — e.g.
    * Dialog dismissal on `Escape` or Chip deletion on `Backspace`/`Delete`. The
    * element is focused first so the event originates from the active element,
-   * matching a real key press. On a focused **text-editing** target (an
-   * `<input>`/`<textarea>` or a `contenteditable` host) the press additionally
-   * carries `beforeinput`/`input` fidelity, so editing keys such as `Backspace`
-   * reach components that commit changes from input events (e.g. the MUI X
-   * picker section field, see #903); on a command target (combobox, dialog,
-   * menu) it stays a plain `keydown`/`keyup` so keyboard handlers fire as they
-   * expect. No pointer event is involved, so behaviours unreachable by
-   * {@link click} (geometry or not) become testable.
+   * matching a real key press. On a focused `contenteditable` host the press
+   * additionally carries `beforeinput`/`input` fidelity, so editing keys such as
+   * `Backspace` reach components that commit changes from input events (e.g. the
+   * MUI X picker section field, see #903); on every other target — including
+   * text `<input>`/`<textarea>` — it stays a plain `keydown`/`keyup` on the
+   * element so keyboard handlers fire as they expect (a text field is edited
+   * through {@link enterText}/{@link typeText}, not this). No pointer event is
+   * involved, so behaviours unreachable by {@link click} (geometry or not)
+   * become testable.
    *
    * Cross-engine caveat: with `shift` and a PRINTABLE key the engines disagree on
    * the resulting `KeyboardEvent.key` — Playwright case-folds (`Shift`+`a` →

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -80,8 +80,12 @@ export interface Interactor {
    * event so components that key off `KeyboardEvent.key` are exercised — e.g.
    * Dialog dismissal on `Escape` or Chip deletion on `Backspace`/`Delete`. The
    * element is focused first so the event originates from the active element,
-   * matching a real key press. No pointer event is involved, so behaviours
-   * unreachable by {@link click} (geometry or not) become testable.
+   * matching a real key press. When the element holds focus the press carries
+   * full editing fidelity (`keydown` → `beforeinput`/`input` on editable
+   * targets → `keyup`), so editing keys such as `Backspace` also reach
+   * components that commit changes from input events (e.g. the MUI X picker
+   * section field). No pointer event is involved, so behaviours unreachable by
+   * {@link click} (geometry or not) become testable.
    *
    * Cross-engine caveat: with `shift` and a PRINTABLE key the engines disagree on
    * the resulting `KeyboardEvent.key` — Playwright case-folds (`Shift`+`a` →
@@ -132,6 +136,30 @@ export interface Interactor {
    * @param value
    */
   enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void>;
+
+  /**
+   * Type text into the desired element as a sequence of real per-character
+   * keystrokes.
+   *
+   * Unlike {@link enterText}, which clears the target and fills its value — a
+   * path invisible to widgets that ignore programmatic value assignment — this
+   * focuses the element and dispatches the full key event sequence per
+   * character (`keydown` → `beforeinput` → `input` → `keyup`), inserting at
+   * the element's current caret with no clearing. That reaches keystroke-driven
+   * editors such as the MUI X picker section field (a `contenteditable`
+   * `role="spinbutton"` span that only commits digits arriving as genuine key
+   * events) and grid cell editors entered via {@link pressKey} — see #903/#905.
+   *
+   * The text is typed literally: characters that carry special meaning in an
+   * underlying dispatcher (user-event's `{`/`[` descriptor syntax) are escaped,
+   * so `typeText(locator, '{a}')` types the five characters `{a}` verbatim.
+   * For non-printable keys or modifier chords use {@link pressKey}; to clear
+   * before typing, combine with {@link enterText} or key presses.
+   *
+   * @param locator Locator of the element to type into
+   * @param text The literal text to type, one keystroke per character
+   */
+  typeText(locator: PartLocator, text: string): Promise<void>;
 
   /**
    * Set the value of a range input (`<input type="range">`, the element behind a

--- a/packages/core/src/interactor/Interactor.ts
+++ b/packages/core/src/interactor/Interactor.ts
@@ -80,11 +80,13 @@ export interface Interactor {
    * event so components that key off `KeyboardEvent.key` are exercised — e.g.
    * Dialog dismissal on `Escape` or Chip deletion on `Backspace`/`Delete`. The
    * element is focused first so the event originates from the active element,
-   * matching a real key press. When the element holds focus the press carries
-   * full editing fidelity (`keydown` → `beforeinput`/`input` on editable
-   * targets → `keyup`), so editing keys such as `Backspace` also reach
-   * components that commit changes from input events (e.g. the MUI X picker
-   * section field). No pointer event is involved, so behaviours unreachable by
+   * matching a real key press. On a focused **text-editing** target (an
+   * `<input>`/`<textarea>` or a `contenteditable` host) the press additionally
+   * carries `beforeinput`/`input` fidelity, so editing keys such as `Backspace`
+   * reach components that commit changes from input events (e.g. the MUI X
+   * picker section field, see #903); on a command target (combobox, dialog,
+   * menu) it stays a plain `keydown`/`keyup` so keyboard handlers fire as they
+   * expect. No pointer event is involved, so behaviours unreachable by
    * {@link click} (geometry or not) become testable.
    *
    * Cross-engine caveat: with `shift` and a PRINTABLE key the engines disagree on

--- a/packages/dom-core/etc/dom-core.api.md
+++ b/packages/dom-core/etc/dom-core.api.md
@@ -106,6 +106,7 @@ export class DOMInteractor implements Interactor {
     selectOptionValue(locator: PartLocator, values: string[]): Promise<void>;
     setInputFiles(locator: PartLocator, files: string | string[]): Promise<void>;
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
+    typeText(locator: PartLocator, text: string): Promise<void>;
     // (undocumented)
     protected readonly userEvent: UserEventDispatcher;
     // (undocumented)
@@ -135,6 +136,8 @@ export interface UserEventDispatcher {
     click(element: Element): Promise<void>;
     // (undocumented)
     hover(element: Element): Promise<void>;
+    // (undocumented)
+    keyboard(text: string): Promise<unknown>;
     // (undocumented)
     selectOptions(element: Element, values: string[]): Promise<void>;
     // (undocumented)

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -396,6 +396,46 @@ export class DOMInteractor implements Interactor {
     if ('focus' in el) {
       (el as HTMLElement).focus();
     }
+
+    // When the element genuinely holds focus, dispatch through
+    // `userEvent.keyboard` so the press carries full editing fidelity —
+    // keydown → beforeinput/input (for editing keys on editable targets) →
+    // keyup — matching Playwright's `locator.press()`. A bare keydown/keyup
+    // pair reaches `KeyboardEvent.key` handlers but is invisible to components
+    // that commit edits from input events (e.g. the MUI X picker section field
+    // clearing on Backspace, see #903).
+    const activeElement = el.ownerDocument?.activeElement;
+    const holdsFocus = el === activeElement || (activeElement != null && el.contains(activeElement));
+    if (holdsFocus) {
+      // Printable keys are typed as-is (doubling `{`/`[` so user-event's
+      // descriptor syntax never engages); named keys become `{Key}` descriptors.
+      const descriptor = key.length === 1 ? key.replace(/[{[]/, '$&$&') : `{${key}}`;
+      let chord = descriptor;
+      if (option?.shift) {
+        chord = `{Shift>}${chord}{/Shift}`;
+      }
+      if (option?.alt) {
+        chord = `{Alt>}${chord}{/Alt}`;
+      }
+      if (option?.ctrl) {
+        chord = `{Control>}${chord}{/Control}`;
+      }
+      if (option?.meta) {
+        chord = `{Meta>}${chord}{/Meta}`;
+      }
+      try {
+        await this.userEvent.keyboard(chord);
+        return;
+      } catch {
+        // user-event rejects keys outside its keyboard map while parsing,
+        // before dispatching anything — fall through to the bare key events so
+        // exotic keys still reach KeyboardEvent.key handlers as before.
+      }
+    }
+
+    // Non-focusable target (or a key user-event cannot type): dispatch the key
+    // events directly on the element, as a real key press cannot originate
+    // from it anyway.
     // `keyCode`/`which` mirror `key` for handlers that still read the legacy
     // numeric code (see legacyKeyCodes above).
     const keyCode = DOMInteractor.legacyKeyCodeOf(key);
@@ -496,6 +536,53 @@ export class DOMInteractor implements Interactor {
     }
 
     await this.userEvent.type(el, text);
+  }
+
+  /**
+   * Type text into the element as real per-character keystrokes.
+   *
+   * Focuses the element, then dispatches the characters through
+   * `userEvent.keyboard`, which fires the full key event sequence
+   * (keydown → beforeinput → input → keyup) against the active element —
+   * matching `PlaywrightInteractor`'s `pressSequentially` (focus + keys, no
+   * pointer event, no clearing). `{`/`[` are doubled so user-event's
+   * descriptor syntax never engages and the text is typed literally.
+   *
+   * @param locator - Locator used to find the target element
+   * @param text - The literal text to type, one keystroke per character
+   * @returns Promise resolved once every keystroke has been dispatched
+   * @throws {ElementNotFoundError} If the element is not found
+   */
+  async typeText(locator: PartLocator, text: string): Promise<void> {
+    const el = await this.getElement(locator);
+    if (el == null) {
+      throw new ElementNotFoundError(locator, 'typeText');
+    }
+    if ('focus' in el) {
+      (el as HTMLElement).focus();
+    }
+    // A real browser places a caret inside a contenteditable host on focus;
+    // jsdom does not, and userEvent.keyboard inserts at the document selection
+    // — so without a caret the keystrokes would land nowhere. Collapse a
+    // selection to the end of the host's content (matching userEvent.type's
+    // append behavior) unless the caret is already inside it.
+    if (el.hasAttribute('contenteditable')) {
+      const selection = el.ownerDocument.getSelection();
+      if (selection != null && (selection.anchorNode == null || !el.contains(selection.anchorNode))) {
+        const range = el.ownerDocument.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    }
+    // userEvent.keyboard('') throws ("Expected key descriptor"), so an empty
+    // text is focus-only — the same outcome pressSequentially('') produces.
+    if (text === '') {
+      return;
+    }
+    const literalText = text.replace(/[{[]/g, '$&$&');
+    await this.userEvent.keyboard(literalText);
   }
 
   /**

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -56,21 +56,24 @@ function deriveKeyCode(key: string): string {
 }
 
 /**
- * Whether a key press on this element needs `beforeinput`/`input` fidelity —
- * true for a text-editing context (an `<input>`/`<textarea>` or a
- * `contenteditable` host). Only editing targets commit changes from input
- * events (e.g. the MUI X picker section field clearing on `Backspace`); a
- * command target (a `role="combobox"`, dialog, chip, menu) reacts to plain
- * `keydown`, so it must keep the direct `fireEvent` dispatch that keyboard-driven
- * drivers rely on — routing those through `userEvent.keyboard` (which delivers
- * to `document.activeElement`) regressed the Angular Material `MatSelect`
- * open-on-`Enter` contract. jsdom leaves `isContentEditable` `undefined`, so the
- * `contenteditable` attribute is consulted directly rather than the property.
+ * Whether a key press on this element needs `beforeinput`/`input` fidelity — true
+ * only for a `contenteditable` host. Such a host commits edits from input events
+ * that a bare `keydown`/`keyup` never produces (the MUI X picker section field
+ * clears on `Backspace` this way, see #903), so it must go through
+ * `userEvent.keyboard`.
+ *
+ * Everything else — including `<input>`/`<textarea>` — keeps the direct
+ * `fireEvent.keyDown` dispatch on the element, which is what keyboard-driven
+ * drivers rely on and matches the pre-existing behavior. `userEvent.keyboard`
+ * delivers to `document.activeElement` and regressed command-key contracts on
+ * both non-editable and editable targets: Angular Material `MatSelect`
+ * (open on `Enter`) and `MatAutocomplete` (close on `Escape`, whose target is a
+ * text `<input>`). Text fields do their actual editing through
+ * {@link DOMInteractor.enterText}/{@link DOMInteractor.typeText}, not `pressKey`,
+ * so excluding them here loses nothing. jsdom leaves `isContentEditable`
+ * `undefined`, so the attribute is consulted directly rather than the property.
  */
 function needsInputEventFidelity(el: Element): boolean {
-  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
-    return true;
-  }
   if ((el as HTMLElement).isContentEditable === true) {
     return true;
   }

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -409,7 +409,9 @@ export class DOMInteractor implements Interactor {
     if (holdsFocus) {
       // Printable keys are typed as-is (doubling `{`/`[` so user-event's
       // descriptor syntax never engages); named keys become `{Key}` descriptors.
-      const descriptor = key.length === 1 ? key.replace(/[{[]/, '$&$&') : `{${key}}`;
+      // The global flag is defensive — `key.length === 1` means at most one char
+      // here — and keeps the escape consistent with `typeText`'s.
+      const descriptor = key.length === 1 ? key.replace(/[{[]/g, '$&$&') : `{${key}}`;
       let chord = descriptor;
       if (option?.shift) {
         chord = `{Shift>}${chord}{/Shift}`;

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -55,6 +55,29 @@ function deriveKeyCode(key: string): string {
   return key;
 }
 
+/**
+ * Whether a key press on this element needs `beforeinput`/`input` fidelity —
+ * true for a text-editing context (an `<input>`/`<textarea>` or a
+ * `contenteditable` host). Only editing targets commit changes from input
+ * events (e.g. the MUI X picker section field clearing on `Backspace`); a
+ * command target (a `role="combobox"`, dialog, chip, menu) reacts to plain
+ * `keydown`, so it must keep the direct `fireEvent` dispatch that keyboard-driven
+ * drivers rely on — routing those through `userEvent.keyboard` (which delivers
+ * to `document.activeElement`) regressed the Angular Material `MatSelect`
+ * open-on-`Enter` contract. jsdom leaves `isContentEditable` `undefined`, so the
+ * `contenteditable` attribute is consulted directly rather than the property.
+ */
+function needsInputEventFidelity(el: Element): boolean {
+  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+    return true;
+  }
+  if ((el as HTMLElement).isContentEditable === true) {
+    return true;
+  }
+  const contentEditable = el.getAttribute('contenteditable');
+  return contentEditable === '' || contentEditable === 'true';
+}
+
 export class DOMInteractor implements Interactor {
   protected readonly userEvent: UserEventDispatcher;
 
@@ -397,16 +420,19 @@ export class DOMInteractor implements Interactor {
       (el as HTMLElement).focus();
     }
 
-    // When the element genuinely holds focus, dispatch through
-    // `userEvent.keyboard` so the press carries full editing fidelity —
-    // keydown → beforeinput/input (for editing keys on editable targets) →
-    // keyup — matching Playwright's `locator.press()`. A bare keydown/keyup
-    // pair reaches `KeyboardEvent.key` handlers but is invisible to components
-    // that commit edits from input events (e.g. the MUI X picker section field
-    // clearing on Backspace, see #903).
+    // For a focused text-editing target, dispatch through `userEvent.keyboard`
+    // so the press carries full editing fidelity — keydown → beforeinput/input →
+    // keyup — matching Playwright's `locator.press()`. A bare keydown/keyup pair
+    // reaches `KeyboardEvent.key` handlers but is invisible to components that
+    // commit edits from input events (e.g. the MUI X picker section field
+    // clearing on Backspace, see #903). This is gated to editing targets
+    // ({@link needsInputEventFidelity}): command targets (combobox, dialog,
+    // chip) must keep the direct `fireEvent` dispatch their keyboard handlers
+    // rely on — `userEvent.keyboard` delivers to `document.activeElement`, which
+    // broke the Angular Material `MatSelect` open-on-Enter path.
     const activeElement = el.ownerDocument?.activeElement;
     const holdsFocus = el === activeElement || (activeElement != null && el.contains(activeElement));
-    if (holdsFocus) {
+    if (holdsFocus && needsInputEventFidelity(el)) {
       // Printable keys are typed as-is (doubling `{`/`[` so user-event's
       // descriptor syntax never engages); named keys become `{Key}` descriptors.
       // The global flag is defensive — `key.length === 1` means at most one char

--- a/packages/dom-core/src/types.ts
+++ b/packages/dom-core/src/types.ts
@@ -16,6 +16,10 @@ export interface UserEventDispatcher {
   clear(element: Element): Promise<void>;
   click(element: Element): Promise<void>;
   hover(element: Element): Promise<void>;
+  // Returns unknown (not void): the default user-event export's keyboard()
+  // resolves to its internal keyboard state, and Promise's type parameter is
+  // invariant to the void-return assignability exception.
+  keyboard(text: string): Promise<unknown>;
   selectOptions(element: Element, values: string[]): Promise<void>;
   type(element: Element, text: string): Promise<void>;
   upload(element: HTMLElement, files: File | File[]): Promise<void>;

--- a/packages/playwright/etc/playwright.api.md
+++ b/packages/playwright/etc/playwright.api.md
@@ -108,6 +108,7 @@ export class PlaywrightInteractor implements Interactor {
     setInputFiles(locator: PartLocator, files: string | string[]): Promise<void>;
     // (undocumented)
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
+    typeText(locator: PartLocator, text: string): Promise<void>;
     // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
     // (undocumented)

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -309,6 +309,26 @@ export class PlaywrightInteractor implements Interactor {
     });
   }
 
+  /**
+   * Type text into the element as real per-character keystrokes.
+   *
+   * `pressSequentially` focuses the element and dispatches a trusted
+   * keydown/keypress/input/keyup sequence per character — the keystroke path
+   * that `enterText`'s `fill()` (a direct value replacement) never exercises,
+   * and the only one keystroke-driven editors such as the MUI X picker section
+   * field respond to. No pointer event and no clearing, mirroring the DOM
+   * implementation's focus + keyboard dispatch. Playwright types the text
+   * literally, so no escaping is needed here.
+   *
+   * @param locator - Locator used to find the target element
+   * @param text - The literal text to type, one keystroke per character
+   * @throws {ElementNotFoundError} If the element is not found
+   */
+  async typeText(locator: PartLocator, text: string): Promise<void> {
+    const cssLocator = await locatorUtil.toCssSelector(locator, this);
+    await this.runMutation(locator, 'typeText', () => this.page.locator(cssLocator).pressSequentially(text));
+  }
+
   async setRangeValue(locator: PartLocator, value: number): Promise<void> {
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
     // Playwright's `fill` rejects `<input type="range">` (it is not a fillable

--- a/packages/react-core/etc/react-core.api.md
+++ b/packages/react-core/etc/react-core.api.md
@@ -23,7 +23,6 @@ import { PressKeyOption } from '@atomic-testing/core';
 import { ReactNode } from 'react';
 import { ScenePart } from '@atomic-testing/core';
 import { TestEngine } from '@atomic-testing/core';
-import { WaitForOption } from '@atomic-testing/core';
 import { WaitUntilOption } from '@atomic-testing/core';
 
 // @public
@@ -82,9 +81,9 @@ export class ReactInteractor extends DOMInteractor {
     // (undocumented)
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
     // (undocumented)
-    waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
+    typeText(locator: PartLocator, text: string): Promise<void>;
     // (undocumented)
-    waitUntilComponentState(locator: PartLocator, option?: Partial<Readonly<WaitForOption>>): Promise<void>;
+    waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-core/src/ReactInteractor.ts
+++ b/packages/react-core/src/ReactInteractor.ts
@@ -69,9 +69,11 @@ export class ReactInteractor extends DOMInteractor {
   }
 
   override async typeText(locator: PartLocator, text: string): Promise<void> {
-    await act(async () => {
-      await super.typeText(locator, text);
-    });
+    // typeText dispatches through `userEvent.keyboard` (DOMInteractor.typeText),
+    // so it must go through runUserEvent — like enterText/click — or the
+    // asyncWrapper's `IS_REACT_ACT_ENVIRONMENT=false` toggle resurfaces the
+    // act-environment warnings runUserEvent exists to suppress.
+    await this.runUserEvent(() => super.typeText(locator, text));
   }
 
   override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
@@ -143,9 +145,11 @@ export class ReactInteractor extends DOMInteractor {
   }
 
   override async pressKey(locator: PartLocator, key: string, option?: Partial<PressKeyOption>): Promise<void> {
-    await act(async () => {
-      await super.pressKey(locator, key, option);
-    });
+    // pressKey now dispatches through `userEvent.keyboard` whenever the target
+    // holds focus (DOMInteractor.pressKey's editing-fidelity path), so it is
+    // user-event-backed like typeText and must use runUserEvent for the same
+    // reason. The non-focused fireEvent fallback is unaffected by the wrapper.
+    await this.runUserEvent(() => super.pressKey(locator, key, option));
   }
 
   override async contextMenu(locator: PartLocator): Promise<void> {

--- a/packages/react-core/src/ReactInteractor.ts
+++ b/packages/react-core/src/ReactInteractor.ts
@@ -1,7 +1,6 @@
 import {
   BlurOption,
   ClickOption,
-  defaultWaitForOption,
   EnterTextOption,
   FocusOption,
   HoverOption,
@@ -14,7 +13,6 @@ import {
   PartLocator,
   Point,
   PressKeyOption,
-  WaitForOption,
   WaitUntilOption,
 } from '@atomic-testing/core';
 import { DOMInteractor } from '@atomic-testing/dom-core';
@@ -68,6 +66,12 @@ export class ReactInteractor extends DOMInteractor {
 
   override async enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void> {
     await this.runUserEvent(() => super.enterText(locator, text, option));
+  }
+
+  override async typeText(locator: PartLocator, text: string): Promise<void> {
+    await act(async () => {
+      await super.typeText(locator, text);
+    });
   }
 
   override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
@@ -187,18 +191,19 @@ export class ReactInteractor extends DOMInteractor {
   }
 
   //#region wait condition
-  override async waitUntilComponentState(
-    locator: PartLocator,
-    option: Partial<Readonly<WaitForOption>> = defaultWaitForOption
-  ): Promise<void> {
-    await act(async () => {
-      await super.waitUntilComponentState(locator, option);
-    });
-  }
-
+  // Waits poll DOM state that often only changes when a React commit flushes —
+  // e.g. an exit transition's timer unmounting a dialog. Wrapping the WHOLE
+  // wait in one `act()` starves those commits: the timer fires during the
+  // wait, but its state update only flushes when the act unwinds, so every
+  // probe reads stale DOM until the timeout. Wrapping each PROBE in `act()`
+  // instead flushes pending work right before every read, so the wait
+  // resolves as soon as the condition really holds.
+  // (`waitUntilComponentState` needs no override: it polls through this
+  // interactor's `waitUntil`.)
   override async waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
-    return await act(async () => {
-      return await super.waitUntil(option);
+    return await super.waitUntil({
+      ...option,
+      probeFn: () => act(async () => await option.probeFn()),
     });
   }
   //#endregion

--- a/packages/react-legacy/src/LegacyReactInteractor.ts
+++ b/packages/react-legacy/src/LegacyReactInteractor.ts
@@ -1,7 +1,6 @@
 import {
   BlurOption,
   ClickOption,
-  defaultWaitForOption,
   EnterTextOption,
   FocusOption,
   HoverOption,
@@ -14,7 +13,6 @@ import {
   PartLocator,
   Point,
   PressKeyOption,
-  WaitForOption,
   WaitUntilOption,
 } from '@atomic-testing/core';
 import { DOMInteractor } from '@atomic-testing/dom-core';
@@ -36,6 +34,12 @@ export class LegacyReactInteractor extends DOMInteractor {
   override async enterText(locator: PartLocator, text: string, option?: Partial<EnterTextOption>): Promise<void> {
     await act(async () => {
       await super.enterText(locator, text, option);
+    });
+  }
+
+  override async typeText(locator: PartLocator, text: string): Promise<void> {
+    await act(async () => {
+      await super.typeText(locator, text);
     });
   }
 
@@ -166,24 +170,29 @@ export class LegacyReactInteractor extends DOMInteractor {
   }
 
   //#region wait condition
-  override async waitUntilComponentState(
-    locator: PartLocator,
-    option: Partial<Readonly<WaitForOption>> = defaultWaitForOption
-  ): Promise<void> {
-    await act(async () => {
-      await super.waitUntilComponentState(locator, option);
-    });
-  }
-
+  // Waits poll DOM state that often only changes when a React commit flushes —
+  // e.g. an exit transition's timer unmounting a dialog. Wrapping the WHOLE
+  // wait in one `act()` starves those commits: the timer fires during the
+  // wait, but its state update only flushes when the act unwinds, so every
+  // probe reads stale DOM until the timeout. Wrapping each PROBE in `act()`
+  // instead flushes pending work right before every read, so the wait
+  // resolves as soon as the condition really holds.
+  // (`waitUntilComponentState` needs no override: it polls through this
+  // interactor's `waitUntil`.)
   override async waitUntil<T>(option: WaitUntilOption<T>): Promise<T> {
-    // The React ≤17 `act` async overload resolves to `undefined`, not the
-    // callback's value (unlike React 18's act), so capture the result via a
-    // closure instead of returning it through `act`.
-    let result!: T;
-    await act(async () => {
-      result = await super.waitUntil(option);
+    return await super.waitUntil({
+      ...option,
+      probeFn: async () => {
+        // The React ≤17 `act` async overload resolves to `undefined`, not the
+        // callback's value (unlike React 18's act), so capture the probe value
+        // via a closure instead of returning it through `act`.
+        let probed!: T;
+        await act(async () => {
+          probed = await option.probeFn();
+        });
+        return probed;
+      },
     });
-    return result;
   }
   //#endregion
 }

--- a/packages/storybook/etc/storybook.api.md
+++ b/packages/storybook/etc/storybook.api.md
@@ -78,6 +78,8 @@ export class StorybookInteractor extends DOMInteractor {
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
     protected settle(): Promise<void>;
     // (undocumented)
+    typeText(locator: PartLocator, text: string): Promise<void>;
+    // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
 }
 

--- a/packages/storybook/src/StorybookInteractor.ts
+++ b/packages/storybook/src/StorybookInteractor.ts
@@ -75,6 +75,11 @@ export class StorybookInteractor extends DOMInteractor {
     await this.settle();
   }
 
+  override async typeText(locator: PartLocator, text: string): Promise<void> {
+    await super.typeText(locator, text);
+    await this.settle();
+  }
+
   override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
     await super.setRangeValue(locator, value);
     await this.settle();

--- a/packages/vue-3/etc/vue-3.api.md
+++ b/packages/vue-3/etc/vue-3.api.md
@@ -83,6 +83,8 @@ export class VueInteractor extends DOMInteractor {
     // (undocumented)
     setRangeValue(locator: PartLocator, value: number): Promise<void>;
     // (undocumented)
+    typeText(locator: PartLocator, text: string): Promise<void>;
+    // (undocumented)
     waitUntil<T>(option: WaitUntilOption<T>): Promise<T>;
     // (undocumented)
     waitUntilComponentState(locator: PartLocator, option?: Partial<Readonly<WaitForOption>>): Promise<void>;

--- a/packages/vue-3/src/VueInteractor.ts
+++ b/packages/vue-3/src/VueInteractor.ts
@@ -30,6 +30,11 @@ export class VueInteractor extends DOMInteractor {
     await this.flush();
   }
 
+  override async typeText(locator: PartLocator, text: string): Promise<void> {
+    await super.typeText(locator, text);
+    await this.flush();
+  }
+
   override async setRangeValue(locator: PartLocator, value: number): Promise<void> {
     await super.setRangeValue(locator, value);
     await this.flush();


### PR DESCRIPTION
## Summary

Delivers the deferred write-side and greenfield scope of the MUI X v9 follow-ups, built on a new portable keystroke primitive.

**Core — a portable keystroke layer (the enabler).**
- New `Interactor.typeText(locator, text)` dispatches real per-character keystrokes — DOM path focuses and drives `userEvent.keyboard` (literal `{`/`[` escaping, plus a planted caret for `contenteditable` hosts, which jsdom does not focus with a selection); Playwright uses `pressSequentially`. Exposed on `ComponentDriver`, implemented across all interactors (React, legacy React, Vue, Storybook, Angular). This is the write path for keystroke-driven editors that ignore value fills.
- `DOMInteractor.pressKey` upgraded to full editing fidelity: when the target holds focus it dispatches through `userEvent.keyboard` (`keydown → beforeinput/input → keyup`, modifier chords via hold syntax), matching Playwright's `locator.press`; non-focusable targets keep the prior direct `keydown`/`keyup` dispatch. This is what makes `Backspace`/`Ctrl+A`-based field clearing work.
- The React interactors now `act()`-wrap each wait **probe** rather than the whole `waitUntil` loop — a whole-loop `act` starved timer-driven React commits (an exit transition's unmount never flushed), so transition-gated waits burned their full timeout; per-probe `act` cut e.g. the mobile-picker dialog-close wait from ~10s to ~0.3s.
- HTML-driver verification: a TypeText example + shared suite covering input and `contenteditable` paths, per-character keystroke counts, literal braces/brackets, appending, and the empty-string no-op.

**Pickers (#903).** `PickerFieldDriverBase` owns the v9 section-field mechanics — reads from the hidden mirror input, `setValue(value | null)` types digit streams into the `role="spinbutton"` section spans (typing overwrites and auto-advances; clearing is `Ctrl+A` + `Backspace` + blur). On it: `DesktopDatePickerDriver` (keeping the calendar-popup `pickDate` as the pointer alternative), `DateTimePickerDriver` and `TimePickerDriver` (with the `a`/`p` meridiem keystroke), `MobileDatePickerDriver` + `MobileDatePickerDialogDriver` (writes drive the modal dialog — pick day, accept/cancel), and `DateRangePickerDriver` over the Pro single-input range field.

**Charts (#904).** Verification policy decided as **hybrid**: `jest.setup.js` shims (`structuredClone`, no-op `ResizeObserver`, zero-rect `getBBox`) make `@mui/x-charts` render under jsdom so structural reads run in both worlds, while hover/tooltip live in a deliberately e2e-only interaction suite (the documented exception — no `.dom.test.ts`). `ChartDriverBase` + `BarChartDriver`/`LineChartDriver`/`PieChartDriver`/`ScatterChartDriver` implement `getSeriesLabels`/`getLegendItems`/`getAxisLabels`/`getDataPointCount`/`hoverDataPoint`/`getTooltipText` against the re-probed v9.7 SVG hooks.

**DataGrid (#905, partial — see residuals).** `DataGridPremiumDriver` gained the interactive surface: sorting (`sortByColumn`/`getSortDirection` via `aria-sort`), quick filter + filter panel (driving the panel's MUI Select comboboxes by option `data-value`), row selection (with footer-summary counting that covers unrendered rows), keyboard cell editing (`startCellEdit`/`setCellValue`/`commitCellEdit`/`cancelCellEdit`), column pin/unpin/`hideColumn`, mouse-drag `resizeColumn` (proved the portable `drag` moves MUI's mouse-event separator), row grouping + `getAggregationValue`, `setPageSize`, `isEmpty`, and `scrollRowIntoView` (pages the virtual scroller toward off-window rows via the new `scrollBy`/`scrollIntoView` primitives).

**Docs.** `api-overview.mdx` v9 driver table updated with the new drivers and expanded descriptions.

### Not in this PR (deliberate)

`#905` is intentionally left open — these residuals remain:
- `reorderColumn` — v9.7 column-header reorder is native HTML5 drag-and-drop (`draggable="true"` + `dataTransfer`), confirmed by probe against `@mui/x-data-grid-pro@9.7.0`; the mouse-only `drag`/`dragTo` cannot drive it (blocked on #922).
- `setDensity` (v9's default toolbar has no density control), `export('csv')`/`print` (downloads/dialogs the portable interactor cannot assert), and detail-panel `expandRow` (distinct from the shipped group `expandGroup`).
- MobileDatePicker **clearing** throws by design — the mobile entry dialog has no Clear action.

### Note on the interface

`typeText` is a new required method on the `Interactor` interface. All in-repo implementors are updated; a custom out-of-tree `Interactor` would need to add it. This follows the additive pattern of prior primitives (`pressKey`, `contextMenu`, `activate`, `scrollIntoView`) and is not flagged with `!` for the pre-1.0 line, consistent with how those landed.

Closes #903
Closes #904
Advances #905 (interactive DataGrid surface; residuals tracked above)

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (relevant packages) — `component-driver-mui-x-v9-test` 77/77, `component-driver-html-test` 79/79, plus the full workspace regression suite green
- [x] `pnpm test:e2e` (relevant packages) — **chromium** green (`component-driver-mui-x-v9-test` 81/81, `component-driver-html-test` 82/82). Firefox/WebKit binaries are not installable in this environment (network policy blocks Playwright's browser CDN); CI is the confirming signal for those two engines.

## Breaking change

- [ ] This PR introduces a breaking change (title uses `!`, e.g. `feat(core)!: ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsvQBAinjzKKvjF8x3txuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsvQBAinjzKKvjF8x3txuv)_