### PR TITLE
feat(create-atomic-testing): guard against version + registry drift

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -358,8 +358,11 @@ jobs:
   # create-atomic-testing scaffolder — pure-logic unit tests (detect / recipes /
   # generate / apply) plus the recipe-catalog sync-check (REC-SYNC-*), which
   # fails if any package a recipe emits does not exist or its version / peer
-  # range drifts from the real workspace. Self-contained (no `needs: build`):
-  # the sync-check builds only this package, the unit tests import from src.
+  # range drifts from the real workspace, and the coverage check (COV-*), which
+  # fails if a shipped component-driver package is not registered in the
+  # scaffolder registry (and so would be silently missing from the CLI and the
+  # generated support matrix). Self-contained (no `needs: build`): the checks
+  # build only this package, the unit tests import from src.
   create-atomic-testing-test:
     name: Test create-atomic-testing scaffolder
     runs-on: ubuntu-latest
@@ -378,6 +381,9 @@ jobs:
 
       - name: Recipe-catalog sync-check
         run: pnpm --filter create-atomic-testing check:recipes
+
+      - name: Scaffolder-coverage check
+        run: pnpm --filter create-atomic-testing check:coverage
 
       - name: Run unit tests
         run: pnpm test:dom

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ export class MyDriver extends ComponentDriver<{}> implements IInputDriver<string
 }
 ```
 
+> **Shipping a new component-driver _package_ (a new design system) or a framework engine?** Register it with the scaffolder so `create atomic-testing` offers it and it shows up in the generated **Framework & Runner Support** matrix (that matrix is derived from the same registry): add or extend a plugin in `packages/create-atomic-testing/src/registry/` (`designSystems.ts` / `frameworks.ts`) plus a `compatibility.ts` row. The `check:coverage` (COV-\*) CI gate fails if a shipped `component-driver-*` package isn't registered. Details: [`packages/create-atomic-testing/CLAUDE.md`](packages/create-atomic-testing/CLAUDE.md).
+
 ## Testing Pattern
 
 ### Simple DOM-Only Test

--- a/packages/create-atomic-testing/CLAUDE.md
+++ b/packages/create-atomic-testing/CLAUDE.md
@@ -1,0 +1,55 @@
+# create-atomic-testing/CLAUDE.md
+
+The onboarding scaffolder — `npm/pnpm/yarn create atomic-testing`. It detects a
+project's stack and writes a working, green example test. This note covers the
+things a change here must keep in sync; the root [`CLAUDE.md`](../../CLAUDE.md)
+covers the monorepo.
+
+## The registry is the extension point
+
+A recipe is **composed**, not hard-coded: a framework, a runner and a design
+system are three independent plugins, and a compatibility matrix decides which
+combinations are offered and at what tier. Everything routes through
+[`src/registry/`](src/registry/):
+
+- **Add a design system** (e.g. a new `component-driver-*`) → a `DesignSystemPlugin`
+  in `designSystems.ts` (its `driverPackage(major)` names the driver package).
+- **Add a framework / a new major** (e.g. Svelte, or React 20) → a `FrameworkPlugin`
+  in `frameworks.ts` (its `enginePackage(major)` names the engine package).
+- **Offer a combination** → one `CompatRule` row in `compatibility.ts` with a
+  support tier and an `enabled` flag. The registered-but-disabled `angular + jest`
+  row is the worked example of the seam. No resolution code changes.
+
+**One registration, two surfaces.** The docs **Framework & Runner Support** matrix
+is generated from this same registry (`docs/scripts/genSupportMatrix.mjs` imports
+the built `dist`), so registering a plugin here makes it appear in the published
+matrix automatically — you do not edit the matrix by hand.
+
+## Invariants the CI gates enforce (build `dist` first — the checks read it)
+
+- **`check:recipes`** (`scripts/check-recipe-sync.mjs`, REC-SYNC-\*) — every
+  `@atomic-testing/*` a recipe emits exists, and its version + peer ranges match
+  the real workspace manifests.
+- **`check:coverage`** (`scripts/check-scaffolder-coverage.mjs`, COV-\*) — every
+  shipped `component-driver-*` package is reachable through a design-system plugin
+  (or on the script's small allow-list), and every engine/driver the registry
+  emits is a real package. This is what turns "forgot to register the new driver"
+  into a red build instead of a silent omission.
+
+Both import the built `dist/index.mjs`, so run `pnpm --filter create-atomic-testing
+build` before them (CI does this in the `create-atomic-testing-test` job).
+
+## Versions are derived, not hand-maintained
+
+`ATOMIC_VERSION` in [`src/constants.ts`](src/constants.ts) is read from this
+package's own `package.json`, which the release process bumps in lockstep across
+every `@atomic-testing/*` package. **Do not** re-introduce a hard-coded version
+literal: a `[skip ci]` release bump once updated the manifests but not such a
+literal, and REC-SYNC only caught it on the next unrelated PR. Third-party ranges
+(`THIRD_PARTY`) are still hand-maintained here and guarded by REC-SYNC.
+
+## Purity boundary
+
+`detect/`, `registry/`, `generate/` and `plan/` are pure (no fs); `io/` and
+`apply/` are the only side-effecting seams. Keep new logic on the pure side so it
+stays unit-testable and `--dry-run` stays cheap.

--- a/packages/create-atomic-testing/package.json
+++ b/packages/create-atomic-testing/package.json
@@ -40,6 +40,7 @@
     "build": "tsdown",
     "check:type": "tsgo --noEmit",
     "check:recipes": "node scripts/check-recipe-sync.mjs",
+    "check:coverage": "node scripts/check-scaffolder-coverage.mjs",
     "test:dom": "jest"
   },
   "dependencies": {

--- a/packages/create-atomic-testing/scripts/check-scaffolder-coverage.mjs
+++ b/packages/create-atomic-testing/scripts/check-scaffolder-coverage.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Scaffolder-coverage check (COV-*). Fails CI when a shipped consumer package is
+// not reachable through the scaffolder registry — so adding a new
+// `component-driver-*` package (or renaming/removing an engine) without wiring it
+// into registry/* is caught HERE rather than silently omitted from
+// `create atomic-testing` and, by extension, the generated support matrix.
+//
+// The support matrix is derived from the same registry (docs/scripts/
+// genSupportMatrix.mjs), so this one check keeps both the scaffolder and the
+// published matrix honest about a new driver.
+//
+// Dependency-free Node ESM, modelled on check-recipe-sync.mjs. Reads the built
+// dist entry, so build this package first:
+//   pnpm --filter create-atomic-testing build
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const distEntry = resolve(scriptDir, '../dist/index.mjs');
+const packagesDir = resolve(scriptDir, '../..');
+
+if (!existsSync(distEntry)) {
+  console.error(`[coverage] Missing build output at ${distEntry}.`);
+  console.error('[coverage] Run: pnpm --filter create-atomic-testing build');
+  process.exit(2);
+}
+
+const { DESIGN_SYSTEMS, FRAMEWORKS } = await import(pathToFileURL(distEntry).href);
+
+// Every workspace package directory (one that carries a package.json).
+const packageDirs = new Set(readdirSync(packagesDir).filter(dir => existsSync(join(packagesDir, dir, 'package.json'))));
+
+// `component-driver-html` is always installed by the resolver directly (its
+// plugin's driverPackage() returns null), so it needs no plugin of its own.
+const ALWAYS_INSTALLED = new Set(['component-driver-html']);
+// Drivers intentionally not offered by the scaffolder yet (EOL, or a driver that
+// exists before its recipe does). Add a name here WITH A REASON to acknowledge a
+// known gap on purpose instead of failing the build.
+const DRIVER_ALLOWLIST = new Set([]);
+
+// The driver packages the registry can emit. Probe a generous major range;
+// each plugin's driverPackage() clamps to the majors it actually supports.
+const emittedDrivers = new Set();
+for (const ds of Object.values(DESIGN_SYSTEMS)) {
+  for (let major = 1; major <= 40; major++) {
+    const pkg = ds.driverPackage(major);
+    if (pkg) emittedDrivers.add(pkg);
+  }
+}
+
+// The engine packages the registry can emit, across each framework's majors.
+const emittedEngines = new Set();
+for (const fw of Object.values(FRAMEWORKS)) {
+  for (const major of fw.supportedMajors) {
+    const engine = fw.enginePackage(major);
+    if (engine) emittedEngines.add(engine);
+  }
+}
+
+const errors = [];
+
+// 1. Reverse coverage: every shipped component-driver-* is reachable.
+const shippedDrivers = [...packageDirs].filter(dir => dir.startsWith('component-driver-')).sort();
+for (const dir of shippedDrivers) {
+  if (ALWAYS_INSTALLED.has(dir) || DRIVER_ALLOWLIST.has(dir) || emittedDrivers.has(dir)) continue;
+  errors.push(
+    `COV-01: ${dir} ships but no design-system plugin emits it. Register it in ` +
+      `src/registry/designSystems.ts (add or extend a DesignSystemPlugin) and give it a ` +
+      `compatibility row, or add it to DRIVER_ALLOWLIST here with a reason.`
+  );
+}
+
+// 2. Forward existence: everything the registry emits must be a real package.
+for (const pkg of [...emittedDrivers].sort()) {
+  if (!packageDirs.has(pkg)) {
+    errors.push(`COV-02: src/registry/designSystems.ts emits ${pkg}, which is not a package under packages/.`);
+  }
+}
+for (const engine of [...emittedEngines].sort()) {
+  if (!packageDirs.has(engine)) {
+    errors.push(`COV-03: src/registry/frameworks.ts emits engine ${engine}, which is not a package under packages/.`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`[coverage] ${errors.length} problem(s):`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[coverage] OK — ${shippedDrivers.length} driver package(s) all offered; ` +
+    `${emittedEngines.size} engine + ${emittedDrivers.size} driver package(s) all exist.\n`
+);

--- a/packages/create-atomic-testing/src/constants.ts
+++ b/packages/create-atomic-testing/src/constants.ts
@@ -1,21 +1,22 @@
 /**
- * Single source of truth for the versions the scaffolder emits.
+ * Single source of truth for the third-party ranges the scaffolder emits, plus
+ * the `@atomic-testing/*` version line (derived from this package's own version).
  *
  * The recipe catalog references these constants rather than hard-coding ranges
- * per recipe, so a workspace version bump or a peer-range change is a one-line
- * edit here — and `scripts/check-recipe-sync.mjs` fails CI if any value here
- * drifts from the real per-package manifests (REC-SYNC-*).
+ * per recipe, so a peer-range change is a one-line edit here — and
+ * `scripts/check-recipe-sync.mjs` fails CI if any value here drifts from the real
+ * per-package manifests (REC-SYNC-*). The `@atomic-testing/*` version is NOT
+ * hand-maintained: it is read from this package's `package.json`, which the
+ * release process bumps in lockstep across every `@atomic-testing/*` package, so
+ * it can never go stale (as a hard-coded literal did when the 0.97.0 bump updated
+ * the manifests but not the constant, and the `[skip ci]` bump hid it).
  */
 
+import pkg from '../package.json';
 import type { DependencySpec } from './types';
 
-// NOTE: this must track the workspace version in lockstep. The release "bump
-// version" step updates every package.json but not this literal, and if that
-// commit carries [skip ci] the REC-SYNC-04 guard below never runs to catch the
-// drift — which is exactly how 0.97.0 shipped with this left at 0.96.0. Deriving
-// it from package.json (so it can't drift) is tracked as a follow-up.
 /** The `@atomic-testing/*` line this build of the scaffolder targets. */
-export const ATOMIC_VERSION = '0.97.0';
+export const ATOMIC_VERSION: string = pkg.version;
 
 /** The range emitted for every `@atomic-testing/*` dependency. */
 export const ATOMIC_RANGE = `^${ATOMIC_VERSION}`;

--- a/packages/create-atomic-testing/tsconfig.json
+++ b/packages/create-atomic-testing/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "exclude": ["node_modules", "dist", "build", "__tests__"],
-  "include": ["./src"],
+  // package.json is listed so src/constants.ts can import its `version` — the
+  // scaffolder's own version is the single source for the emitted @atomic-testing
+  // range (see constants.ts). It only affects tsc's (unused) emit: check:type runs
+  // --noEmit and the published dist is produced by tsdown, not tsc.
+  "include": ["./src", "./package.json"],
   "compilerOptions": {
     "outDir": "./build",
     "composite": true,


### PR DESCRIPTION
## Summary

Follow-up to #1096 (RFC #1095) that closes, at the root, the drift class that produced the `0.97.0` scaffolder CI break — and future-proofs the scaffolder + generated support matrix as new frameworks/design systems are added (the question raised on #1096).

**1. Version can't drift** — `ATOMIC_VERSION` is now **derived** from this package's own `package.json` (`constants.ts`; `tsconfig.json` lists `package.json` in `include` so the composite project can import it) instead of a hand-maintained literal. The release process already bumps every `package.json` in lockstep, so the emitted `@atomic-testing/*` range tracks it automatically. This is exactly what failed on `main`: the `0.97.0` bump (`01b2eb9`, `[skip ci]`) updated the manifests but not the literal, and `[skip ci]` meant `check-recipe-sync` never ran to catch it.

**2. Missing registration fails loudly** — new `check:coverage` (`scripts/check-scaffolder-coverage.mjs`, COV-\*): a shipped `component-driver-*` package that isn't reachable through a design-system plugin now fails CI (COV-01) instead of being silently absent from `create atomic-testing` **and** the generated Framework & Runner Support matrix (which is derived from the same registry). Also verifies every engine/driver the registry emits is a real package (COV-02/03). Wired into the `create-atomic-testing-test` job.

**3. Discoverable for future contributors** — a package-scoped `packages/create-atomic-testing/CLAUDE.md` (the extension point, the version-derive invariant, and the two CI gates) plus a pointer from the root CLAUDE.md "Creating a Driver" section, so an agent adding a driver or framework knows to register it and that coverage enforces it.

> **Relationship to #1096:** this supersedes the one-line `ATOMIC_VERSION → 0.97.0` bump in #1096 with the durable derived form. Whichever merges first, I'll reconcile the other (rebase to keep the derive).

## Checks

- [x] `pnpm --filter create-atomic-testing check:type` — passes (JSON import resolves under the composite project)
- [x] `pnpm run check:lint` (oxlint) / `pnpm run check:style` (oxfmt) — clean
- [x] `pnpm --filter create-atomic-testing check:recipes` — "all in sync at 0.97.0" (derived)
- [x] `pnpm --filter create-atomic-testing check:coverage` — "15 driver package(s) all offered"; verified it fails COV-01 on an unregistered driver
- [x] `pnpm --filter create-atomic-testing test:dom` — 47 passed (jest resolves the derive from source)
- [ ] `pnpm test:e2e` — n/a

## Breaking change

- [ ] This PR introduces a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVVoYr7bm8zyRsHhBpMUAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVVoYr7bm8zyRsHhBpMUAp)_