### PR TITLE
feat(component-driver-astryx): add LightboxDriver

### DIFF
--- a/agent-docs/modules/component-driver-astryx.md
+++ b/agent-docs/modules/component-driver-astryx.md
@@ -9,7 +9,7 @@ Drivers for [Astryx](https://github.com/facebook/astryx) components (published o
 Barrel: [component-driver-astryx/src/index.ts](../../packages/component-driver-astryx/src/index.ts) — the canonical, authoritative export list. Drivers are grouped by leverage tier:
 
 - **Buttons, inputs, toggles (Wave 1):** `Button`, `IconButton`, `ToggleButton`, `ButtonGroup`, `ToggleButtonGroup`, `Link`, `TextInput`, `TextArea`, `NumberInput`, `TimeInput`, `CheckboxInput`, `RadioList`, `CheckboxList`, `Switch`, `SegmentedControl`, `SelectableCard`, `Slider`, `Field`, `InputGroup`, `FieldStatus`, `Banner`, `Pagination`, `Collapsible` drivers, plus the shared `AstryxFieldInputDriver` base.
-- **Overlays & menus (Wave 2):** `NavMenuDriver`, `ToolbarDriver`, `ToastDriver`, `TabListDriver` (+ `TabDriver`), `DropdownMenuDriver`, `MoreMenuDriver` (extends DropdownMenu), `PopoverDriver`, `DialogDriver`, `AlertDialogDriver`, plus the shared `AstryxMenuDriver` base and `MenuItemDriver`.
+- **Overlays & menus (Wave 2):** `NavMenuDriver`, `ToolbarDriver`, `ToastDriver`, `TabListDriver` (+ `TabDriver`), `DropdownMenuDriver`, `MoreMenuDriver` (extends DropdownMenu), `PopoverDriver`, `DialogDriver`, `AlertDialogDriver`, `LightboxDriver`, plus the shared `AstryxMenuDriver` base and `MenuItemDriver`.
 
 ## Dependency shape
 
@@ -40,6 +40,8 @@ Astryx overlays are **not portalled** — `DropdownMenu`/`MoreMenu`/`Popover` re
 Conditional/derived reads, not hard-coded roles: `Toast.getType` reads `data-type` (its `role` flips `alert`↔`status` by severity); `Dialog.getRole` returns `'alertdialog'` only for `purpose="required"`; `TabList` active tab is `aria-current="page"` (no `role="tab"`), and its label is read from the visible span (Astryx duplicates the label in an `aria-hidden` width "sizer").
 
 **E2E-only / WebKit-gated.** Native-popover open/close visibility is not modelled in jsdom (reads still work — content is mounted), so it is covered by the Playwright run. Playwright's **WebKit** cannot drive these interactions: opening a native-popover overlay busies WebKit's main thread (subsequent automation times out) and Escape on the animating modal `<dialog>` never reaches a stable press target. The 6 open/close _interaction_ tests are therefore skipped on WebKit via [src/webkitGate.ts](../../package-tests/component-driver-astryx-test/src/webkitGate.ts) (`useBrowserName` + `skipInteractionOnWebkit`); all reads run on chromium/firefox/webkit, full interactions on chromium/firefox.
+
+**`LightboxDriver`** ([LightboxDriver.ts](../../packages/component-driver-astryx/src/components/LightboxDriver.ts)) is also a native `<dialog>` (like `Dialog`, no portal), but its own Escape-to-dismiss is E2E-only for a different reason than Dialog's WebKit gate: Lightbox relies on the browser firing a native `cancel` event on Escape (verified empirically that jsdom does not synthesize this from a dispatched `keydown`), so `close()` instead drives the close button, which is jsdom-faithful. Its gallery counter/caption have no `data-testid`/role of their own; the driver anchors them structurally (`:has()`/`:not(:has(*))` on the fixed child layout — see the locator comments in the driver). `zoom()`/`pan()` are E2E-only and use the `Interactor.click({ clickCount: 2 })` option (added alongside this driver — see `ClickOption.clickCount`) since two separate `click()` calls do not reliably register as a real double-click.
 
 ## Non-goals
 

--- a/docs/docs/driver-coverage/astryx-driver-coverage.md
+++ b/docs/docs/driver-coverage/astryx-driver-coverage.md
@@ -59,6 +59,7 @@ All DOM + E2E (Chromium/Firefox/WebKit).
 | Avatar      | `AvatarDriver`      | image load-failure → initials fallback (jsdom never fires `onError`) |
 | AvatarGroup | `AvatarGroupDriver` | —                                                                    |
 | Thumbnail   | `ThumbnailDriver`   | hover tooltip & lightbox preview                                     |
+| Lightbox    | `LightboxDriver`    | double-click zoom & drag-to-pan (real double-click timing / pointer geometry) |
 
 ## Coverage — nav chrome
 

--- a/package-tests/component-driver-astryx-test/__tests__/LightboxDriver.dom.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/LightboxDriver.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { lightboxExample, lightboxExampleTestSuite } from '../src/examples';
+
+testRunner(lightboxExampleTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof lightboxExample.scene) => {
+    return createTestEngine(lightboxExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-astryx-test/__tests__/LightboxDriver.e2e.test.ts
+++ b/package-tests/component-driver-astryx-test/__tests__/LightboxDriver.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { lightboxExampleTestSuite } from '../src/examples';
+
+testRunner(lightboxExampleTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-astryx-test/src/directory.tsx
+++ b/package-tests/component-driver-astryx-test/src/directory.tsx
@@ -51,6 +51,7 @@ import { hoverCardUIExample } from './examples/hover-card/HoverCard.examples';
 import { iconButtonUIExample } from './examples/icon-button/IconButton.examples';
 import { inputGroupUIExample } from './examples/input-group/InputGroup.examples';
 import { itemUIExample } from './examples/item/Item.examples';
+import { lightboxUIExample } from './examples/lightbox/Lightbox.examples';
 import { linkUIExample } from './examples/link/Link.examples';
 import { listUIExample } from './examples/list/List.examples';
 import { markdownUIExample } from './examples/markdown/Markdown.examples';
@@ -139,6 +140,7 @@ export const tocs: ExampleToc[] = [
   toc('Popover', '/popover', popoverUIExample),
   toc('Dialog', '/dialog', dialogUIExample),
   toc('AlertDialog', '/alert-dialog', alertDialogUIExample),
+  toc('Lightbox', '/lightbox', lightboxUIExample),
   toc('List', '/list', listUIExample),
   toc('MetadataList', '/metadata-list', metadataListUIExample),
   toc('Outline', '/outline', outlineUIExample),

--- a/package-tests/component-driver-astryx-test/src/examples/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/index.ts
@@ -30,6 +30,7 @@ export * from './more-menu';
 export * from './popover';
 export * from './dialog';
 export * from './alert-dialog';
+export * from './lightbox';
 export * from './list';
 export * from './metadata-list';
 export * from './outline';

--- a/package-tests/component-driver-astryx-test/src/examples/lightbox/Lightbox.examples.tsx
+++ b/package-tests/component-driver-astryx-test/src/examples/lightbox/Lightbox.examples.tsx
@@ -1,0 +1,44 @@
+import { Lightbox } from '@astryxdesign/core/Lightbox';
+import { IExampleUIUnit } from '@atomic-testing/core';
+import React, { JSX, useState } from 'react';
+
+const galleryMedia = [
+  { src: '/photo-a.jpg', alt: 'Photo A', caption: 'Caption A' },
+  { src: '/photo-b.jpg', alt: 'Photo B', caption: 'Caption B' },
+  { src: '/photo-c.jpg', alt: 'Photo C' },
+];
+
+const singleMedia = { src: '/photo-solo.jpg', alt: 'Solo photo' };
+
+/**
+ * Two independent Lightbox triggers: a 3-item gallery (exercises next/prev,
+ * counter, and per-item captions) and a single-item lightbox (exercises the
+ * outside-gallery-mode absent case for counter/prev/next).
+ */
+export const LightboxExample = () => {
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [singleOpen, setSingleOpen] = useState(false);
+  return (
+    <div>
+      <button type='button' data-testid='open-gallery-lightbox' onClick={() => setGalleryOpen(true)}>
+        Open gallery lightbox
+      </button>
+      <Lightbox
+        isOpen={galleryOpen}
+        onOpenChange={setGalleryOpen}
+        media={galleryMedia}
+        hasZoom
+        data-testid='gallery-lightbox'
+      />
+      <button type='button' data-testid='open-single-lightbox' onClick={() => setSingleOpen(true)}>
+        Open single lightbox
+      </button>
+      <Lightbox isOpen={singleOpen} onOpenChange={setSingleOpen} media={singleMedia} data-testid='single-lightbox' />
+    </div>
+  );
+};
+
+export const lightboxUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Astryx Lightbox',
+  ui: <LightboxExample />,
+};

--- a/package-tests/component-driver-astryx-test/src/examples/lightbox/Lightbox.suite.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/lightbox/Lightbox.suite.ts
@@ -1,0 +1,88 @@
+import { LightboxDriver } from '@atomic-testing/component-driver-astryx';
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import { byDataTestId, IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import { lightboxUIExample } from './Lightbox.examples';
+
+export const lightboxExampleScenePart = {
+  openGalleryButton: { locator: byDataTestId('open-gallery-lightbox'), driver: HTMLElementDriver },
+  galleryLightbox: { locator: byDataTestId('gallery-lightbox'), driver: LightboxDriver },
+  openSingleButton: { locator: byDataTestId('open-single-lightbox'), driver: HTMLElementDriver },
+  singleLightbox: { locator: byDataTestId('single-lightbox'), driver: LightboxDriver },
+} satisfies ScenePart;
+
+export const lightboxExample: IExampleUnit<typeof lightboxExampleScenePart, JSX.Element> = {
+  ...lightboxUIExample,
+  scene: lightboxExampleScenePart,
+};
+
+// zoom()/pan() are E2E-only (real double-click timing / drag geometry jsdom
+// cannot provide — see the driver's JSDoc) and, like CarouselDriver's
+// scrollNext/scrollPrev and SliderDriver's pointer-drag, are intentionally not
+// exercised here.
+export const lightboxExampleTestSuite: TestSuiteInfo<typeof lightboxExample.scene> = {
+  title: 'Astryx Lightbox',
+  url: '/lightbox',
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertEqual, assertFalse, assertTrue }) => {
+    describe(`${lightboxExample.title}`, () => {
+      const engine = useTestEngine(lightboxExample.scene, getTestEngine, { beforeEach, afterEach });
+
+      test(`opens via the trigger and reports isOpen`, async () => {
+        assertFalse(await engine().parts.galleryLightbox.isOpen());
+        await engine().parts.openGalleryButton.click();
+        assertTrue(await engine().parts.galleryLightbox.waitForOpen(2000));
+      });
+
+      test(`starts on the first item: counter, caption, alt, and nav boundaries`, async () => {
+        await engine().parts.openGalleryButton.click();
+        await engine().parts.galleryLightbox.waitForOpen(2000);
+        assertEqual(await engine().parts.galleryLightbox.getCounter(), '1 / 3');
+        assertEqual(await engine().parts.galleryLightbox.getCaption(), 'Caption A');
+        assertEqual(await engine().parts.galleryLightbox.getCurrentAlt(), 'Photo A');
+        assertFalse(await engine().parts.galleryLightbox.canPrev());
+        assertTrue(await engine().parts.galleryLightbox.canNext());
+      });
+
+      test(`next/prev navigate the gallery and update counter/caption/alt`, async () => {
+        await engine().parts.openGalleryButton.click();
+        await engine().parts.galleryLightbox.waitForOpen(2000);
+        await engine().parts.galleryLightbox.next();
+        assertEqual(await engine().parts.galleryLightbox.getCounter(), '2 / 3');
+        assertEqual(await engine().parts.galleryLightbox.getCaption(), 'Caption B');
+        assertEqual(await engine().parts.galleryLightbox.getCurrentAlt(), 'Photo B');
+        await engine().parts.galleryLightbox.prev();
+        assertEqual(await engine().parts.galleryLightbox.getCounter(), '1 / 3');
+      });
+
+      test(`canNext/canPrev flip at the last item, whose caption is absent`, async () => {
+        await engine().parts.openGalleryButton.click();
+        await engine().parts.galleryLightbox.waitForOpen(2000);
+        await engine().parts.galleryLightbox.next();
+        await engine().parts.galleryLightbox.next();
+        assertEqual(await engine().parts.galleryLightbox.getCounter(), '3 / 3');
+        assertFalse(await engine().parts.galleryLightbox.canNext());
+        assertTrue(await engine().parts.galleryLightbox.canPrev());
+        assertEqual(await engine().parts.galleryLightbox.getCaption(), undefined);
+      });
+
+      test(`close dismisses the lightbox via the close button`, async () => {
+        await engine().parts.openGalleryButton.click();
+        await engine().parts.galleryLightbox.waitForOpen(2000);
+        assertTrue(await engine().parts.galleryLightbox.close(2000));
+        assertFalse(await engine().parts.galleryLightbox.isOpen());
+      });
+
+      test(`outside gallery mode: no counter, no caption, no nav, alt still reads`, async () => {
+        await engine().parts.openSingleButton.click();
+        assertTrue(await engine().parts.singleLightbox.waitForOpen(2000));
+        assertEqual(await engine().parts.singleLightbox.getCounter(), undefined);
+        assertEqual(await engine().parts.singleLightbox.getCaption(), undefined);
+        assertEqual(await engine().parts.singleLightbox.getCurrentAlt(), 'Solo photo');
+        assertFalse(await engine().parts.singleLightbox.canPrev());
+        assertFalse(await engine().parts.singleLightbox.canNext());
+      });
+    });
+  },
+};

--- a/package-tests/component-driver-astryx-test/src/examples/lightbox/index.ts
+++ b/package-tests/component-driver-astryx-test/src/examples/lightbox/index.ts
@@ -1,0 +1,9 @@
+import { IExampleUnit, ScenePart } from '@atomic-testing/core';
+import { JSX } from 'react';
+
+import { lightboxExample, lightboxExampleTestSuite } from './Lightbox.suite';
+
+export { lightboxUIExample } from './Lightbox.examples';
+export { lightboxExample, lightboxExampleTestSuite };
+
+export const lightboxExamples = [lightboxExample] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
@@ -39,6 +39,13 @@ export const ClickLocationMouseEventExample = () => {
     [displayEvent]
   );
 
+  const onDoubleClick = useCallback(
+    (evt: React.MouseEvent<HTMLDivElement>) => {
+      displayEvent(evt, 'dblclick');
+    },
+    [displayEvent]
+  );
+
   return (
     <React.Fragment>
       <div
@@ -46,7 +53,8 @@ export const ClickLocationMouseEventExample = () => {
         data-testid='click-target'
         onClick={onClick}
         onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}></div>
+        onMouseUp={onMouseUp}
+        onDoubleClick={onDoubleClick}></div>
       <div className='mouse-event'>
         <span className='label'>Event</span>
         <span className='value' data-testid='event-name'>

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.examples.tsx
@@ -8,6 +8,7 @@ export const ClickLocationMouseEventExample = () => {
   const [mouseX, setMouseX] = useState<number | null>(null);
   const [mouseY, setMouseY] = useState<number | null>(null);
   const [eventName, setEventName] = useState<string | null>(null);
+  const [clickCount, setClickCount] = useState(0);
 
   const displayEvent = useCallback((evt: React.MouseEvent<HTMLDivElement>, evtName: string) => {
     const rect = evt.currentTarget.getBoundingClientRect();
@@ -21,6 +22,7 @@ export const ClickLocationMouseEventExample = () => {
   const onClick = useCallback(
     (evt: React.MouseEvent<HTMLDivElement>) => {
       displayEvent(evt, 'click');
+      setClickCount(count => count + 1);
     },
     [displayEvent]
   );
@@ -59,6 +61,11 @@ export const ClickLocationMouseEventExample = () => {
         <span className='label'>Event</span>
         <span className='value' data-testid='event-name'>
           {eventName}
+        </span>
+
+        <span className='label'>Click count</span>
+        <span className='value' data-testid='click-count'>
+          {clickCount}
         </span>
 
         <span className='label'>X</span>

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.suite.ts
@@ -22,6 +22,10 @@ export const clickLocationMouseEventExampleScenePart = {
     locator: byDataTestId('event-name'),
     driver: HTMLElementDriver,
   },
+  clickCountDisplay: {
+    locator: byDataTestId('click-count'),
+    driver: HTMLElementDriver,
+  },
 } satisfies ScenePart;
 
 export const clickLocationMouseEventExample: IExampleUnit<typeof clickLocationMouseEventExampleScenePart, JSX.Element> =
@@ -33,7 +37,7 @@ export const clickLocationMouseEventExample: IExampleUnit<typeof clickLocationMo
 export const clickLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof clickLocationMouseEventExample.scene> = {
   title: 'Mouse event: Click',
   url: '/mouse-event',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertApproxEqual, assertEqual }) => {
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertApproxEqual, assertEqual, assertTrue }) => {
     describe(`${clickLocationMouseEventExample.title}`, () => {
       const engine = useTestEngine(clickLocationMouseEventExample.scene, getTestEngine, { beforeEach, afterEach });
 
@@ -61,6 +65,27 @@ export const clickLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof click
       test('click({ clickCount: 2 }) dispatches a real double-click', async () => {
         await engine().parts.target.click({ clickCount: 2 });
         assertEqual(await engine().parts.eventDisplay.getText(), 'dblclick');
+      });
+
+      // The positioned path (`position` set) must still fire the two `click`
+      // events before `dblclick` — a component relying on both `onClick` and
+      // `onDoubleClick` would otherwise silently lose the click handling.
+      test('click({ position, clickCount: 2 }) fires click twice before dblclick', async () => {
+        await engine().parts.target.click({ position: { x: 10, y: 10 }, clickCount: 2 });
+        assertEqual(await engine().parts.eventDisplay.getText(), 'dblclick');
+        assertEqual(await engine().parts.clickCountDisplay.getText(), '2');
+      });
+
+      // clickCount values other than 2 are rejected consistently across
+      // every Interactor implementation (see assertValidClickCount).
+      test('click({ clickCount: 3 }) throws', async () => {
+        let threw = false;
+        try {
+          await engine().parts.target.click({ clickCount: 3 });
+        } catch {
+          threw = true;
+        }
+        assertTrue(threw);
       });
     });
   },

--- a/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.suite.ts
+++ b/package-tests/component-driver-html-test/src/examples/mouseEvent/ClickLocation.suite.ts
@@ -18,6 +18,10 @@ export const clickLocationMouseEventExampleScenePart = {
     locator: byDataTestId('position-y'),
     driver: HTMLElementDriver,
   },
+  eventDisplay: {
+    locator: byDataTestId('event-name'),
+    driver: HTMLElementDriver,
+  },
 } satisfies ScenePart;
 
 export const clickLocationMouseEventExample: IExampleUnit<typeof clickLocationMouseEventExampleScenePart, JSX.Element> =
@@ -29,7 +33,7 @@ export const clickLocationMouseEventExample: IExampleUnit<typeof clickLocationMo
 export const clickLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof clickLocationMouseEventExample.scene> = {
   title: 'Mouse event: Click',
   url: '/mouse-event',
-  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertApproxEqual }) => {
+  tests: (getTestEngine, { describe, test, beforeEach, afterEach, assertApproxEqual, assertEqual }) => {
     describe(`${clickLocationMouseEventExample.title}`, () => {
       const engine = useTestEngine(clickLocationMouseEventExample.scene, getTestEngine, { beforeEach, afterEach });
 
@@ -50,6 +54,13 @@ export const clickLocationMouseEventExampleTestSuite: TestSuiteInfo<typeof click
 
         assertApproxEqual(xActual, 20, 1);
         assertApproxEqual(yActual, 15, 1);
+      });
+
+      // clickCount: 2 dispatches a real double-click gesture, distinct from
+      // calling click() twice (which does not reliably register as one).
+      test('click({ clickCount: 2 }) dispatches a real double-click', async () => {
+        await engine().parts.target.click({ clickCount: 2 });
+        assertEqual(await engine().parts.eventDisplay.getText(), 'dblclick');
       });
     });
   },

--- a/packages/component-driver-astryx/src/components/LightboxDriver.ts
+++ b/packages/component-driver-astryx/src/components/LightboxDriver.ts
@@ -1,0 +1,193 @@
+import { HTMLElementDriver } from '@atomic-testing/component-driver-html';
+import {
+  byAriaLabel,
+  byCssSelector,
+  byTagName,
+  ContainerDriver,
+  IContainerDriverOption,
+  Interactor,
+  locatorUtil,
+  Optional,
+  PartLocator,
+  Point,
+  ScenePart,
+} from '@atomic-testing/core';
+
+import { isDialogOpen, OVERLAY_TRANSITION_MS, waitForDialogOpenState } from '../internal/overlayLifecycle';
+import { ButtonDriver } from './ButtonDriver';
+
+// The counter ("1 / 3") is a direct child of the dialog's single wrapper <div>
+// that itself has no element children — every sibling wrapper (close/prev/next)
+// nests an IconButton's <button>, and the media-area wrapper nests further
+// <div>s, so "no element children" uniquely identifies the counter among the
+// wrapper's direct children. It never matches the caption <div> either, which
+// sits one level deeper (inside the media-area wrapper), not a direct child of
+// the top wrapper.
+const counterLocator: PartLocator = locatorUtil.append(
+  byCssSelector('div', 'Child'),
+  byCssSelector('div:not(:has(*))', 'Child')
+);
+
+// The media-area wrapper is the <div> with a <div> grandchild wrapping the
+// <img>/<video> (two levels down); the caption, when rendered, is that
+// wrapper's LAST child that is not also its first (":not(:first-child)" excludes
+// the image wrapper itself when it is the sole child, i.e. no caption).
+const captionLocator: PartLocator = locatorUtil.append(
+  byCssSelector('div:has(> div > img, > div > video)'),
+  byCssSelector('*:last-child:not(:first-child)', 'Child')
+);
+
+// The image wrapper is the direct parent of the <img>/<video> — Astryx wires
+// double-click (zoom) and pointerdown (pan) on this wrapper, not on the media
+// element itself, so it's the target for both.
+const imageWrapperLocator: PartLocator = byCssSelector('div:has(> img, > video)');
+
+export const parts = {
+  closeButton: { locator: byAriaLabel('Close'), driver: ButtonDriver },
+  prevButton: { locator: byAriaLabel('Previous'), driver: ButtonDriver },
+  nextButton: { locator: byAriaLabel('Next'), driver: ButtonDriver },
+  imageWrapper: { locator: imageWrapperLocator, driver: HTMLElementDriver },
+  image: { locator: byTagName('img'), driver: HTMLElementDriver },
+  video: { locator: byTagName('video'), driver: HTMLElementDriver },
+  counter: { locator: counterLocator, driver: HTMLElementDriver },
+  caption: { locator: captionLocator, driver: HTMLElementDriver },
+} satisfies ScenePart;
+
+/**
+ * Driver for the Astryx Lightbox (`@astryxdesign/core/Lightbox`).
+ *
+ * Like Astryx `Dialog`, Lightbox is a controlled, native `<dialog>` opened with
+ * `showModal()` and rendered in place (no portal, hence no
+ * `overriddenParentLocator()`). Close/Previous/Next are icon-only buttons
+ * anchored by their verbatim `aria-label` (`"Close"`/`"Previous"`/`"Next"`);
+ * Previous/Next only render in gallery mode (`media` is an array with more than
+ * one item) and are disabled at the first/last item respectively. The counter
+ * (`"1 / 3"`) and caption have no role/testid of their own — see the locator
+ * comments above for how each is anchored structurally instead of by StyleX class.
+ *
+ * **jsdom-faithful:** {@link isOpen}, {@link close}, {@link next}/{@link prev},
+ * {@link canNext}/{@link canPrev}, {@link getCounter}, {@link getCaption},
+ * {@link getCurrentAlt} — all pure structure/attribute reads or clicks that
+ * update React state synchronously.
+ *
+ * **E2E-only:** {@link zoom} and {@link pan} depend on real double-click timing
+ * and pointer/layout geometry that jsdom cannot provide (see
+ * {@link ComponentDriver.drag}). Escape-to-dismiss is also E2E-only for
+ * Lightbox specifically: unlike Astryx `Dialog` (which closes on its own
+ * `keydown` handler), Lightbox relies on the native `<dialog>` `cancel` event,
+ * which real browsers fire automatically when Escape is pressed on a
+ * `showModal()`-opened dialog but jsdom does not synthesize from a dispatched
+ * `keydown` — verified empirically, not merely assumed.
+ */
+export class LightboxDriver<ContentT extends ScenePart> extends ContainerDriver<ContentT, typeof parts> {
+  constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IContainerDriverOption>) {
+    super(locator, interactor, {
+      ...option,
+      parts,
+      content: (option?.content ?? {}) as ContentT,
+    });
+  }
+
+  /** Whether the lightbox is open — Astryx sets the `<dialog>`'s `open` attribute via `showModal()`. */
+  async isOpen(): Promise<boolean> {
+    return isDialogOpen(this.interactor, this.locator);
+  }
+
+  /** Wait until the lightbox is open. */
+  async waitForOpen(timeoutMs: number = OVERLAY_TRANSITION_MS): Promise<boolean> {
+    return waitForDialogOpenState(this.interactor, this.locator, true, timeoutMs);
+  }
+
+  /** Wait until the lightbox is closed. */
+  async waitForClose(timeoutMs: number = OVERLAY_TRANSITION_MS): Promise<boolean> {
+    return waitForDialogOpenState(this.interactor, this.locator, false, timeoutMs);
+  }
+
+  /** Dismiss the lightbox via its close button, then wait for it to close. */
+  async close(timeoutMs: number = OVERLAY_TRANSITION_MS): Promise<boolean> {
+    await this.parts.closeButton.click();
+    return this.waitForClose(timeoutMs);
+  }
+
+  /** Advance to the next gallery item. A no-op when already on the last item (the button is `disabled`). */
+  async next(): Promise<void> {
+    await this.parts.nextButton.click();
+  }
+
+  /** Go back to the previous gallery item. A no-op when already on the first item (the button is `disabled`). */
+  async prev(): Promise<void> {
+    await this.parts.prevButton.click();
+  }
+
+  /** Whether there is a next item to navigate to (`false` outside gallery mode or at the last item). */
+  async canNext(): Promise<boolean> {
+    if (!(await this.parts.nextButton.exists())) {
+      return false;
+    }
+    return !(await this.parts.nextButton.isDisabled());
+  }
+
+  /** Whether there is a previous item to navigate to (`false` outside gallery mode or at the first item). */
+  async canPrev(): Promise<boolean> {
+    if (!(await this.parts.prevButton.exists())) {
+      return false;
+    }
+    return !(await this.parts.prevButton.isDisabled());
+  }
+
+  /** The `"N / total"` gallery counter, or `undefined` outside gallery mode. */
+  async getCounter(): Promise<Optional<string>> {
+    if (!(await this.parts.counter.exists())) {
+      return undefined;
+    }
+    return (await this.parts.counter.getText()) ?? undefined;
+  }
+
+  /** The current item's caption, or `undefined` when the item has none. */
+  async getCaption(): Promise<Optional<string>> {
+    if (!(await this.parts.caption.exists())) {
+      return undefined;
+    }
+    return (await this.parts.caption.getText()) ?? undefined;
+  }
+
+  /** The current item's alt text (`<img alt>`, or a video's `aria-label`). */
+  async getCurrentAlt(): Promise<Optional<string>> {
+    if (await this.parts.image.exists()) {
+      return this.parts.image.getAttribute('alt');
+    }
+    if (await this.parts.video.exists()) {
+      return this.parts.video.getAttribute('aria-label');
+    }
+    return undefined;
+  }
+
+  /**
+   * Toggle zoom on the current image (double-click, 1x ↔ 2x). Only meaningful
+   * for an image item with zoom enabled (Astryx disables zoom for video).
+   *
+   * Uses `click({ clickCount: 2 })` for a genuine double-click gesture — two
+   * separate `click()` calls do not reliably register as one (verified against
+   * a real browser: Playwright's per-click actionability re-checks introduce
+   * enough delay to break the double-click timing).
+   *
+   * E2E-only: real double-click timing and the resulting CSS transform are not
+   * something jsdom (no layout engine) can reproduce or verify.
+   */
+  async zoom(): Promise<void> {
+    await this.interactor.click(this.parts.imageWrapper.locator, { clickCount: 2 });
+  }
+
+  /**
+   * Pan the zoomed image by the given pixel delta (drag). Only takes effect
+   * once zoomed in via {@link zoom}. See {@link ComponentDriver.drag} — jsdom
+   * has no layout engine, so the positional outcome is E2E-only.
+   */
+  async pan(delta: Point): Promise<void> {
+    await this.interactor.drag(this.parts.imageWrapper.locator, delta);
+  }
+
+  get driverName(): string {
+    return 'AstryxLightboxDriver';
+  }
+}

--- a/packages/component-driver-astryx/src/index.ts
+++ b/packages/component-driver-astryx/src/index.ts
@@ -45,6 +45,7 @@ export { DropdownMenuDriver, MoreMenuDriver } from './components/DropdownMenuDri
 export { PopoverDriver } from './components/PopoverDriver';
 export { DialogDriver } from './components/DialogDriver';
 export { AlertDialogDriver } from './components/AlertDialogDriver';
+export { LightboxDriver } from './components/LightboxDriver';
 
 // Lists, tables & display (Wave 3)
 export { ListDriver } from './components/ListDriver';

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -70,7 +70,9 @@ export namespace childListHelper {
 }
 
 // @public (undocumented)
-export interface ClickOption extends MouseOption {}
+export interface ClickOption extends MouseOption {
+    clickCount?: number;
+}
 
 // @public (undocumented)
 export namespace collectionUtil {

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -7,6 +7,9 @@
 // @public
 export type AssertScenePlaceableDriver<Ctor extends ScenePlaceableDriverCtor> = Ctor;
 
+// @public
+export function assertValidClickCount(clickCount: number | undefined): void;
+
 // @public (undocumented)
 export interface BlurOption {}
 

--- a/packages/core/src/interactor/MouseOption.ts
+++ b/packages/core/src/interactor/MouseOption.ts
@@ -17,8 +17,26 @@ export interface ClickOption extends MouseOption {
    * double-click (actionability re-checks between calls can exceed the
    * platform's double-click timing threshold), so a genuine double-click
    * gesture needs this option rather than calling `click()` twice.
+   *
+   * Every `Interactor.click()` implementation validates this via
+   * {@link assertValidClickCount} and throws for anything other than `2`, so
+   * an unsupported value fails the same way in every environment instead of
+   * silently diverging (e.g. Playwright honoring a `3` while jsdom silently
+   * falls back to a single click).
    */
   clickCount?: number;
+}
+
+/**
+ * Validate a {@link ClickOption.clickCount}. Shared by every `Interactor.click()`
+ * implementation so an unsupported value throws identically everywhere,
+ * rather than each environment interpreting it differently.
+ * @throws {Error} If `clickCount` is set to anything other than `2`.
+ */
+export function assertValidClickCount(clickCount: number | undefined): void {
+  if (clickCount != null && clickCount !== 2) {
+    throw new Error(`click() 'clickCount' must be 2 (a double-click) when provided; received ${clickCount}.`);
+  }
 }
 
 export interface MouseMoveOption extends MouseOption {}

--- a/packages/core/src/interactor/MouseOption.ts
+++ b/packages/core/src/interactor/MouseOption.ts
@@ -9,7 +9,17 @@ export interface MouseOption {
   position?: Point;
 }
 
-export interface ClickOption extends MouseOption {}
+export interface ClickOption extends MouseOption {
+  /**
+   * Number of clicks to dispatch as a single gesture, e.g. `2` for a
+   * double-click. Only `2` is currently implemented; omit for a single click.
+   * Two separate `click()` calls do not reliably register as a real
+   * double-click (actionability re-checks between calls can exceed the
+   * platform's double-click timing threshold), so a genuine double-click
+   * gesture needs this option rather than calling `click()` twice.
+   */
+  clickCount?: number;
+}
 
 export interface MouseMoveOption extends MouseOption {}
 

--- a/packages/core/src/interactor/__tests__/MouseOption.test.ts
+++ b/packages/core/src/interactor/__tests__/MouseOption.test.ts
@@ -1,0 +1,16 @@
+import { assertValidClickCount } from '../MouseOption';
+
+describe('assertValidClickCount', () => {
+  test('accepts undefined (a single click)', () => {
+    expect(() => assertValidClickCount(undefined)).not.toThrow();
+  });
+
+  test('accepts 2 (a double-click)', () => {
+    expect(() => assertValidClickCount(2)).not.toThrow();
+  });
+
+  test('rejects any other value, so every Interactor.click() implementation fails the same way', () => {
+    expect(() => assertValidClickCount(1)).toThrow(/clickCount/);
+    expect(() => assertValidClickCount(3)).toThrow(/clickCount/);
+  });
+});

--- a/packages/dom-core/etc/dom-core.api.md
+++ b/packages/dom-core/etc/dom-core.api.md
@@ -137,6 +137,8 @@ export interface UserEventDispatcher {
     // (undocumented)
     click(element: Element): Promise<void>;
     // (undocumented)
+    dblClick(element: Element): Promise<void>;
+    // (undocumented)
     hover(element: Element): Promise<void>;
     // (undocumented)
     keyboard(text: string): Promise<unknown>;

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -165,13 +165,14 @@ export class DOMInteractor implements Interactor {
         throw new ElementNotFoundError(locator, 'click');
       }
 
+      const isDoubleClick = option?.clickCount === 2;
       const isSimpleEvent = option?.position == null;
       if (isSimpleEvent) {
         // Some MUI component does not work with fireEvent('click', ...)
-        await this.userEvent.click(el);
+        await (isDoubleClick ? this.userEvent.dblClick(el) : this.userEvent.click(el));
       } else {
         const clickLocation = this.calculateMousePosition(el, option?.position);
-        const evt = new FakeMouseEvent('click', {
+        const evt = new FakeMouseEvent(isDoubleClick ? 'dblclick' : 'click', {
           bubbles: true,
           clientX: clickLocation.x,
           clientY: clickLocation.y,

--- a/packages/dom-core/src/DOMInteractor.ts
+++ b/packages/dom-core/src/DOMInteractor.ts
@@ -1,4 +1,5 @@
 import {
+  assertValidClickCount,
   BlurOption,
   BoundingRect,
   ClickOption,
@@ -159,6 +160,7 @@ export class DOMInteractor implements Interactor {
    * @throws {ElementNotFoundError} If the element is not found
    */
   async click(locator: PartLocator, option?: ClickOption): Promise<void> {
+    assertValidClickCount(option?.clickCount);
     return this.runInteraction(async () => {
       const el = await this.getElement(locator);
       if (el == null) {
@@ -172,13 +174,25 @@ export class DOMInteractor implements Interactor {
         await (isDoubleClick ? this.userEvent.dblClick(el) : this.userEvent.click(el));
       } else {
         const clickLocation = this.calculateMousePosition(el, option?.position);
-        const evt = new FakeMouseEvent(isDoubleClick ? 'dblclick' : 'click', {
-          bubbles: true,
-          clientX: clickLocation.x,
-          clientY: clickLocation.y,
-        });
-
-        fireEvent(el, evt);
+        const dispatch = (type: string) =>
+          fireEvent(
+            el,
+            new FakeMouseEvent(type, {
+              bubbles: true,
+              clientX: clickLocation.x,
+              clientY: clickLocation.y,
+            })
+          );
+        // A real double-click gesture is two full clicks followed by the
+        // `dblclick` event — firing `dblclick` alone would skip `onClick`
+        // handlers a component also relies on.
+        if (isDoubleClick) {
+          dispatch('click');
+          dispatch('click');
+          dispatch('dblclick');
+        } else {
+          dispatch('click');
+        }
       }
     });
   }

--- a/packages/dom-core/src/types.ts
+++ b/packages/dom-core/src/types.ts
@@ -15,6 +15,7 @@ export type IDomTestEngineOption = ITestEngineOption;
 export interface UserEventDispatcher {
   clear(element: Element): Promise<void>;
   click(element: Element): Promise<void>;
+  dblClick(element: Element): Promise<void>;
   hover(element: Element): Promise<void>;
   // Returns unknown (not void): the default user-event export's keyboard()
   // resolves to its internal keyboard state, and Promise's type parameter is

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -347,7 +347,9 @@ export class PlaywrightInteractor implements Interactor {
 
   async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
-    await this.runMutation(locator, 'click', () => this.page.locator(cssLocator).click({ position: option?.position }));
+    await this.runMutation(locator, 'click', () =>
+      this.page.locator(cssLocator).click({ position: option?.position, clickCount: option?.clickCount })
+    );
   }
 
   /**

--- a/packages/playwright/src/PlaywrightInteractor.ts
+++ b/packages/playwright/src/PlaywrightInteractor.ts
@@ -1,4 +1,5 @@
 import {
+  assertValidClickCount,
   BlurOption,
   BoundingRect,
   ClickOption,
@@ -346,6 +347,7 @@ export class PlaywrightInteractor implements Interactor {
   }
 
   async click(locator: PartLocator, option?: Partial<ClickOption>): Promise<void> {
+    assertValidClickCount(option?.clickCount);
     const cssLocator = await locatorUtil.toCssSelector(locator, this);
     await this.runMutation(locator, 'click', () =>
       this.page.locator(cssLocator).click({ position: option?.position, clickCount: option?.clickCount })


### PR DESCRIPTION
## Summary

Closes #934.

Adds `LightboxDriver` for the Astryx `Lightbox` (`@astryxdesign/core/Lightbox`), modelled on the Wave 2 `DialogDriver` per the issue's scope:

- **jsdom-faithful:** `isOpen`, `close` (via the close button), `next`/`prev`, `canNext`/`canPrev`, `getCounter`, `getCaption`, `getCurrentAlt`.
- **E2E-only:** `zoom` (double-click) and `pan` (drag) — real double-click timing and pointer/layout geometry aren't something jsdom can provide.

The gallery counter (`"1 / 3"`) and per-item caption have no `data-testid`/role of their own in Astryx's markup, so they're anchored structurally (`:has()` / `:not(:has(*))` over the component's fixed child layout) rather than by StyleX class — verified against the real rendered DOM (jsdom probe), not guessed. New test fixture + three-file suite (`.examples.tsx`/`.suite.ts`/`.dom.test.ts`/`.e2e.test.ts`) added under `package-tests/component-driver-astryx-test`, registered in the example directory.

**A real interactor gap, found and fixed while implementing `zoom()`:** two sequential `click()` calls do not reliably register as a genuine double-click — verified empirically against real Chromium: Playwright's per-click actionability re-checks introduce enough delay to break the browser's double-click timing threshold, while a real `dblclick()` works correctly. Fixed by adding an optional `clickCount` field to `ClickOption`/`Interactor.click()` (implemented in `DOMInteractor` via `userEvent.dblClick`/a synthetic `dblclick` event, and in `PlaywrightInteractor` via its native `clickCount` option). This is additive and backward-compatible — omitted, it behaves exactly as before — and proven with a new double-click case added to `component-driver-html-test`'s shared `ClickLocation` fixture (`ComponentDriver` → `ReactInteractor`/`VueInteractor` need no changes, since both route all mutations through one `runInteraction` seam).

Docs updated: `agent-docs/modules/component-driver-astryx.md` (driver list + a note on Lightbox's Escape-is-E2E-only quirk and the `clickCount` addition) and `docs/docs/driver-coverage/astryx-driver-coverage.md` (coverage matrix row).

## Checks

- [x] `pnpm run check:type` — clean on every touched package (`core`, `dom-core`, `playwright`, `component-driver-astryx`, `component-driver-html`, plus `react-core`/`vue-3`/`storybook` as consumers of the touched `Interactor`/`UserEventDispatcher` types)
- [x] `pnpm run check:lint` — clean (repo-wide `oxlint`)
- [x] `pnpm run check:style` — clean (`oxfmt`)
- [x] `pnpm test:dom` — `component-driver-astryx-test` (92 suites/345 tests), `component-driver-html-test` (19/80), `vue-3-test` (2/2), `component-driver-mui-v7-test` (28/226, broad `click()` consumer regression check) — all green
- [x] `pnpm test:e2e` — **Chromium only** in this sandboxed session (only a Chromium binary is pre-installed here; Firefox/WebKit aren't available in this environment). `LightboxDriver.e2e.test.ts` (6/6) and the `ClickLocation`/`MouseEvent` double-click case pass on Chromium; `zoom()`/`pan()` were additionally verified directly against real Chromium outside the committed suite (matching the existing house convention set by `CarouselDriver`/`SliderDriver` of not asserting E2E-only geometry/timing behavior in the automated suite). **Firefox and WebKit need confirmation in CI.**

## Breaking change

- [ ] This PR introduces a breaking change

---

## LSP tool usage & estimated token savings

Per the request to report on this: I drove navigation with the repo's `tsc --lsp` (TS7 native) tool once in this session, for a concrete case — finding `isDisabled`'s implementation to design `canNext`/`canPrev`. A `workspaceSymbol` query returned a compact, kind-classified list of every `isDisabled` declaration across the monorepo (with exact file:line), letting me jump straight to a 20-line targeted read of `DOMInteractor.ts` at the right offset.

For an honest comparison (not an invented multiplier — see `agent-docs/ADOPTING-LSP-FOR-CODING-AGENTS.md`'s own caution against that), I measured the grep counterfactual after the fact: `grep -rn "isDisabled" packages/` returns **356 matching lines (~45KB) across 178 files** — every call site, comment, and test alongside the real declarations, with no way to tell them apart without reading further. The LSP call filtered directly to symbol *declarations* only, avoiding that scan.

Worth being honest about scope: this was the **one** case in this session where a static symbol lookup was the bottleneck. The rest of the work — discovering Lightbox's actual rendered DOM shape (no stable anchors for the counter/caption), and empirically verifying `zoom()`/`pan()` against a real browser — required rendering and probing, which an LSP can't help with; that's what `grep`/`Read`/throwaway jsdom and Playwright probes were for. So the applicability here was real but narrow, consistent with the adoption guide's framing (payoff scales with genuine symbol-navigation load, not universally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sto3nk4WiQ3capQhMu3mDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sto3nk4WiQ3capQhMu3mDS)_