### PR TITLE
feat(component-driver-mui-v9): add isRequired and isError for v6/v7 capability parity

### DIFF
--- a/package-tests/component-driver-mui-v9-test/__tests__/Switch.e2e.test.ts
+++ b/package-tests/component-driver-mui-v9-test/__tests__/Switch.e2e.test.ts
@@ -4,6 +4,6 @@ import {
   playWrightTestFrameworkMapper,
 } from '@atomic-testing/internal-test-runner-playwright-adapter';
 
-import { basicSelectTestSuite } from '../src/examples';
+import { basicSwitchTestSuite } from '../src/examples';
 
-testRunner(basicSelectTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());
+testRunner(basicSwitchTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-v9-test/src/examples/checkbox/LabelCheckbox.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/checkbox/LabelCheckbox.examples.tsx
@@ -9,6 +9,7 @@ export const LabelCheckbox = () => {
     <FormGroup>
       <FormControlLabel control={<Checkbox defaultChecked data-testid='apple' value='apple' />} label='Apple' />
       <FormControlLabel control={<Checkbox data-testid='banana' value='banana' />} label='Banana' />
+      <FormControlLabel control={<Checkbox data-testid='cherry' required value='cherry' />} label='Cherry' />
     </FormGroup>
   );
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/checkbox/LabelCheckbox.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/checkbox/LabelCheckbox.suite.ts
@@ -13,6 +13,10 @@ export const labelCheckboxExampleScenePart = {
     locator: byDataTestId('banana'),
     driver: CheckboxDriver,
   },
+  cherry: {
+    locator: byDataTestId('cherry'),
+    driver: CheckboxDriver,
+  },
 } satisfies ScenePart;
 
 export const labelCheckboxExample: IExampleUnit<typeof labelCheckboxExampleScenePart, JSX.Element> = {
@@ -50,6 +54,14 @@ export const labelCheckboxTestSuite: TestSuiteInfo<typeof labelCheckboxExample.s
       await engine().parts.banana.setSelected(true);
       const isSelected = await engine().parts.banana.isSelected();
       assertTrue(isSelected);
+    });
+
+    test('Cherry checkbox reports required', async () => {
+      assertTrue(await engine().parts.cherry.isRequired());
+    });
+
+    test('Banana checkbox reports not required', async () => {
+      assertFalse(await engine().parts.banana.isRequired());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/input/BasicInput.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/input/BasicInput.examples.tsx
@@ -11,6 +11,8 @@ export const BasicInput: React.FunctionComponent = () => {
       <FilledInput data-testid='basic' />
       <FilledInput data-testid='readonly' readOnly />
       <FilledInput data-testid='disabled' disabled />
+      <FilledInput data-testid='required' required />
+      <FilledInput data-testid='error' error />
       <OutlinedInput data-testid='multiline' multiline rows={5} />
     </Box>
   );

--- a/package-tests/component-driver-mui-v9-test/src/examples/input/BasicInput.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/input/BasicInput.suite.ts
@@ -21,6 +21,14 @@ export const basicInputExampleScenePart = {
     locator: byDataTestId('disabled'),
     driver: InputDriver,
   },
+  required: {
+    locator: byDataTestId('required'),
+    driver: InputDriver,
+  },
+  error: {
+    locator: byDataTestId('error'),
+    driver: InputDriver,
+  },
 } satisfies ScenePart;
 
 export const basicInputExample: IExampleUnit<typeof basicInputExampleScenePart, JSX.Element> = {
@@ -31,7 +39,7 @@ export const basicInputExample: IExampleUnit<typeof basicInputExampleScenePart, 
 export const basicInputTestSuite: TestSuiteInfo<typeof basicInputExample.scene> = {
   title: 'Basic Input',
   url: '/input',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicInputExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('Basic input should exist', async () => {
@@ -59,6 +67,22 @@ export const basicInputTestSuite: TestSuiteInfo<typeof basicInputExample.scene> 
       await engine().parts.multiline.setValue('Line 1\nLine 2');
       const value = await engine().parts.multiline.getValue();
       assertEqual(value, 'Line 1\nLine 2');
+    });
+
+    test('Required input reports required', async () => {
+      assertTrue(await engine().parts.required.isRequired());
+    });
+
+    test('Basic input reports not required', async () => {
+      assertFalse(await engine().parts.basic.isRequired());
+    });
+
+    test('Error input reports error', async () => {
+      assertTrue(await engine().parts.error.isError());
+    });
+
+    test('Basic input reports no error', async () => {
+      assertFalse(await engine().parts.basic.isError());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/select/BasicSelect.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/select/BasicSelect.examples.tsx
@@ -17,14 +17,34 @@ export const basicSelectExampleData = {
 
 export const BasicSelectExample = () => {
   const [value, setValue] = React.useState('');
+  const [requiredValue, setRequiredValue] = React.useState('');
   const onChange = useCallback((event: SelectChangeEvent<string>) => {
     setValue(event.target.value);
+  }, []);
+  const onRequiredChange = useCallback((event: SelectChangeEvent<string>) => {
+    setRequiredValue(event.target.value);
   }, []);
   return (
     <Box sx={{ minWidth: 120 }}>
       <FormControl fullWidth>
         <InputLabel id='simple-select-label'>Age</InputLabel>
         <Select data-testid='simple-select' label='Age' labelId='simple-select-label' value={value} onChange={onChange}>
+          {basicSelectExampleData.options.map(option => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth>
+        <InputLabel id='required-select-label'>Age</InputLabel>
+        <Select
+          data-testid='required-select'
+          label='Age'
+          labelId='required-select-label'
+          required
+          value={requiredValue}
+          onChange={onRequiredChange}>
           {basicSelectExampleData.options.map(option => (
             <MenuItem key={option.value} value={option.value}>
               {option.label}

--- a/package-tests/component-driver-mui-v9-test/src/examples/select/BasicSelect.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/select/BasicSelect.suite.ts
@@ -10,6 +10,10 @@ export const basicSelectExampleScenePart = {
     locator: byDataTestId('simple-select'),
     driver: SelectDriver,
   },
+  requiredSelect: {
+    locator: byDataTestId('required-select'),
+    driver: SelectDriver,
+  },
 } satisfies ScenePart;
 
 /**
@@ -24,7 +28,7 @@ export const basicSelectExample: IExampleUnit<typeof basicSelectExampleScenePart
 export const basicSelectTestSuite: TestSuiteInfo<typeof basicSelectExampleScenePart> = {
   title: 'Basic Select',
   url: '/select',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicSelectExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('it should have default select element', async () => {
@@ -41,6 +45,14 @@ export const basicSelectTestSuite: TestSuiteInfo<typeof basicSelectExampleSceneP
       await engine().parts.select.selectByLabel('Thirty');
       const value = await engine().parts.select.getValue();
       assertEqual(value, '30');
+    });
+
+    test('a required select reports required', async () => {
+      assertTrue(await engine().parts.requiredSelect.isRequired());
+    });
+
+    test('a plain select reports not required', async () => {
+      assertFalse(await engine().parts.select.isRequired());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/select/NativeSelect.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/select/NativeSelect.examples.tsx
@@ -20,6 +20,18 @@ export const NativeSelectExample = () => (
       <option value={20}>Twenty</option>
       <option value={30}>Thirty</option>
     </NativeSelect>
+    <NativeSelect
+      data-testid='required-native-select'
+      defaultValue={30}
+      required
+      inputProps={{
+        name: 'required-age',
+        id: 'uncontrolled-required-native',
+      }}>
+      <option value={10}>Ten</option>
+      <option value={20}>Twenty</option>
+      <option value={30}>Thirty</option>
+    </NativeSelect>
   </FormControl>
 );
 

--- a/package-tests/component-driver-mui-v9-test/src/examples/select/NativeSelect.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/select/NativeSelect.suite.ts
@@ -10,6 +10,10 @@ export const nativeSelectExampleScenePart = {
     locator: byDataTestId('native-select'),
     driver: SelectDriver,
   },
+  requiredSelect: {
+    locator: byDataTestId('required-native-select'),
+    driver: SelectDriver,
+  },
 } satisfies ScenePart;
 
 /**
@@ -24,7 +28,7 @@ export const nativeSelectExample: IExampleUnit<typeof nativeSelectExampleScenePa
 export const nativeSelectTestSuite: TestSuiteInfo<typeof nativeSelectExampleScenePart> = {
   title: 'Native Select',
   url: '/select',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(nativeSelectExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('it should have default native select element', async () => {
@@ -40,6 +44,14 @@ export const nativeSelectTestSuite: TestSuiteInfo<typeof nativeSelectExampleScen
       await engine().parts.select.setValue('20');
       const value = await engine().parts.select.getValue();
       assertEqual(value, '20');
+    });
+
+    test('a required native select reports required', async () => {
+      assertTrue(await engine().parts.requiredSelect.isRequired());
+    });
+
+    test('a plain native select reports not required', async () => {
+      assertFalse(await engine().parts.select.isRequired());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/switch/BasicSwitch.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/switch/BasicSwitch.examples.tsx
@@ -10,6 +10,7 @@ export const BasicSwitch: React.FunctionComponent = () => {
       <Switch data-testid='default-checked' defaultChecked />
       <Switch data-testid='default-unchecked' />
       <Switch data-testid='disabled' disabled />
+      <Switch data-testid='required' required />
     </Stack>
   );
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/switch/BasicSwitch.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/switch/BasicSwitch.suite.ts
@@ -18,6 +18,10 @@ export const basicSwitchExampleScenePart = {
     locator: byDataTestId('disabled'),
     driver: SwitchDriver,
   },
+  required: {
+    locator: byDataTestId('required'),
+    driver: SwitchDriver,
+  },
 } satisfies ScenePart;
 
 /**
@@ -53,6 +57,14 @@ export const basicSwitchTestSuite: TestSuiteInfo<typeof basicSwitchExampleSceneP
     test('it should be able to toggle unchecked switch', async () => {
       await engine().parts.unchecked.setSelected(true);
       assertTrue(await engine().parts.unchecked.isSelected());
+    });
+
+    test('a required switch reports required', async () => {
+      assertTrue(await engine().parts.required.isRequired());
+    });
+
+    test('a plain switch reports not required', async () => {
+      assertFalse(await engine().parts.unchecked.isRequired());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/textField/BasicTextField.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/textField/BasicTextField.examples.tsx
@@ -8,6 +8,7 @@ export const BasicTextField: React.FunctionComponent = () => {
   return (
     <Box component='form' noValidate autoComplete='off'>
       <TextField data-testid='basic' label='Basic Field' variant='outlined' helperText='Enter text here' />
+      <TextField data-testid='required-error' label='Email' required error placeholder='you@example.com' />
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/textField/BasicTextField.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/textField/BasicTextField.suite.ts
@@ -10,6 +10,10 @@ export const basicTextFieldExampleScenePart = {
     locator: byDataTestId('basic'),
     driver: TextFieldDriver,
   },
+  requiredError: {
+    locator: byDataTestId('required-error'),
+    driver: TextFieldDriver,
+  },
 } satisfies ScenePart;
 
 /**
@@ -24,7 +28,7 @@ export const basicTextFieldExample: IExampleUnit<typeof basicTextFieldExampleSce
 export const basicTextFieldTestSuite: TestSuiteInfo<typeof basicTextFieldExampleScenePart> = {
   title: 'Basic TextField',
   url: '/textfield',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(basicTextFieldExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('it should have a basic text field', async () => {
@@ -45,6 +49,16 @@ export const basicTextFieldTestSuite: TestSuiteInfo<typeof basicTextFieldExample
       await engine().parts.basic.setValue('Hello World');
       const value = await engine().parts.basic.getValue();
       assertEqual(value, 'Hello World');
+    });
+
+    test('a required, error field reports both', async () => {
+      assertTrue(await engine().parts.requiredError.isRequired());
+      assertTrue(await engine().parts.requiredError.isError());
+    });
+
+    test('a plain field reports not required and no error', async () => {
+      assertFalse(await engine().parts.basic.isRequired());
+      assertFalse(await engine().parts.basic.isError());
     });
   },
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/textField/SelectTextField.examples.tsx
+++ b/package-tests/component-driver-mui-v9-test/src/examples/textField/SelectTextField.examples.tsx
@@ -22,6 +22,13 @@ export const SelectTextField = () => {
           </MenuItem>
         ))}
       </TextField>
+      <TextField data-testid='required-error-select' select label='Number' defaultValue='30' required error>
+        {selectTextFieldExampleData.options.map(option => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
     </Box>
   );
 };

--- a/package-tests/component-driver-mui-v9-test/src/examples/textField/SelectTextField.suite.ts
+++ b/package-tests/component-driver-mui-v9-test/src/examples/textField/SelectTextField.suite.ts
@@ -10,6 +10,10 @@ export const selectTextFieldExampleScenePart = {
     locator: byDataTestId('select'),
     driver: TextFieldDriver,
   },
+  requiredErrorSelect: {
+    locator: byDataTestId('required-error-select'),
+    driver: TextFieldDriver,
+  },
 } satisfies ScenePart;
 
 export const selectTextFieldExample: IExampleUnit<typeof selectTextFieldExampleScenePart, JSX.Element> = {
@@ -20,7 +24,7 @@ export const selectTextFieldExample: IExampleUnit<typeof selectTextFieldExampleS
 export const selectTextFieldTestSuite: TestSuiteInfo<typeof selectTextFieldExampleScenePart> = {
   title: 'Select TextField',
   url: '/textfield',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(selectTextFieldExample.scene, getTestEngine, { beforeEach, afterEach });
 
     test('it should have the correct label', async () => {
@@ -37,6 +41,16 @@ export const selectTextFieldTestSuite: TestSuiteInfo<typeof selectTextFieldExamp
       await engine().parts.select.setValue('60');
       const value = await engine().parts.select.getValue();
       assertEqual(value, '60');
+    });
+
+    test('a required, error select-variant field reports both', async () => {
+      assertTrue(await engine().parts.requiredErrorSelect.isRequired());
+      assertTrue(await engine().parts.requiredErrorSelect.isError());
+    });
+
+    test('a plain select-variant field reports not required and no error', async () => {
+      assertFalse(await engine().parts.select.isRequired());
+      assertFalse(await engine().parts.select.isError());
     });
   },
 };

--- a/packages/component-driver-mui-v9/src/components/CheckboxDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/CheckboxDriver.ts
@@ -6,6 +6,7 @@ import {
   IComponentDriverOption,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   locatorUtil,
   Optional,
@@ -26,7 +27,7 @@ export type CheckboxScenePartDriver = ScenePartDriver<CheckboxScenePart>;
 
 export class CheckboxDriver
   extends ComponentDriver<CheckboxScenePart>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -63,6 +64,14 @@ export class CheckboxDriver
 
   isReadonly(): Promise<boolean> {
     return this.parts.checkbox.isReadonly();
+  }
+
+  /**
+   * Whether the checkbox is required. MUI puts the native `required` attribute
+   * directly on the underlying `<input type="checkbox">`.
+   */
+  isRequired(): Promise<boolean> {
+    return this.interactor.isRequired(this.parts.checkbox.locator);
   }
 
   /**

--- a/packages/component-driver-mui-v9/src/components/InputDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/InputDriver.ts
@@ -5,6 +5,8 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
   PartLocator,
   ScenePart,
 } from '@atomic-testing/core';
@@ -25,7 +27,10 @@ type TextFieldInputType = 'singleLine' | 'multiline';
 /**
  * A driver for the Material UI v9 Input, FilledInput, OutlinedInput, and StandardInput components.
  */
-export class InputDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class InputDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -101,6 +106,29 @@ export class InputDriver extends ComponentDriver<typeof parts> implements IInput
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  /**
+   * Locator of the element that carries the native validation attributes
+   * (`required`, `aria-invalid`) — the visible single-line input or textarea.
+   */
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    return inputType === 'singleLine' ? this.parts.singlelineInput.locator : this.parts.multilineInput.locator;
+  }
+
+  /**
+   * Whether the input is required (MUI sets the native `required` attribute).
+   */
+  async isRequired(): Promise<boolean> {
+    return this.interactor.isRequired(await this.getValueInputLocator());
+  }
+
+  /**
+   * Whether the input is in the error state (`error` prop → `aria-invalid="true"`).
+   */
+  async isError(): Promise<boolean> {
+    return this.interactor.isError(await this.getValueInputLocator());
   }
 
   /**

--- a/packages/component-driver-mui-v9/src/components/SelectDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/SelectDriver.ts
@@ -13,6 +13,7 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
   listHelper,
   locatorUtil,
   Nullable,
@@ -53,7 +54,10 @@ export interface MenuItemGetOption {
 }
 const optionLocator = byRole('option');
 
-export class SelectDriver extends ComponentDriver<SelectScenePart> implements IInputDriver<string | null> {
+export class SelectDriver
+  extends ComponentDriver<SelectScenePart>
+  implements IInputDriver<string | null>, IRequirableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -215,6 +219,17 @@ export class SelectDriver extends ComponentDriver<SelectScenePart> implements II
       // Cannot determine readonly state of a select input.
       return false;
     }
+  }
+
+  /**
+   * Whether the select is required. The native select carries `required` directly;
+   * a rich (non-native) select mirrors its value into a hidden `<input>` that also
+   * carries the native `required` attribute, so both cases resolve through the same probe.
+   */
+  async isRequired(): Promise<boolean> {
+    const isNative = await this.isNative();
+    const locator = isNative ? this.parts.nativeSelect.locator : this.parts.input.locator;
+    return this.interactor.isRequired(locator);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v9/src/components/SwitchDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/SwitchDriver.ts
@@ -5,6 +5,7 @@ import {
   IComponentDriverOption,
   IFormFieldDriver,
   Interactor,
+  IRequirableDriver,
   IToggleDriver,
   PartLocator,
   ScenePart,
@@ -19,7 +20,7 @@ export const parts = {
 
 export class SwitchDriver
   extends ComponentDriver<typeof parts>
-  implements IFormFieldDriver<string | null>, IToggleDriver
+  implements IFormFieldDriver<string | null>, IToggleDriver, IRequirableDriver
 {
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
@@ -54,6 +55,15 @@ export class SwitchDriver
   async isReadonly(): Promise<boolean> {
     // MUI v5 does not have a readonly state for the switch
     return Promise.resolve(false);
+  }
+
+  /**
+   * Whether the switch is required. MUI puts the native `required` attribute
+   * directly on the underlying `<input type="checkbox" role="switch">`.
+   */
+  async isRequired(): Promise<boolean> {
+    await this.enforcePartExistence('input');
+    return this.interactor.isRequired(this.parts.input.locator);
   }
 
   get driverName(): string {

--- a/packages/component-driver-mui-v9/src/components/TextFieldDriver.ts
+++ b/packages/component-driver-mui-v9/src/components/TextFieldDriver.ts
@@ -7,6 +7,9 @@ import {
   IComponentDriverOption,
   IInputDriver,
   Interactor,
+  IRequirableDriver,
+  IValidatableDriver,
+  locatorUtil,
   Optional,
   PartLocator,
   ScenePart,
@@ -59,7 +62,10 @@ type TextFieldInputType = 'singleLine' | 'multiline' | 'select';
 /**
  * A driver for the Material UI v9 TextField component with single line or multiline text input.
  */
-export class TextFieldDriver extends ComponentDriver<typeof parts> implements IInputDriver<string | null> {
+export class TextFieldDriver
+  extends ComponentDriver<typeof parts>
+  implements IInputDriver<string | null>, IRequirableDriver, IValidatableDriver
+{
   constructor(locator: PartLocator, interactor: Interactor, option?: Partial<IComponentDriverOption>) {
     super(locator, interactor, {
       ...option,
@@ -147,6 +153,41 @@ export class TextFieldDriver extends ComponentDriver<typeof parts> implements II
       case 'multiline':
         return this.parts.multilineInput.isReadonly();
     }
+  }
+
+  /**
+   * Locator of the element that carries the native validation attributes
+   * (`required`, `aria-invalid`). For text/multiline that is the visible
+   * input/textarea; for a select TextField, MUI mirrors the value into a hidden
+   * `<input>` descendant of the field root that carries both attributes instead.
+   */
+  private async getValueInputLocator(): Promise<PartLocator> {
+    const inputType = await this.getInputType();
+    switch (inputType) {
+      case 'singleLine':
+        return this.parts.singlelineInput.locator;
+      case 'multiline':
+        return this.parts.multilineInput.locator;
+      case 'select':
+        return locatorUtil.append(this.locator, byCssSelector('input'));
+    }
+  }
+
+  /**
+   * Whether the field is required. MUI sets the native `required` attribute on the
+   * underlying input (present with an empty value), so a first-class accessor saves
+   * consumers from reaching into the nested input themselves.
+   */
+  async isRequired(): Promise<boolean> {
+    return this.interactor.isRequired(await this.getValueInputLocator());
+  }
+
+  /**
+   * Whether the field is in the error state. MUI's `error` prop sets
+   * `aria-invalid="true"` on the underlying input.
+   */
+  async isError(): Promise<boolean> {
+    return this.interactor.isError(await this.getValueInputLocator());
   }
 
   get driverName(): string {


### PR DESCRIPTION
## Summary

`component-driver-mui-v9` was forked from an earlier MUI driver package and has drifted **behind** its siblings. Counting files that implement each capability:

| package | `isRequired` | `isError` |
| --- | --- | --- |
| `mui-v6` | 5 | 2 |
| `mui-v7` | 5 | 2 |
| `mui-v9` | **0** | **0** |

The user-visible consequence: a suite written against MUI v7 that migrates to v9 silently loses `isRequired()` / `isError()` on Switch, Checkbox, Select, Input and TextField. Nothing fails — the methods simply aren't there.

This adds them, declared through the existing `IRequirableDriver` / `IValidatableDriver` capability interfaces so they are discoverable by type rather than only by reading the class.

| Driver | Added | DOM signal in MUI v9 |
| --- | --- | --- |
| `SwitchDriver` | `isRequired` | native `required` on the underlying `<input type="checkbox" role="switch">` |
| `CheckboxDriver` | `isRequired` | native `required` on the underlying `<input type="checkbox">` |
| `SelectDriver` | `isRequired` | native select carries `required` directly; a rich select mirrors it onto the hidden `.MuiSelect-nativeInput` |
| `InputDriver` | `isRequired`, `isError` | `required` / `aria-invalid="true"` on the visible input or textarea |
| `TextFieldDriver` | `isRequired`, `isError` | as above for single-line/multiline; the `select` variant carries both on a hidden `<input>` descendant of the field root |

Two notes on how this was implemented:

- **Locators were verified against MUI v9's actual rendered DOM, not ported from v7.** That mattered: v9's `TextFieldDriver` had already diverged in unrelated ways (the label is `.MuiInputLabel-root`, not `<label>`; the select input is `.MuiInputBase-root`, not `> div`), so v7's structure could not be assumed to carry over. A blind port would have typechecked and read the wrong element.
- **The accessors route through the `Interactor.isRequired` / `isError` capability probes** rather than v6/v7's hand-rolled `getAttribute(...) != null` reads. This matches the idiom already used in `component-driver-html`, `component-driver-fluent-v9` and the Angular Material packages, and additionally honours `aria-required`.

Every capability gets **paired positive and negative cases** (16 new cases across six suites), including the `TextField select` hidden-input branch. A test asserting only the truthy direction is what would let this kind of gap reappear.

### Adjacent fix

`__tests__/Switch.e2e.test.ts` imported `basicSelectTestSuite` instead of `basicSwitchTestSuite`, so the Switch e2e job silently re-ran Select's tests and never exercised `SwitchDriver` at all. Corrected here, because without it the new `SwitchDriver.isRequired()` e2e coverage would have been vacuous.

### Deliberately out of scope

`ButtonDriver` has drifted the same way — it has lost v7's `isDisabled` anchor / `aria-disabled` handling and its `isLoading`. Same root cause, different diff; left for a separate PR.

Also observed but **pre-existing and unrelated**: `AlertDialog.suite.ts` → "Clicking the backdrop should close the dialog" fails intermittently with `Target page, context or browser has been closed`. It reproduces on the unmodified baseline (3/3 under `--repeat-each=3`), so it is not caused by this change.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (relevant packages) — 30 suites, 236 tests, 235 passed + 1 pre-existing skip
- [ ] `pnpm test:e2e` (relevant packages, all three browsers) — **Chromium only.** Firefox and WebKit binaries are not present in the dev sandbox used here, so those two were not run and are not claimed. Chromium: 231 passed, 1 skipped. CI should be treated as the authority for the other two.

## Breaking change

- [ ] This PR introduces a breaking change (title uses `!`, e.g. `feat(core)!: ...`)

Purely additive: new methods on existing drivers, no signature or behaviour changes to anything that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFVdXARiWzs5F712oCAASA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFVdXARiWzs5F712oCAASA)_