### PR TITLE
docs: remove internal delivery-sequencing jargon from published docs

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -142,3 +142,11 @@ this site's.
   transcribe its options, buckets, or transform steps. Routine content changes (adding a
   package, retitling a category) should not require a doc edit here — only a change in how
   the pipeline works should.
+- **No internal delivery-sequencing jargon in `docs/docs/`.** Work on a driver package is
+  often planned and tracked internally in numbered batches ("Wave 0", "Wave 1", …, per an
+  epic/issue). That labeling belongs in `agent-docs/` and issue trackers, never in the
+  published site — a reader has no context for it and it reads as an unfinished draft.
+  When a coverage doc groups components by delivery batch, title the section by what the
+  components actually are (e.g. "Coverage — overlays & menus", "Coverage — in-tree
+  controls"), the way [`astryx-driver-coverage.md`](docs/driver-coverage/astryx-driver-coverage.md)
+  and [`radix-driver-coverage.md`](docs/driver-coverage/radix-driver-coverage.md) already do.

--- a/docs/docs/driver-coverage/astryx-driver-coverage.md
+++ b/docs/docs/driver-coverage/astryx-driver-coverage.md
@@ -88,7 +88,7 @@ All DOM + E2E (Chromium/Firefox/WebKit).
 
 ## Coverage — hard set (best-effort v1)
 
-These shipped against the now-landed Wave 0 primitives (`contextMenu`,
+These shipped against interactor primitives already available (`contextMenu`,
 `setInputFiles`) or via structural workarounds; each names its blocking dependency
 inline.
 
@@ -102,10 +102,10 @@ inline.
 | HoverCard         | `HoverCardDriver`         | content via the trigger's `aria-describedby` → layer `id`. **Open state is E2E-only** (no role/testid/open attr on the layer). Tracked upstream: [facebook/astryx#3240](https://github.com/facebook/astryx/issues/3240). |
 | Tooltip           | `TooltipDriver`           | same anchor/limitation as HoverCard. Tracked upstream: [facebook/astryx#3240](https://github.com/facebook/astryx/issues/3240).                                                                                           |
 
-## Earlier waves
+## Also fully covered
 
 Buttons, inputs, toggles, selection controls, overlays/menus, selectors,
-date/time pickers, lists, tables and trees (Waves 1–3) are fully covered with
+date/time pickers, lists, tables and trees are fully covered with
 DOM + E2E. See the package's `src/index.ts` for the complete export list; overlay
 open/close behavior follows the [Portals & overlays](../guides/portal-and-overlays.md) recipe.
 

--- a/docs/docs/driver-coverage/radix-driver-coverage.md
+++ b/docs/docs/driver-coverage/radix-driver-coverage.md
@@ -74,7 +74,7 @@ worth cataloguing:
 
 NavigationMenu, Toast, and Toolbar render **in-tree**, no portal at all.
 
-## Coverage — Wave 0 (foundation) and Wave 1 (pain-first flagship)
+## Coverage — foundational primitives & flagship overlays
 
 | Component    | Driver               | E2E-only behavior                                                                                                                                                                |
 | ------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -84,7 +84,7 @@ NavigationMenu, Toast, and Toolbar render **in-tree**, no portal at all.
 | DropdownMenu | `DropdownMenuDriver` | a `ContainerDriver`, so scenes can declare custom `content` parts for `CheckboxItem`/`RadioGroup`/submenu content                                                                |
 | Popover      | `PopoverDriver`      | trigger-anchored via `aria-controls` → `byLinkedElement` (its content shares `role="dialog"` with modal `Dialog`, so a static re-root would collide)                             |
 
-## Coverage — Wave 2 (foundation controls)
+## Coverage — in-tree controls
 
 All in-tree — no portals.
 
@@ -103,7 +103,7 @@ All in-tree — no portals.
 | Collapsible | `CollapsibleDriver`                         | —                                                                                                                   |
 | Accordion   | `AccordionDriver`                           | —                                                                                                                   |
 
-## Coverage — Wave 3 (remaining overlays & menus)
+## Coverage — overlays & menus
 
 | Component      | Driver                                              | E2E-only behavior                                                                                                                                                                                 |
 | -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -116,7 +116,7 @@ All in-tree — no portals.
 | Toast          | `ToastDriver`                                       | timer-driven auto-dismissal is untested by the suite (real-time behavior); click paths (`Action`/`Close`) are covered                                                                             |
 | Toolbar        | `ToolbarDriver`                                     | —                                                                                                                                                                                                 |
 
-## Coverage — Wave 4 (interaction-heavy)
+## Coverage — interaction-heavy primitives
 
 | Component            | Driver                       | E2E-only behavior                                                                                                                                                                         |
 | -------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -125,7 +125,7 @@ All in-tree — no portals.
 | PasswordToggleField  | `PasswordToggleFieldDriver`  | — (`PasswordToggleField.Root` renders no DOM node of its own — a pure context provider — so the scene must supply an explicit wrapping element for the driver's root locator)             |
 | OneTimePasswordField | `OneTimePasswordFieldDriver` | — (`setValue` types one character per box rather than using Radix's paste-into-first-box autofill path — no portable `Interactor` primitive for `ClipboardEvent`)                         |
 
-## Coverage — Wave 5 (best-effort v1: Combobox)
+## Coverage — best-effort v1: Combobox
 
 Radix ships no Combobox primitive. `ComboboxDriver` targets the canonical
 shadcn/ui **composition** — a Radix `Popover` hosting a


### PR DESCRIPTION
## Summary

Remove internal "Wave" numbering (Wave 0–5) from driver coverage documentation and replace with descriptive section titles that reflect what the components actually are. This aligns with the project's documentation standards: internal delivery-sequencing jargon belongs in issue trackers and agent docs, not in the published site where readers have no context for it.

**Changes:**
- `radix-driver-coverage.md`: Retitle five sections from "Wave N (description)" to just the description
  - "Wave 0 (foundation) and Wave 1 (pain-first flagship)" → "foundational primitives & flagship overlays"
  - "Wave 2 (foundation controls)" → "in-tree controls"
  - "Wave 3 (remaining overlays & menus)" → "overlays & menus"
  - "Wave 4 (interaction-heavy)" → "interaction-heavy primitives"
  - "Wave 5 (best-effort v1: Combobox)" → "best-effort v1: Combobox"

- `astryx-driver-coverage.md`: Remove "Wave 0" reference and retitle sections
  - "now-landed Wave 0 primitives" → "interactor primitives already available"
  - "Earlier waves" → "Also fully covered"
  - Remove "Waves 1–3" reference

- `docs/CLAUDE.md`: Add new documentation standard documenting this convention for future contributors

## Checks

- [x] No code changes — documentation only
- [x] Follows existing section-naming pattern already used in both coverage docs
- [x] Aligns with project documentation standards per `docs/CLAUDE.md`

https://claude.ai/code/session_01VDMmbxzRCYQ8cKCmGtZ3m7