### PR TITLE
build(deps): add major-version-pin CI gate, close dependabot gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,3 +107,333 @@ updates:
         versions: ['>=20.0.0']
       - dependency-name: '@types/react-dom'
         versions: ['>=20.0.0']
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Everything below guards a package intentionally pinned to ONE major
+  # version of a third-party dependency (see CLAUDE.md's Package Structure /
+  # per-major driver packages) that previously had NO dependabot coverage at
+  # all — the gap behind PR #1132 (@angular/core bumped 20/21 -> 22) and #1134
+  # (@mui/x-data-grid-generator bumped 6/7/8 -> 9 via the then-uncovered
+  # mui-x-v9-test). These use `update-types: semver-major` instead of a
+  # hardcoded version ceiling so a new major of the SAME dependency never
+  # silently slips through — no version number to remember to update here.
+  #
+  # IMPORTANT: PR #1134 shows these `ignore` rules are necessary but NOT
+  # sufficient on their own — the mui-x-v6/v7/v8-test rules above already
+  # existed and were bypassed anyway, because pnpm workspaces share one
+  # lockfile and an update from an unguarded sibling directory can rewrite
+  # other manifests without re-checking their ignore lists. The authoritative
+  # gate is `pnpm check:deps-pinning`
+  # (scripts/check-dependency-pinning.mjs, DEP-PIN-01), which verifies the
+  # committed manifest directly and runs in CI on every PR. Treat these
+  # entries as reducing how often a bad PR gets opened, not as the guarantee.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/angular-20'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/angular-21'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/angular-22'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/angular-core'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/angular-20-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/angular-21-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/angular-22-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-angular-material-v20'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-angular-material-v21'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-angular-material-v22'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-angular-material-v20-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-angular-material-v21-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-angular-material-v22-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-mui-v7'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@mui/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-mui-v9'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@mui/*'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-mui-v9-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@mui/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-mui-x-v9-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@mui/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@mui/x-*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-primevue-v4'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'primevue'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-primevue-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'primevue'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-radix-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'radix-ui'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'cmdk'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/component-driver-reka-ui-v2'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'reka-ui'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-reka-ui-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'reka-ui'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/component-driver-fluent-v9-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@fluentui/react-components'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/react-18'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/react-19'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  # react-legacy spans two majors by design (peerDep `^16 || ^17`); the pinned
+  # devDependency is already at the top of that range (17), so blocking any
+  # further semver-major bump is exactly right — Dependabot never proposes a
+  # downgrade to 16.
+  - package-ecosystem: 'npm'
+    directory: '/packages/react-legacy'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/vue-3'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  # vue-3-test also depends on `storybook`, but at a deliberately different,
+  # unrelated major for its own Storybook stories (see DEP-PIN-01's `storybook`
+  # exception) — not guarded here on purpose.
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/vue-3-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'vue'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/packages/storybook'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'storybook'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/package-tests/storybook-test'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'storybook'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -400,6 +400,14 @@ jobs:
       - name: Skill harness unit tests
         run: pnpm test:skills
 
+      # Dependency-major-pinning gate (DEP-PIN-*): fails if a package intentionally
+      # scoped to one major version of a third-party dependency (by its own
+      # directory name, e.g. `angular-20`, `component-driver-mui-x-v6`) has that
+      # dependency pinned to a different major — the bug class behind PR #1132 and
+      # #1134. Dependency-free, reads package.json directly, so it runs here too.
+      - name: Dependency-major-pinning check
+        run: pnpm check:deps-pinning
+
       - name: Run unit tests
         run: pnpm test:dom
         working-directory: ./packages/create-atomic-testing

--- a/package-tests/component-driver-mui-x-v8-test/package.json
+++ b/package-tests/component-driver-mui-x-v8-test/package.json
@@ -34,7 +34,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
-    "@mui/x-data-grid-generator": "^7.29.13",
+    "@mui/x-data-grid-generator": "^8.5.2",
     "@mui/x-data-grid-pro": "^8.5.2",
     "@mui/x-date-pickers": "^8.5.2",
     "@mui/x-date-pickers-pro": "^8.5.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:api": "pnpm -r check:api",
     "check:lint": "oxlint --fix",
     "check:style": "oxfmt --ignore-path .gitignore --ignore-path .oxfmtignore",
+    "check:deps-pinning": "node scripts/check-dependency-pinning.mjs",
     "check:driver-structure": "node scripts/skills/check-driver-structure.mjs",
     "check:golden-fixtures": "node scripts/skills/check-golden-fixtures.mjs",
     "check:skill-sync": "node scripts/skills/check-skill-sync.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9781,8 +9781,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.8:
-    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -15052,7 +15052,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.39(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.8
+      vue-component-type-helpers: 3.3.7
 
   '@stylexjs/stylex@0.18.3':
     dependencies:
@@ -18876,7 +18876,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.10
-      '@vitest/browser-playwright': 4.1.9(playwright@1.61.1)(vite@8.1.5(@types/node@24.0.10)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.56.1)(vite@8.1.5(@types/node@24.0.10)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -18896,7 +18896,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.8: {}
+  vue-component-type-helpers@3.3.7: {}
 
   vue-demi@0.14.10(vue@3.5.39(typescript@7.0.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,8 +873,8 @@ importers:
         specifier: ^7.3.11
         version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/x-data-grid-generator':
-        specifier: ^7.29.13
-        version: 7.29.13(6113f7a8ebd40e90688343e0809f221a)
+        specifier: ^8.5.2
+        version: 8.29.2(6113f7a8ebd40e90688343e0809f221a)
       '@mui/x-data-grid-pro':
         specifier: ^8.5.2
         version: 8.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3913,6 +3913,21 @@ packages:
       '@emotion/styled':
         optional: true
 
+  '@mui/x-data-grid-generator@8.29.2':
+    resolution: {integrity: sha512-rAQAoTAA+fqV1St4w/B8dlLKRTTsjL6Hw1Nj9edjybfg/kDUIiUtonc+6ZDzC+2kBd+9SsfVGyZ5uGacWkc7/A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/icons-material': ^5.4.1 || ^6.0.0 || ^7.0.0
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-data-grid-generator@9.7.0':
     resolution: {integrity: sha512-qjw94GfPM41T5KPo2hGoDY3aMGKxZNNUnF4isxKY8kQA9xiR31BfHiHFVukFX5m2qv8XhxKlX9VpzceuOFn2tg==}
     engines: {node: '>=14.0.0'}
@@ -3953,6 +3968,22 @@ packages:
       '@emotion/styled':
         optional: true
 
+  '@mui/x-data-grid-premium@8.29.2':
+    resolution: {integrity: sha512-fOMEyV2Zzcq3ZIUmIccWfiKqGy89upQmTaTJSxoe1mHhHRXjtQvvOD0YrYsZIhNzzrGJIpdKlG7tAMj6PK+FJQ==}
+    engines: {node: '>=14.17.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-data-grid-premium@9.7.0':
     resolution: {integrity: sha512-jw8nQ9Q/Kc2wK2rvJukaZPDmzFLZmPUaQ/aA7ujxraJrA904h2O5B0JMlFDP6mDEMnY+QpvaskrrMb8KTX2q6g==}
     engines: {node: '>=14.17.0'}
@@ -3980,6 +4011,22 @@ packages:
 
   '@mui/x-data-grid-pro@7.29.13':
     resolution: {integrity: sha512-APJOk2rq8YM+VcNrbHAOnAueroN7ry99xOY0dBB4yfYWp9LN8wZ3PbupwFw1EfCIec6LOL2hGT7TTPPnMwuMsA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-data-grid-pro@8.29.2':
+    resolution: {integrity: sha512-F3B/9nI/x6Qmxx9FKg0/b8+xLuz0M8gaaxIOuG5ydlgNh3EnNmIvEVmMfntkYxogGezyb15utgDkm328ttv35g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -4037,6 +4084,22 @@ packages:
 
   '@mui/x-data-grid@7.29.13':
     resolution: {integrity: sha512-XHrZTvpa61eqSgUIevDzXYfYCbI7cbN/aRxSCaw2cZzQZ/USdpECYbnTEhgw5XgUlvkAK0mItKZmgKM4X7zT+Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-data-grid@8.29.2':
+    resolution: {integrity: sha512-AnH3yQJZXUB+Dv2CtSx8J1XBU1y4GTbq3MCC+r0CCTtglB032K4UhbyeMXG6FLFqWDn1nKofcBNYVoNv5ELR4A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -4392,6 +4455,12 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@mui/x-internals@8.29.2':
+    resolution: {integrity: sha512-TLILyHia5NHh3MGErFDh0bXZ4V6iS45hdStofsV5wklF6dpgZjduo65oJB0h81mI5mexNlhHANEVfw0KV6BxBg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mui/x-internals@8.6.0':
     resolution: {integrity: sha512-ed6IOmnUpm18b607JRTJS+xya731CrQtJKX35l/4TlH8Df1SpkSJsmoyBBmZ09DNX8YNEFpYt5EyfXI28iyM2A==}
     engines: {node: '>=14.0.0'}
@@ -4418,6 +4487,12 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@mui/x-license@8.29.2':
+    resolution: {integrity: sha512-rq/WGwPkMyu9PpMU/Psa+o7ebXMN6ljxIa0uh5kgptk36TEY8bMdW6cgGbhlTTS83L9/AzTOTBafhUAucsVxbg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mui/x-license@8.6.0':
     resolution: {integrity: sha512-pHQRoFaB1rj8jcC/MyKlcxRpEF+J7QhYB1f4FG6qhNKcI7rKejWjIpiCWkYWoO8Dmbl+1JoE8RLJYab7TnTGlQ==}
     engines: {node: '>=14.0.0'}
@@ -4429,6 +4504,10 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@mui/x-telemetry@8.29.0':
+    resolution: {integrity: sha512-U2fDXtC6Y5z1HwQGS4z+nKl/Eui/spNVdQITTZDKojNLTs4ql/sMxIoetz49CY2Rs9F/51UrXcnT1qLDLsdaHA==}
+    engines: {node: '>=14.0.0'}
 
   '@mui/x-telemetry@8.5.3':
     resolution: {integrity: sha512-vBLVBXCBWY44HonjRefpYjowEXa25k2AtAXkWk2tHfL3/unnnexrYPosuo/p4giIWer0pMy/bPqGY2qM0xlM+g==}
@@ -4453,6 +4532,13 @@ packages:
         optional: true
       '@emotion/styled':
         optional: true
+
+  '@mui/x-virtualizer@0.4.1':
+    resolution: {integrity: sha512-EM4lCW9MFRHxAgdqBG6nRQXlrhctlHqOjPm95usht15JBXtuWwtuVdA5q8ta+EwXE9zF0BcKyQsGs8R/vWzmFw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@mui/x-virtualizer@0.5.0':
     resolution: {integrity: sha512-L87mSQnUtPGoAX8AZstQEr2I2/8hy41FWOQoL3g6iG/UzvF+VP8zJ9pF07qiEg+sH+iwnAxShLRlCrqEBS1qSw==}
@@ -9695,8 +9781,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.7:
-    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -12764,12 +12850,12 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  '@mui/x-data-grid-generator@7.29.13(6113f7a8ebd40e90688343e0809f221a)':
+  '@mui/x-data-grid-generator@7.29.13(73f999d12181ded6644c753e7d35fbc5)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/icons-material': 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-data-grid-premium': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/icons-material': 6.5.0(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-premium': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chance: 1.1.13
       clsx: 2.1.1
       lru-cache: 11.5.1
@@ -12782,12 +12868,15 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  '@mui/x-data-grid-generator@7.29.13(73f999d12181ded6644c753e7d35fbc5)':
+  '@mui/x-data-grid-generator@8.29.2(6113f7a8ebd40e90688343e0809f221a)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/icons-material': 6.5.0(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
-      '@mui/material': 6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-data-grid-premium': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@6.4.12(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/icons-material': 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-premium': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-pro': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
       chance: 1.1.13
       clsx: 2.1.1
       lru-cache: 11.5.1
@@ -12863,23 +12952,21 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid-premium@7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-data-grid-premium@8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-data-grid': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-data-grid-pro': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-license': 7.29.1(@types/react@19.2.17)(react@19.2.7)
-      '@types/format-util': 1.0.4
+      '@mui/x-data-grid': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-data-grid-pro': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internal-exceljs-fork': 5.0.0
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-license': 8.29.2(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
-      exceljs: 4.4.0
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      reselect: 5.2.0
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
@@ -12946,21 +13033,19 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid-pro@7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-data-grid-pro@8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-data-grid': 7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-license': 7.29.1(@types/react@19.2.17)(react@19.2.7)
-      '@types/format-util': 1.0.4
+      '@mui/x-data-grid': 8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-license': 8.29.2(@types/react@19.2.17)(react@19.2.7)
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      reselect: 5.2.0
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
@@ -13039,18 +13124,18 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid@7.29.13(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@mui/x-data-grid@8.29.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
-      '@mui/x-internals': 7.29.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-virtualizer': 0.4.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      reselect: 5.2.0
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
@@ -13294,6 +13379,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-internals@8.29.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-internals@8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -13333,6 +13428,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-license@8.29.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-telemetry': 8.29.0
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-license@8.6.0(@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -13354,6 +13459,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
+
+  '@mui/x-telemetry@8.29.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@fingerprintjs/fingerprintjs': 3.4.2
+      ci-info: 4.4.0
+      conf: 11.0.2
+      is-docker: 4.0.0
+      node-machine-id: 1.1.12
 
   '@mui/x-telemetry@8.5.3':
     dependencies:
@@ -13389,6 +13503,16 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-virtualizer@0.4.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 7.3.11(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 8.29.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -14928,7 +15052,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.39(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.8
 
   '@stylexjs/stylex@0.18.3':
     dependencies:
@@ -18752,7 +18876,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.10
-      '@vitest/browser-playwright': 4.1.9(playwright@1.56.1)(vite@8.1.5(@types/node@24.0.10)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.1)(vite@8.1.5(@types/node@24.0.10)(esbuild@0.28.1)(jiti@2.4.2)(yaml@2.9.0))(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -18772,7 +18896,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.7: {}
+  vue-component-type-helpers@3.3.8: {}
 
   vue-demi@0.14.10(vue@3.5.39(typescript@7.0.2)):
     dependencies:

--- a/scripts/check-dependency-pinning.mjs
+++ b/scripts/check-dependency-pinning.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Dependency-major-pinning gate (DEP-PIN-*). Fails CI when a package that is
+// intentionally scoped to one major version of a third-party dependency — its
+// own directory name says so, e.g. `angular-20`, `component-driver-mui-x-v6` —
+// has that dependency pinned to a different major in its package.json.
+//
+// This is the backstop for the bug class behind PR #1132 (`@angular/core`
+// bumped 20→22 in the angular-20/angular-21 packages) and PR #1134
+// (`@mui/x-data-grid-generator` bumped 6/7/8→9 in the mui-x-v6/v7/v8 test
+// packages). `.github/dependabot.yml` `ignore` rules are necessary but proved
+// NOT sufficient: mui-x-v6/v7/v8-test already had ignore rules capping
+// `@mui/x-*` below the next major, and PR #1134 bumped past them anyway —
+// consistent with a known pnpm/npm-workspace limitation where an update
+// originating from an unguarded sibling directory (here, `mui-x-v9-test`,
+// which had no dependabot.yml entry at all) rewrites other manifests to keep
+// the one shared lockfile consistent, without re-checking their ignore lists.
+// So this check verifies the committed manifest directly — it doesn't trust
+// Dependabot config to have worked.
+//
+// DEP-PIN-01  a package's own major-version suffix (or documented exception)
+//             doesn't match one of its pinned dependencies' majors
+//
+// Dependency-free Node ESM, modelled on scripts/skills/check-skill-sync.mjs.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = resolve(repoRoot, 'packages');
+const packageTestsDir = resolve(repoRoot, 'package-tests');
+
+// A directory whose (test-suffix-stripped) name matches `pattern` is expected
+// to pin every name in `deps` (or every dependency whose name starts with
+// `depPrefix`) to the major captured by the pattern's group. A future package
+// within an EXISTING family (e.g. a `component-driver-mui-x-v10`) is covered
+// automatically — nothing to update here. A genuinely NEW family needs one
+// line added, same as registering a new DesignSystemPlugin in
+// create-atomic-testing/src/registry/designSystems.ts.
+const FAMILIES = [
+  {
+    pattern: /^angular-(\d+)$/,
+    deps: ['@angular/core', '@angular/common', '@angular/compiler', '@angular/platform-browser'],
+  },
+  {
+    pattern: /^component-driver-angular-material-v(\d+)$/,
+    deps: [
+      '@angular/core',
+      '@angular/cdk',
+      '@angular/material',
+      '@angular/common',
+      '@angular/compiler',
+      '@angular/forms',
+      '@angular/platform-browser',
+    ],
+  },
+  { pattern: /^component-driver-mui-v(\d+)$/, deps: ['@mui/material', '@mui/icons-material'] },
+  { pattern: /^component-driver-mui-x-v(\d+)$/, depPrefix: '@mui/x-' },
+  { pattern: /^component-driver-primevue-v(\d+)$/, deps: ['primevue'] },
+  { pattern: /^component-driver-radix-v(\d+)$/, deps: ['radix-ui', 'cmdk'] },
+  { pattern: /^component-driver-reka-ui-v(\d+)$/, deps: ['reka-ui'] },
+  { pattern: /^component-driver-fluent-v(\d+)$/, deps: ['@fluentui/react-components'] },
+  { pattern: /^react-(\d+)$/, deps: ['react', 'react-dom', '@types/react', '@types/react-dom'] },
+  { pattern: /^vue-(\d+)$/, deps: ['vue', '@vue/compiler-sfc', '@vue/compiler-dom', '@vue/server-renderer'] },
+];
+
+// `package-tests/*-test` directories that dropped their driver's version
+// suffix in their own name — resolved to the packages/ name FAMILIES expects.
+const TEST_DIR_ALIASES = {
+  'component-driver-primevue-test': 'component-driver-primevue-v4',
+  'component-driver-radix-test': 'component-driver-radix-v1',
+  'component-driver-reka-ui-test': 'component-driver-reka-ui-v2',
+};
+
+// Directories with no numeric suffix at all, so there's nothing for a pattern
+// to capture — the expected major(s) are asserted directly. Keep this list
+// short: it's for genuinely name-less singletons, not a substitute for FAMILIES.
+const EXPLICIT = {
+  // Legacy React support spans two majors by design (peerDep `^16 || ^17`), so
+  // either pinned major is acceptable — only a jump to 18+ is a real mistake.
+  'react-legacy': {
+    deps: ['react', 'react-dom', '@types/react', '@types/react-dom'],
+    allowedMajors: [16, 17],
+  },
+  // The shared AngularInteractor's dev/test harness is deliberately pinned to
+  // the OLDEST Angular major this repo still supports (today: 20), so shared
+  // code is proven against the floor, not just the newest major. Update this
+  // if the oldest supported Angular major changes.
+  'angular-core': {
+    deps: ['@angular/core', '@angular/common', '@angular/compiler', '@angular/platform-browser'],
+    allowedMajors: [20],
+  },
+  // CLAUDE.md: "packages/storybook ... (Storybook 10)". Scoped to exactly
+  // these two directories — vue-3-test also depends on `storybook`, but at a
+  // deliberately different, unrelated major for its own Storybook stories, so
+  // it is intentionally NOT covered by this rule.
+  storybook: { deps: ['storybook'], allowedMajors: [10] },
+  'storybook-test': { deps: ['storybook'], allowedMajors: [10] },
+};
+
+function readManifest(dir) {
+  const path = join(dir, 'package.json');
+  if (!existsSync(path)) return null;
+  try {
+    return { path, json: JSON.parse(readFileSync(path, 'utf8')) };
+  } catch {
+    return null;
+  }
+}
+
+// Concrete `dependencies`/`devDependencies` pins only — peerDependencies are
+// intentionally open floors (e.g. `>=18.0.0`) and Dependabot doesn't bump them.
+function concreteDeps(json) {
+  return { ...(json.dependencies ?? {}), ...(json.devDependencies ?? {}) };
+}
+
+// Extract the major from a simple concrete range like `^20.3.0`, `~9.0.0`,
+// `9.0.0`. Returns null for anything else (compound ranges never appear as
+// concrete dependency/devDependency pins in this repo; if that ever changes,
+// this fails safe by skipping the entry rather than crashing).
+function majorOf(range) {
+  const match = /^[\^~]?(\d+)\./.exec(range.trim());
+  return match ? Number(match[1]) : null;
+}
+
+function ruleFor(dirName) {
+  if (EXPLICIT[dirName]) return EXPLICIT[dirName];
+  const base = TEST_DIR_ALIASES[dirName] ?? dirName.replace(/-test$/, '');
+  for (const family of FAMILIES) {
+    const match = family.pattern.exec(base);
+    if (match) return { ...family, allowedMajors: [Number(match[1])] };
+  }
+  return null;
+}
+
+function checkDir(dir, dirName, errors) {
+  const rule = ruleFor(dirName);
+  if (!rule) return;
+  const manifest = readManifest(dir);
+  if (!manifest) return;
+  const deps = concreteDeps(manifest.json);
+  const names = rule.depPrefix ? Object.keys(deps).filter(n => n.startsWith(rule.depPrefix)) : rule.deps.filter(n => n in deps);
+  for (const name of names) {
+    const major = majorOf(deps[name]);
+    if (major == null) continue;
+    if (!rule.allowedMajors.includes(major)) {
+      const relPath = manifest.path.slice(repoRoot.length + 1);
+      errors.push(
+        `DEP-PIN-01: ${relPath} pins ${name} at ${deps[name]} (major ${major}), but ` +
+          `this package is scoped to major ${rule.allowedMajors.join(' or ')} — did a ` +
+          `dependency-update PR bump it past an intentional major-version boundary?`
+      );
+    }
+  }
+}
+
+const errors = [];
+for (const root of [packagesDir, packageTestsDir]) {
+  for (const dirName of readdirSync(root)) {
+    checkDir(join(root, dirName), dirName, errors);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`[deps-pinning] ${errors.length} problem(s):`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+process.stdout.write('[deps-pinning] OK — every major-version-scoped package matches its own pin.\n');

--- a/scripts/check-dependency-pinning.mjs
+++ b/scripts/check-dependency-pinning.mjs
@@ -107,10 +107,14 @@ function readManifest(dir) {
   }
 }
 
-// Concrete `dependencies`/`devDependencies` pins only — peerDependencies are
-// intentionally open floors (e.g. `>=18.0.0`) and Dependabot doesn't bump them.
+// Concrete pins only. Most peerDependencies are intentionally open floors
+// (e.g. `react: >=18.0.0`) that majorOf() already skips, but some packages
+// (e.g. component-driver-fluent-v9's `@fluentui/react-components`,
+// component-driver-radix-v1's `radix-ui`/`cmdk`) pin their scoped third-party
+// dependency with a concrete caret range in peerDependencies alone — so those
+// need checking too, not just dependencies/devDependencies.
 function concreteDeps(json) {
-  return { ...(json.dependencies ?? {}), ...(json.devDependencies ?? {}) };
+  return { ...(json.dependencies ?? {}), ...(json.devDependencies ?? {}), ...(json.peerDependencies ?? {}) };
 }
 
 // Extract the major from a simple concrete range like `^20.3.0`, `~9.0.0`,

--- a/scripts/check-dependency-pinning.mjs
+++ b/scripts/check-dependency-pinning.mjs
@@ -138,7 +138,9 @@ function checkDir(dir, dirName, errors) {
   const manifest = readManifest(dir);
   if (!manifest) return;
   const deps = concreteDeps(manifest.json);
-  const names = rule.depPrefix ? Object.keys(deps).filter(n => n.startsWith(rule.depPrefix)) : rule.deps.filter(n => n in deps);
+  const names = rule.depPrefix
+    ? Object.keys(deps).filter(n => n.startsWith(rule.depPrefix))
+    : rule.deps.filter(n => n in deps);
   for (const name of names) {
     const major = majorOf(deps[name]);
     if (major == null) continue;


### PR DESCRIPTION
## Summary

Prompted by #1132 and #1134 (both closed): Dependabot bumped `@angular/core` and `@mui/x-data-grid-generator` past intentional major-version boundaries in packages that are deliberately pinned to one major (the per-major Angular/MUI-X compatibility-matrix packages this repo maintains).

Root cause: `.github/dependabot.yml` had zero coverage for the whole Angular family and several other per-major packages, and — more importantly — PR #1134 showed that even an *existing, correct* `ignore` rule (on `component-driver-mui-x-v6/v7/v8-test`) doesn't reliably stop this: a pnpm workspace shares one lockfile, and an update originating from an unguarded sibling directory (`mui-x-v9-test` had no dependabot.yml entry at all) can rewrite other manifests without re-checking their own ignore lists.

This PR:

- **Adds a CI gate** (`scripts/check-dependency-pinning.mjs`, `pnpm check:deps-pinning`, wired into `buildui.yml`'s `create-atomic-testing-test` job): fails the build if a package that is intentionally scoped to one major version of a dependency — by its own directory name (`angular-20`, `component-driver-mui-x-v6`, …) or a documented exception (`react-legacy`, `angular-core`, `storybook`) — has that dependency pinned to a different major. This is the authoritative backstop, verified by simulating both #1132's and #1134's bad bumps locally and confirming the gate fails, then reverting.
- **Closes the `.github/dependabot.yml` coverage gaps**: 30 new `ignore` entries (using the self-maintaining `update-types: semver-major` form, so there's no version-ceiling number to remember to bump later) for every previously-unguarded per-major package — the Angular family, mui-v7/v9, mui-x-v9-test, primevue-v4, radix, reka-ui-v2, fluent-v9, react-18/19/legacy, vue-3, and storybook. These reduce how often a bad PR gets opened but, per the above, are deliberately not relied on alone.
- **Fixes a pre-existing, unrelated bug** the new gate immediately surfaced: `component-driver-mui-x-v8-test` had `@mui/x-data-grid-generator` stuck at `^7.29.13` (major 7) while every sibling `@mui/x-*` dependency in the same file was already on `^8.5.2`. Bumped to match, `pnpm-lock.yaml` updated, suite re-run green (5/5).

## Checks

- [ ] `pnpm run check:type` — not applicable to this change (no `.ts` files touched; new script is plain Node ESM outside any package's tsconfig)
- [x] `pnpm run check:lint` — `oxlint` clean on the new script
- [x] `pnpm run check:style` — `oxfmt` applied
- [x] `pnpm test:dom` (relevant packages) — `component-driver-mui-x-v8-test`: 5/5 passing after the dependency fix
- [ ] `pnpm test:e2e` (relevant packages, all three browsers) — not run (no e2e-relevant behavior changed)

## Breaking change

- [ ] This PR introduces a breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLsnyeqmWeqmQA1CEXfeDC)_