### PR TITLE
docs(create-atomic-testing): document --agents flag; fix framework-guide bugs

### DIFF
--- a/docs/docs/framework-guide.mdx
+++ b/docs/docs/framework-guide.mdx
@@ -37,16 +37,7 @@ Great for user flows, cross-browser testing, and production-like scenarios.
 <Tabs>
 <TabItem value="react-mui" label="React + Material-UI">
 
-```bash
-# Most popular combination
-pnpm add @atomic-testing/react-18 @atomic-testing/component-driver-mui-v9
-
-# If you're using React 19
-pnpm add @atomic-testing/react-19 @atomic-testing/component-driver-mui-v9
-
-# If you're still on React 17
-pnpm add @atomic-testing/react-legacy @atomic-testing/component-driver-mui-v6
-```
+Install the React packages from [Manual Installation](./manual-installation.mdx), then add the Material-UI driver matching your MUI major from [Material-UI Drivers](#material-ui-drivers) below (most apps want `@atomic-testing/component-driver-mui-v9` on React 18/19, or `-mui-v6` on React 17).
 
 **Perfect for**: Modern React apps with Material-UI components
 
@@ -54,15 +45,9 @@ pnpm add @atomic-testing/react-legacy @atomic-testing/component-driver-mui-v6
 
 <TabItem value="vue-html" label="Vue 3 + HTML">
 
-```bash
-# Vue 3 with standard HTML elements
-pnpm add @atomic-testing/vue-3 @atomic-testing/component-driver-html
+See the Vue 3 install command in [Manual Installation](./manual-installation.mdx).
 
-# Vue 3 with Material-UI (if using Vuetify/similar)
-pnpm add @atomic-testing/vue-3 @atomic-testing/component-driver-mui-v9
-```
-
-**Perfect for**: Vue 3 applications with custom components or HTML-based UI libraries
+**Perfect for**: Vue 3 applications with custom components or HTML-based UI libraries. (There is currently no `@atomic-testing/component-driver-*` package for Vuetify — if you're on PrimeVue instead, see [PrimeVue Drivers](#primevue-drivers) below.)
 
 </TabItem>
 
@@ -70,11 +55,11 @@ pnpm add @atomic-testing/vue-3 @atomic-testing/component-driver-mui-v9
 
 ```bash
 # Angular 20 with standard HTML elements — pick the package matching your Angular major
-pnpm add @atomic-testing/angular-20 @atomic-testing/component-driver-html
+pnpm add -D @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/angular-20
 
 # Angular 21 / 22
-pnpm add @atomic-testing/angular-21 @atomic-testing/component-driver-html
-pnpm add @atomic-testing/angular-22 @atomic-testing/component-driver-html
+pnpm add -D @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/angular-21
+pnpm add -D @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/angular-22
 ```
 
 **Perfect for**: Standalone-component Angular apps — works with both zone.js and
@@ -84,18 +69,7 @@ zoneless change detection (`zone.js` is an optional peer; zoneless apps don't ne
 
 <TabItem value="e2e-any" label="E2E Testing (Any Framework)">
 
-```bash
-# E2E testing with Material-UI components
-pnpm add @atomic-testing/playwright @atomic-testing/component-driver-mui-v9
-
-# E2E testing with HTML elements
-pnpm add @atomic-testing/playwright @atomic-testing/component-driver-html
-
-# E2E testing with multiple component libraries
-pnpm add @atomic-testing/playwright \
-  @atomic-testing/component-driver-mui-v9 \
-  @atomic-testing/component-driver-html
-```
+Install the Playwright packages from [Manual Installation](./manual-installation.mdx), then add whichever component-driver package(s) match your UI from [Component Driver Libraries](#-component-driver-libraries) below — mix in as many as you need (e.g. Material-UI and HTML together).
 
 **Perfect for**: Cross-browser testing, user journey validation, production testing
 
@@ -103,13 +77,7 @@ pnpm add @atomic-testing/playwright \
 
 <TabItem value="fullstack" label="Full-Stack Testing">
 
-```bash
-# Cover all bases: DOM + E2E
-pnpm add @atomic-testing/react-18 \
-  @atomic-testing/playwright \
-  @atomic-testing/component-driver-mui-v9 \
-  @atomic-testing/component-driver-html
-```
+Combine the React and Playwright install commands from [Manual Installation](./manual-installation.mdx), then add your component-driver package(s) from [Component Driver Libraries](#-component-driver-libraries) below.
 
 **Perfect for**: Comprehensive testing strategy with fast DOM tests + thorough E2E coverage
 
@@ -124,9 +92,7 @@ pnpm add @atomic-testing/react-18 \
 
 <TabItem value="react-19" label="React 19">
 
-```bash
-pnpm add @atomic-testing/react-19
-```
+See the React install command in [Manual Installation](./manual-installation.mdx).
 
 - ✅ **Latest React features**
 - ✅ **Performance improvements**
@@ -136,9 +102,7 @@ pnpm add @atomic-testing/react-19
 
 <TabItem value="react-18" label="React 18">
 
-```bash
-pnpm add @atomic-testing/react-18
-```
+See the React install command in [Manual Installation](./manual-installation.mdx) — swap in `@atomic-testing/react-18`.
 
 - ✅ **React 18 concurrent features**
 - ✅ **Automatic batching support**
@@ -149,9 +113,7 @@ pnpm add @atomic-testing/react-18
 
 <TabItem value="react-legacy" label="React 17">
 
-```bash
-pnpm add @atomic-testing/react-legacy
-```
+See the React install command in [Manual Installation](./manual-installation.mdx) — swap in `@atomic-testing/react-legacy`.
 
 - ✅ **Legacy React support**
 - ✅ **Gradual migration path**
@@ -161,9 +123,7 @@ pnpm add @atomic-testing/react-legacy
 
 <TabItem value="vue-3" label="Vue 3">
 
-```bash
-pnpm add @atomic-testing/vue-3
-```
+See the Vue 3 install command in [Manual Installation](./manual-installation.mdx).
 
 - ✅ **Automatic reactivity handling** with `nextTick()`
 - ✅ **SFC-like component support** for easy testing
@@ -174,9 +134,7 @@ pnpm add @atomic-testing/vue-3
 
 <TabItem value="playwright" label="Playwright">
 
-```bash
-pnpm add @atomic-testing/playwright
-```
+See the Playwright install command in [Manual Installation](./manual-installation.mdx).
 
 - ✅ **Cross-browser testing** (Chrome, Firefox, Safari)
 - ✅ **Mobile testing** with device emulation
@@ -376,7 +334,7 @@ pnpm add @atomic-testing/component-driver-html
 
 ```bash
 # If you're just getting started — react-19 is the default; on React 18, swap in @atomic-testing/react-18
-pnpm add @atomic-testing/react-19 @atomic-testing/component-driver-html
+pnpm add -D @atomic-testing/core @atomic-testing/component-driver-html @atomic-testing/react-19
 ```
 
 You can always add more packages later. HTML drivers work with any components.

--- a/docs/docs/guides/scaffold-in-ci.md
+++ b/docs/docs/guides/scaffold-in-ci.md
@@ -45,21 +45,22 @@ of what the target project happens to look like.
 
 ## Flag reference
 
-| Flag                               | Values                                                                                            | Effect                                      |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `--framework`                      | `react` \| `vue` \| `angular`                                                                     | Override framework detection                |
-| `--framework-major`                | integer                                                                                           | Override the detected major version         |
-| `--runner`                         | `jest` \| `vitest` \| `vitest-browser` \| `playwright`                                            | Choose the test runner                      |
-| `--design-system`                  | `html` \| `mui` \| `mui-x` \| `angular-material` \| `primevue` \| `radix` \| `shadcn` \| `astryx` | Choose the driver package                   |
-| `--package-manager`                | `npm` \| `pnpm` \| `yarn` \| `bun`                                                                | Override lockfile-based detection           |
-| `--typescript` / `--no-typescript` | —                                                                                                 | Force TypeScript on/off (default: detect)   |
-| `--dir <path>`                     | path                                                                                              | Target project directory (default: cwd)     |
-| `-y`, `--yes`                      | —                                                                                                 | Accept detected values without prompting    |
-| `--ci`                             | —                                                                                                 | Non-interactive (implied when not a TTY)    |
-| `--dry-run`                        | —                                                                                                 | Print the plan; write nothing               |
-| `--install` / `--no-install`       | —                                                                                                 | Force install / skip install (default: ask) |
-| `-h`, `--help`                     | —                                                                                                 | Print usage                                 |
-| `-v`, `--version`                  | —                                                                                                 | Print version                               |
+| Flag                               | Values                                                                                            | Effect                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `--framework`                      | `react` \| `vue` \| `angular`                                                                     | Override framework detection                                          |
+| `--framework-major`                | integer                                                                                           | Override the detected major version                                   |
+| `--runner`                         | `jest` \| `vitest` \| `vitest-browser` \| `playwright`                                            | Choose the test runner                                                |
+| `--design-system`                  | `html` \| `mui` \| `mui-x` \| `angular-material` \| `primevue` \| `radix` \| `shadcn` \| `astryx` | Choose the driver package                                             |
+| `--package-manager`                | `npm` \| `pnpm` \| `yarn` \| `bun`                                                                | Override lockfile-based detection                                     |
+| `--typescript` / `--no-typescript` | —                                                                                                 | Force TypeScript on/off (default: detect)                             |
+| `--agents` / `--no-agents`         | —                                                                                                 | Emit the Claude Code testing skills + a CLAUDE.md guide (default: on) |
+| `--dir <path>`                     | path                                                                                              | Target project directory (default: cwd)                               |
+| `-y`, `--yes`                      | —                                                                                                 | Accept detected values without prompting                              |
+| `--ci`                             | —                                                                                                 | Non-interactive (implied when not a TTY)                              |
+| `--dry-run`                        | —                                                                                                 | Print the plan; write nothing                                         |
+| `--install` / `--no-install`       | —                                                                                                 | Force install / skip install (default: ask)                           |
+| `-h`, `--help`                     | —                                                                                                 | Print usage                                                           |
+| `-v`, `--version`                  | —                                                                                                 | Print version                                                         |
 
 Which framework × runner combinations are actually offered — and which are
 `verified` versus `experimental` — is spelled out in

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -42,7 +42,7 @@ Run it from inside an existing project — it scaffolds Atomic Testing into your
 1. **Detects** your framework and major version, test runner, package manager, TypeScript, and design system from `package.json`, lockfiles, and config files.
 2. **Prompts** for anything it couldn't detect confidently — interactively in a terminal, or automatically (non-interactive) in CI.
 3. **Resolves a recipe** for your framework × runner × design system, and refuses impossible or unsupported combinations with a clear message.
-4. **Writes** a standalone runner config plus an example component, `ScenePart`, and a passing test under `atomic-testing-example/`, and adds a `test` script to `package.json`.
+4. **Writes** a standalone runner config plus an example component, `ScenePart`, and a passing test under `atomic-testing-example/`, and adds a `test` script to `package.json`. By default it also writes four Claude Code skills under `.claude/skills/` and a root `CLAUDE.md` guide adapted to your detected stack (skip both with `--no-agents`).
 5. **Installs** the dependencies after asking — or, with `--no-install`, prints the exact per-package-manager commands so you can run them yourself.
 
 When it finishes you have a green example test in `atomic-testing-example/`, and the CLI prints the exact command to run it. Combinations outside the verified set (React + Jest, Vue 3 + Jest) are marked **experimental** — the CLI warns before writing one.
@@ -61,6 +61,13 @@ For the canonical React + Jest stack, the scaffolder drops:
 
 ```text
 your-project/
+├─ .claude/
+│  └─ skills/
+│     ├─ scaffold-test-driver/SKILL.md
+│     ├─ author-component-tests/SKILL.md
+│     ├─ diagnose-test-failure/SKILL.md
+│     └─ sync-test-driver/SKILL.md
+├─ CLAUDE.md                      # guide adapted to your detected framework, runner, and driver package
 ├─ jest.config.cjs                # standalone runner config (.cjs sidesteps the ESM rename trap)
 ├─ package.json                   # gains a "test" script
 └─ atomic-testing-example/
@@ -68,6 +75,8 @@ your-project/
    ├─ scenePart.ts                # maps a named part to a locator + driver
    └─ ExampleComponent.test.tsx   # a passing test
 ```
+
+The skills and `CLAUDE.md` are on by default; pass `--no-agents` to skip them.
 
 The generated test drives a **real state change** through the framework-agnostic HTML driver — `HTMLTextInputDriver.setValue()` then reads it back with `getValue()` — so on any **in-process runner** (Jest, Vitest, or Vitest browser mode) it passes on the first run, whatever framework you picked. Those stacks differ only in the details: Vue and Angular emit a `.ts` component, Vitest emits `vitest.config.ts`, and the example test filename follows the runner. **Playwright is the exception** — it drives a real browser against your running app, so the scaffolder emits `playwright.config.ts` plus a placeholder `*.e2e` starter test (no example component or scene part) that you point at your dev server; it turns green once your app serves the page, not out of the box.
 

--- a/packages/create-atomic-testing/README.md
+++ b/packages/create-atomic-testing/README.md
@@ -20,19 +20,20 @@ It does not create your app — it adds testing to a project you already have (o
 
 ## Options
 
-| Flag                                                                                    | Purpose                                   |
-| --------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `--framework <react\|vue\|angular>`                                                     | Override framework detection              |
-| `--framework-major <number>`                                                            | Override the framework major              |
-| `--runner <jest\|vitest\|vitest-browser\|playwright>`                                   | Pick the runner                           |
-| `--design-system <html\|mui\|mui-x\|angular-material\|primevue\|radix\|shadcn\|astryx>` | Pick the design system                    |
-| `--package-manager <npm\|pnpm\|yarn\|bun>`                                              | Force a package manager                   |
-| `--typescript` / `--no-typescript`                                                      | Force TypeScript on/off (default: detect) |
-| `--dir <path>`                                                                          | Target directory (default: cwd)           |
-| `-y, --yes`                                                                             | Accept detected values without prompting  |
-| `--ci`                                                                                  | Non-interactive (implied when not a TTY)  |
-| `--dry-run`                                                                             | Show what would happen; write nothing     |
-| `--install` / `--no-install`                                                            | Force / skip install (default: ask)       |
+| Flag                                                                                    | Purpose                                                               |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `--framework <react\|vue\|angular>`                                                     | Override framework detection                                          |
+| `--framework-major <number>`                                                            | Override the framework major                                          |
+| `--runner <jest\|vitest\|vitest-browser\|playwright>`                                   | Pick the runner                                                       |
+| `--design-system <html\|mui\|mui-x\|angular-material\|primevue\|radix\|shadcn\|astryx>` | Pick the design system                                                |
+| `--package-manager <npm\|pnpm\|yarn\|bun>`                                              | Force a package manager                                               |
+| `--typescript` / `--no-typescript`                                                      | Force TypeScript on/off (default: detect)                             |
+| `--agents` / `--no-agents`                                                              | Emit the Claude Code testing skills + a CLAUDE.md guide (default: on) |
+| `--dir <path>`                                                                          | Target directory (default: cwd)                                       |
+| `-y, --yes`                                                                             | Accept detected values without prompting                              |
+| `--ci`                                                                                  | Non-interactive (implied when not a TTY)                              |
+| `--dry-run`                                                                             | Show what would happen; write nothing                                 |
+| `--install` / `--no-install`                                                            | Force / skip install (default: ask)                                   |
 
 Exit codes: `0` ok · `1` cancelled / install failed · `2` usage · `3` needs a flag (ambiguous, non-interactive) · `4` unsupported combination · `5` write failed.
 

--- a/packages/create-atomic-testing/__tests__/recipe.test.ts
+++ b/packages/create-atomic-testing/__tests__/recipe.test.ts
@@ -216,3 +216,17 @@ describe('agent skills wiring', () => {
     expect(plan.files.find(f => f.kind === 'agent-config')!.contents).toContain('@atomic-testing/playwright');
   });
 });
+
+describe('nextSteps skills pointer', () => {
+  it('points agents-on users at the skills docs', () => {
+    const plan = resolveRecipe(sel({ agents: true }));
+    expect(plan.nextSteps.some(step => step.includes('.claude/skills/') && step.includes('atomic-testing.dev'))).toBe(
+      true
+    );
+  });
+
+  it('omits the skills pointer entirely with --no-agents', () => {
+    const plan = resolveRecipe(sel({ agents: false }));
+    expect(plan.nextSteps.some(step => step.includes('.claude/skills/'))).toBe(false);
+  });
+});

--- a/packages/create-atomic-testing/src/registry/resolveRecipe.ts
+++ b/packages/create-atomic-testing/src/registry/resolveRecipe.ts
@@ -93,6 +93,18 @@ export function resolveRecipe(selection: RecipeSelection): RecipePlan {
   }
   if (designSystem.usageNote) warnings.push(designSystem.usageNote);
 
+  const nextSteps = [
+    ...ctx.runner.nextSteps(ctx),
+    'Replace the sample component in atomic-testing-example/ with your own.',
+  ];
+  // Point agents-on users at the skills the CLI just wrote — --no-agents users get no
+  // mention of a feature they explicitly opted out of.
+  if (effectiveSelection.agents) {
+    nextSteps.push(
+      'Using Claude Code? `.claude/skills/` and `CLAUDE.md` are ready to help write and maintain tests — see https://atomic-testing.dev/docs/guides/decomposing-driver-trees to learn how.'
+    );
+  }
+
   return {
     id: `${selection.framework}-${selection.frameworkMajor}+${selection.runner}+${selection.designSystem}`,
     // Report the effective selection (with the resolved design-system major) so
@@ -103,6 +115,6 @@ export function resolveRecipe(selection: RecipeSelection): RecipePlan {
     files: generateFiles(ctx),
     packageJsonPatch: { scripts: ctx.runner.scripts(ctx) },
     warnings,
-    nextSteps: [...ctx.runner.nextSteps(ctx), 'Replace the sample component in atomic-testing-example/ with your own.'],
+    nextSteps,
   };
 }


### PR DESCRIPTION
## Summary

Two prior research audits found: (a) `create-atomic-testing`'s `--agents` flag — which scaffolds four Claude Code Skills plus a `CLAUDE.md` into new projects, on by default — shipped without any downstream doc/CLI-output updates mentioning it, and (b) `docs/docs/framework-guide.mdx` had a factually wrong driver recommendation plus install commands that duplicated (and disagreed with) `manual-installation.mdx`. This PR makes the six fixes those audits called for.

1. **Fix wrong Vuetify/MUI recommendation** (`docs/docs/framework-guide.mdx`) — the "Vue 3 + HTML" combo recommended `@atomic-testing/component-driver-mui-v9` for "Vuetify/similar" setups. That package's `peerDependencies` (`packages/component-driver-mui-v9/package.json`) are React/ReactDOM only — it drives actual Material-UI (React) markup, not Vuetify's. Removed the line; the doc now says honestly that no Vuetify driver exists yet, and points PrimeVue users at the driver that does.

2. **Document `--agents`/`--no-agents`** in `packages/create-atomic-testing/README.md`'s Options table — added a row matching `cli.ts`'s HELP text: "Emit the Claude Code testing skills + a CLAUDE.md guide (default: on)".

3. **Document `--agents`/`--no-agents`** in `docs/docs/guides/scaffold-in-ci.md`'s flag reference table — same row, matching that table's Flag/Values/Effect format.

4. **CLI "Next steps" now points at the skills** — `resolveRecipe.ts`'s `nextSteps` gained one line, gated on `agents === true` (nothing prints for `--no-agents`), pointing at `https://atomic-testing.dev/docs/guides/decomposing-driver-trees` — the closest existing explainer of the skills concept. Added tests for both the `agents: true` and `agents: false` cases in `recipe.test.ts`. **Note:** this deliberately points at the closest existing page, not a dedicated one — a dedicated "AI-assisted testing" docs page was the other half of the original audit's recommendation and is intentionally **out of scope** for this PR pending a separate decision on its placement/content.

5. **Trimmed duplicated/inconsistent install commands** in `framework-guide.mdx`'s "Common Package Combinations" and "Framework Integration" sections — those blocks re-typed `pnpm add` commands missing `@atomic-testing/core` and the `-D` flag, disagreeing with `manual-installation.mdx` (the accurate source of truth). Replaced with short prose pointing at Manual Installation / the Component Driver Libraries section instead of re-deriving commands. One exception: the Angular block in "Common Package Combinations" has no equivalent tab in `manual-installation.mdx` to point to, so I fixed its commands in place (added `-D`/`core`) rather than fabricating a link. Also fixed the same missing-`core`/`-D` pattern in one more block outside the two named sections ("Not Sure Which to Choose? → Start Simple") since it's the identical bug in the same file. Did **not** touch the "Component Driver Libraries" decision-matrix or "Decision Tree" sections, per the audit's scope.

6. **`docs/docs/quick-start.mdx`** — the "What the CLI writes" file tree and step list omitted that the scaffolder also writes `.claude/skills/{scaffold-test-driver,author-component-tests,diagnose-test-failure,sync-test-driver}/SKILL.md` and a root `CLAUDE.md` by default. Added both to the tree and one sentence to the step list.

## Verification

- `cd docs && pnpm build` — succeeds. (First run surfaced a broken in-page anchor from my own edit — `#component-driver-libraries` vs. the actual emoji-mangled id `#-component-driver-libraries` — fixed and confirmed clean on rebuild.)
- `node docs/scripts/check-doc-accuracy.mjs` — OK, 29 doc files scanned, all imports resolve.
- `node docs/scripts/check-doc-driver-sync.mjs` — OK.
- `pnpm --filter create-atomic-testing test:dom` — baseline (before `resolveRecipe.ts` change): **55/55 passing**. After the change: **57/57 passing** (2 new tests for the `nextSteps` gating).
- `pnpm --filter create-atomic-testing check:type` — clean.
- `pnpm run check:type` (full repo) — clean.
- `pnpm run check:lint` (full repo, `--fix`) — no changes needed.
- `pnpm run check:style` (full repo) — no changes needed.
- `cd docs && pnpm typecheck` — pre-existing failure on `main` unrelated to this change (missing `@docusaurus/theme-classic` type defs / deprecated `baseUrl` option); confirmed via `git stash` that it fails identically on a clean checkout.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (relevant packages — `create-atomic-testing`)
- [ ] `pnpm test:e2e` — not applicable, no runtime/browser surface touched (docs + CLI plan output only)

## Breaking change

- [ ] This PR introduces a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TV1EKroLpu1RbSU1A9pfzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV1EKroLpu1RbSU1A9pfzy)_