### PR TITLE
fix(mui): give a late close-transition timer real wall-clock time before giving up

### DIFF
--- a/packages/component-driver-mui-v6/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/DialogDriver.ts
@@ -113,9 +113,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
-   * Wait for dialog to close
+   * Wait for dialog to close. Polls for up to `timeoutMs`, then allows a further
+   * `closeGraceMs` grace period for a real transition timer that's merely running
+   * late before giving up (see the fallback below).
    * @param timeoutMs
-   * @returns true open has performed successfully
+   * @returns true once the dialog has closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const isOpened = await this.interactor.waitUntil({

--- a/packages/component-driver-mui-v6/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/DialogDriver.ts
@@ -25,6 +25,7 @@ export const parts = {
 const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<ContentT, typeof parts> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
@@ -122,7 +123,21 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
       terminateCondition: false,
       timeoutMs,
     });
-    return isOpened === false;
+    if (isOpened === false) {
+      return true;
+    }
+    // Under React's act() the close transition can commit only when the polling
+    // act block exits, so the loop above can still observe the dialog as open
+    // even though the real exit-transition timer is merely running late (e.g. a
+    // contended CI runner) rather than genuinely stuck. A short, act()-wrapped
+    // grace-period recheck gives that timer real wall-clock time to fire before
+    // giving up (mirrors OverlayDriver.waitForClose's fallback).
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
@@ -2,6 +2,7 @@ import { byCssClass, ContainerDriver, locatorUtil, PartLocator, ScenePart } from
 
 const backdropLocator = byCssClass('MuiBackdrop-root');
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 /**
  * Shared base for MUI portal-rendered overlays (Drawer today; Dialog, Menu,
@@ -69,9 +70,18 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
       return true;
     }
     // Under React's act() the close transition can commit only when the polling
-    // act block exits (seen with MUI v5 in jsdom), so the loop above observes the
-    // overlay as still open. A final fresh read reflects the now-committed state.
-    return !(await this.isOpen());
+    // act block exits (seen with MUI v5 in jsdom), so the loop above can still
+    // observe the overlay as open even though the real exit-transition timer is
+    // merely running late (e.g. a contended CI runner) rather than genuinely
+    // stuck. A short, act()-wrapped grace-period recheck gives that timer real
+    // wall-clock time to fire before giving up, instead of a single unwaited
+    // snapshot racing the same timer with zero margin.
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v6/src/components/OverlayDriver.ts
@@ -57,8 +57,10 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
   }
 
   /**
-   * Wait until the overlay is closed.
-   * @returns true once closed within the timeout.
+   * Wait until the overlay is closed. Polls for up to `timeoutMs`, then allows a
+   * further `closeGraceMs` grace period for a real transition timer that's merely
+   * running late before giving up (see the fallback below).
+   * @returns true once closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const result = await this.interactor.waitUntil({

--- a/packages/component-driver-mui-v7/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/DialogDriver.ts
@@ -113,9 +113,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
-   * Wait for dialog to close
+   * Wait for dialog to close. Polls for up to `timeoutMs`, then allows a further
+   * `closeGraceMs` grace period for a real transition timer that's merely running
+   * late before giving up (see the fallback below).
    * @param timeoutMs
-   * @returns true open has performed successfully
+   * @returns true once the dialog has closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const isOpened = await this.interactor.waitUntil({

--- a/packages/component-driver-mui-v7/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/DialogDriver.ts
@@ -25,6 +25,7 @@ export const parts = {
 const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<ContentT, typeof parts> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
@@ -122,7 +123,21 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
       terminateCondition: false,
       timeoutMs,
     });
-    return isOpened === false;
+    if (isOpened === false) {
+      return true;
+    }
+    // Under React's act() the close transition can commit only when the polling
+    // act block exits, so the loop above can still observe the dialog as open
+    // even though the real exit-transition timer is merely running late (e.g. a
+    // contended CI runner) rather than genuinely stuck. A short, act()-wrapped
+    // grace-period recheck gives that timer real wall-clock time to fire before
+    // giving up (mirrors OverlayDriver.waitForClose's fallback).
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
@@ -2,6 +2,7 @@ import { byCssClass, ContainerDriver, locatorUtil, PartLocator, ScenePart } from
 
 const backdropLocator = byCssClass('MuiBackdrop-root');
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 /**
  * Shared base for MUI portal-rendered overlays (Drawer today; Dialog, Menu,
@@ -69,9 +70,18 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
       return true;
     }
     // Under React's act() the close transition can commit only when the polling
-    // act block exits (seen with MUI v5 in jsdom), so the loop above observes the
-    // overlay as still open. A final fresh read reflects the now-committed state.
-    return !(await this.isOpen());
+    // act block exits (seen with MUI v5 in jsdom), so the loop above can still
+    // observe the overlay as open even though the real exit-transition timer is
+    // merely running late (e.g. a contended CI runner) rather than genuinely
+    // stuck. A short, act()-wrapped grace-period recheck gives that timer real
+    // wall-clock time to fire before giving up, instead of a single unwaited
+    // snapshot racing the same timer with zero margin.
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v7/src/components/OverlayDriver.ts
@@ -57,8 +57,10 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
   }
 
   /**
-   * Wait until the overlay is closed.
-   * @returns true once closed within the timeout.
+   * Wait until the overlay is closed. Polls for up to `timeoutMs`, then allows a
+   * further `closeGraceMs` grace period for a real transition timer that's merely
+   * running late before giving up (see the fallback below).
+   * @returns true once closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const result = await this.interactor.waitUntil({

--- a/packages/component-driver-mui-v9/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/DialogDriver.ts
@@ -93,9 +93,11 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
   }
 
   /**
-   * Wait for dialog to close
+   * Wait for dialog to close. Polls for up to `timeoutMs`, then allows a further
+   * `closeGraceMs` grace period for a real transition timer that's merely running
+   * late before giving up (see the fallback below).
    * @param timeoutMs
-   * @returns true open has performed successfully
+   * @returns true once the dialog has closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const isOpened = await this.interactor.waitUntil({

--- a/packages/component-driver-mui-v9/src/components/DialogDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/DialogDriver.ts
@@ -25,6 +25,7 @@ export const parts = {
 const dialogRootLocator: PartLocator = byRole('presentation', 'Root');
 
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<ContentT, typeof parts> {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
@@ -102,7 +103,21 @@ export class DialogDriver<ContentT extends ScenePart> extends ContainerDriver<Co
       terminateCondition: false,
       timeoutMs,
     });
-    return isOpened === false;
+    if (isOpened === false) {
+      return true;
+    }
+    // Under React's act() the close transition can commit only when the polling
+    // act block exits, so the loop above can still observe the dialog as open
+    // even though the real exit-transition timer is merely running late (e.g. a
+    // contended CI runner) rather than genuinely stuck. A short, act()-wrapped
+    // grace-period recheck gives that timer real wall-clock time to fire before
+    // giving up (mirrors OverlayDriver.waitForClose's fallback).
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v9/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/OverlayDriver.ts
@@ -2,6 +2,7 @@ import { byCssClass, ContainerDriver, locatorUtil, PartLocator, ScenePart } from
 
 const backdropLocator = byCssClass('MuiBackdrop-root');
 const defaultTransitionDuration = 250;
+const closeGraceMs = 150;
 
 /**
  * Shared base for MUI portal-rendered overlays (Drawer today; Dialog, Menu,
@@ -74,9 +75,18 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
       return true;
     }
     // Under React's act() the close transition can commit only when the polling
-    // act block exits (seen with MUI v5 in jsdom), so the loop above observes the
-    // overlay as still open. A final fresh read reflects the now-committed state.
-    return !(await this.isOpen());
+    // act block exits (seen with MUI v5 in jsdom), so the loop above can still
+    // observe the overlay as open even though the real exit-transition timer is
+    // merely running late (e.g. a contended CI runner) rather than genuinely
+    // stuck. A short, act()-wrapped grace-period recheck gives that timer real
+    // wall-clock time to fire before giving up, instead of a single unwaited
+    // snapshot racing the same timer with zero margin.
+    const settled = await this.interactor.waitUntil({
+      probeFn: () => this.isOpen(),
+      terminateCondition: false,
+      timeoutMs: closeGraceMs,
+    });
+    return settled === false;
   }
 
   /**

--- a/packages/component-driver-mui-v9/src/components/OverlayDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/OverlayDriver.ts
@@ -62,8 +62,10 @@ export abstract class OverlayDriver<ContentT extends ScenePart, T extends SceneP
   }
 
   /**
-   * Wait until the overlay is closed.
-   * @returns true once closed within the timeout.
+   * Wait until the overlay is closed. Polls for up to `timeoutMs`, then allows a
+   * further `closeGraceMs` grace period for a real transition timer that's merely
+   * running late before giving up (see the fallback below).
+   * @returns true once closed, within `timeoutMs` plus the grace period.
    */
   async waitForClose(timeoutMs: number = defaultTransitionDuration): Promise<boolean> {
     const result = await this.interactor.waitUntil({


### PR DESCRIPTION
## Summary

Fixes #1121 — flaky MUI overlay/dialog close-detection tests, confirmed to affect **v6, v7, and v9** (not just v9 as originally reported), since the underlying driver code is byte-identical across all three.

**Root cause:** the CI failure is `OverlayDriver.closeByBackdrop()` in the DOM/jsdom suite (`component-driver-mui-v9-test`, `BasicDrawer.suite.ts` — "closes when the backdrop is clicked"), not a Playwright/e2e issue. `waitForClose()` polls `isOpen()` for `defaultTransitionDuration` (250ms), act()-wrapped per probe. MUI's Fade/Slide exit transitions commit via a real jsdom `setTimeout` (~195–225ms by default), so under CI CPU contention that timer can still not have fired by 250ms — and the existing post-timeout fallback was a single **bare, unwaited** `isOpen()` re-read, racing the same timer with effectively zero margin instead of actually waiting. The CI log shows React "not wrapped in act()" warnings for `Transition`/`Fade`/`Slide` firing from a jsdom `Timeout.task`, confirming the deferred-timer race. `DialogDriver.ts` (all three majors) has the identical gap in its own `waitForClose` — no fallback at all — though it wasn't the one observed flaking in this run.

**Fix:** replace the bare post-timeout snapshot with a short (150ms), act()-wrapped grace-period `waitUntil` recheck in `OverlayDriver.waitForClose` and `DialogDriver.waitForClose` (v6/v7/v9, 6 files). This gives a real timer that's merely running late under CI load actual wall-clock time to fire, instead of racing it with zero margin. The fallback only activates on the already-timed-out path, so it's additive and can't change behavior for any currently-passing test.

Related: #928 (separate, still-open Playwright-side `DialogDriver.closeByBackdropClick` actionability hang — a different symptom of similar cross-version dialog-close flakiness, not addressed here).

## Checks

- [x] `pnpm run check:type` (component-driver-mui-v6, -v9; v7 has no package-level script)
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (component-driver-mui-v6-test 222/222, -v7-test 226/226, -v9-test 219/220 + 1 pre-existing unrelated skip — including the previously-flaking Drawer backdrop-click test)
- [x] `pnpm test:e2e` (Chromium) — v6, v7, v9 Dialog/Drawer specs verified in isolation: 15/15 (v9), 16/17 (v6, single unrelated failure below). Full-suite concurrent runs surfaced unrelated noise (browser resource contention in the sandbox used to verify this); an isolated, low-contention rerun of just the Dialog/Drawer specs was clean, including the exact originally-flaking test ("closes when the backdrop is clicked") and the AlertDialog backdrop-close test. One reproducible failure — `AlertDialog › Pressing Escape should close the dialog`, cascading from `AlertDialog › Clicking the backdrop should close the dialog` timing out — is the **already-tracked, separate #928 issue** (`DialogDriver.closeByBackdropClick`'s raw geometry-based click sequence hitting a Playwright actionability stall); the failure occurs before/outside the code this PR touches and is not a regression from this change. Firefox/WebKit could not be verified locally — those browser binaries aren't installed in this sandbox (only a mismatched Chromium revision is pre-installed); CI will cover all three browsers.

## Breaking change

- [ ] This PR introduces a breaking change
