### PR TITLE
fix(ci): pin pnpm version and unfreeze lockfile in dependabot triage workflow

### DIFF
--- a/.github/workflows/triage-dependabot-prs.yml
+++ b/.github/workflows/triage-dependabot-prs.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -31,8 +33,12 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
+      # --no-frozen-lockfile, matching every other workflow's install step
+      # (.github/actions/deps-setup, builderui-setup): dependabot PRs in this repo
+      # sometimes bump a manifest without a matching pnpm-lock.yaml update (e.g. #1267),
+      # which --frozen-lockfile would hard-fail on every run until a human intervened.
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run triage
         run: pnpm triage:dependabot

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1250,8 +1250,8 @@ importers:
         specifier: ^8.0.5
         version: 8.6.14(@types/react@19.2.17)(storybook@8.6.18(prettier@3.6.2))
       '@storybook/addon-themes':
-        specifier: ^8.0.5
-        version: 8.6.14(storybook@8.6.18(prettier@3.6.2))
+        specifier: ^8.6.18
+        version: 8.6.18(storybook@8.6.18(prettier@3.6.2))
       '@storybook/test':
         specifier: ^8.6.15
         version: 8.6.15(storybook@8.6.18(prettier@3.6.2))
@@ -6183,10 +6183,10 @@ packages:
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-themes@8.6.14':
-    resolution: {integrity: sha512-/HJCgskA3OFGectuoLEBQ3JX1nQhE7lnpSv5gH13CWyyaMEk/mP8JYF1uO25YQqwGuSgL2gaEox+aK7UmglAmQ==}
+  '@storybook/addon-themes@8.6.18':
+    resolution: {integrity: sha512-v+Xcxo/XB2ayw9E/RygGOqUIaPOXp9XEFv6EF7DRt41/RQkQ846yJBARTC2cH8kCb+7FYcvDLD3GN/ms7i8wNg==}
     peerDependencies:
-      storybook: ^8.6.14
+      storybook: ^8.6.18
 
   '@storybook/addon-toolbars@8.6.14':
     resolution: {integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==}
@@ -15406,7 +15406,7 @@ snapshots:
       storybook: 8.6.18(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-themes@8.6.14(storybook@8.6.18(prettier@3.6.2))':
+  '@storybook/addon-themes@8.6.18(storybook@8.6.18(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.18(prettier@3.6.2)
       ts-dedent: 2.2.0

--- a/scripts/triage-dependabot-prs.ts
+++ b/scripts/triage-dependabot-prs.ts
@@ -98,13 +98,13 @@ function isConflictError(error: unknown): boolean {
 
 // Returns 'conflict' rather than throwing on a 422, since a real merge conflict
 // is an expected outcome here, not an operational failure.
-async function updateBranch(pullNumber: number): Promise<'updated' | 'conflict'> {
+async function updateBranch(pullNumber: number): Promise<'updated' | 'conflict' | 'dry-run'> {
   if (DRY_RUN) {
     // Whether this would conflict is only knowable by attempting the merge, so
     // dry-run can't distinguish the two outcomes without mutating - report the
     // decision (behind base -> needs an update) and stop there.
     console.log(`#${pullNumber}: [dry-run] would update branch (behind base)`);
-    return 'updated';
+    return 'dry-run';
   }
   try {
     await octokit.pulls.updateBranch({ owner: OWNER, repo: REPO, pull_number: pullNumber });
@@ -162,7 +162,7 @@ async function triagePullRequest(pull: TriagedPull): Promise<void> {
     const result = await updateBranch(pullNumber);
     if (result === 'conflict') {
       await closePullRequest(pullNumber, 'merge conflict with main.');
-    } else {
+    } else if (result === 'updated') {
       console.log(`#${pullNumber}: branch update triggered, will re-check CI next run`);
     }
     return;

--- a/scripts/triage-dependabot-prs.ts
+++ b/scripts/triage-dependabot-prs.ts
@@ -11,7 +11,15 @@
 // so it tolerates a CI queue that can take a long time to drain (see
 // .github/workflows/triage-dependabot-prs.yml, which re-invokes this on a schedule).
 // No DEP-PIN-01 (or any other) special-casing - every failing check is blocking.
+//
+// Runs the same way locally as in CI - no GitHub Actions context is required:
+//   GITHUB_TOKEN=<pat with repo + workflow scopes> pnpm triage:dependabot
+//   GITHUB_TOKEN=$(gh auth token) pnpm triage:dependabot   # reuse an existing gh login
+// Pass --dry-run to log the close/update/approve-and-merge decisions without making
+// them - useful for previewing what a run would do before letting it touch real PRs.
 import { Octokit } from '@octokit/rest';
+
+const DRY_RUN = process.argv.includes('--dry-run');
 
 const OWNER = 'atomic-testing';
 const REPO = 'atomic-testing';
@@ -70,6 +78,10 @@ async function isBehindBase(base: string, head: string): Promise<boolean> {
 }
 
 async function closePullRequest(pullNumber: number, reason: string): Promise<void> {
+  if (DRY_RUN) {
+    console.log(`#${pullNumber}: [dry-run] would close (${reason})`);
+    return;
+  }
   await octokit.issues.createComment({
     owner: OWNER,
     repo: REPO,
@@ -87,6 +99,13 @@ function isConflictError(error: unknown): boolean {
 // Returns 'conflict' rather than throwing on a 422, since a real merge conflict
 // is an expected outcome here, not an operational failure.
 async function updateBranch(pullNumber: number): Promise<'updated' | 'conflict'> {
+  if (DRY_RUN) {
+    // Whether this would conflict is only knowable by attempting the merge, so
+    // dry-run can't distinguish the two outcomes without mutating - report the
+    // decision (behind base -> needs an update) and stop there.
+    console.log(`#${pullNumber}: [dry-run] would update branch (behind base)`);
+    return 'updated';
+  }
   try {
     await octokit.pulls.updateBranch({ owner: OWNER, repo: REPO, pull_number: pullNumber });
     return 'updated';
@@ -97,6 +116,10 @@ async function updateBranch(pullNumber: number): Promise<'updated' | 'conflict'>
 }
 
 async function approveAndMerge(pullNumber: number): Promise<void> {
+  if (DRY_RUN) {
+    console.log(`#${pullNumber}: [dry-run] would approve and merge`);
+    return;
+  }
   await octokit.pulls.createReview({
     owner: OWNER,
     repo: REPO,


### PR DESCRIPTION
## Summary

PR #1271 added a scheduled "Triage dependabot PRs" workflow. Every run since it merged (4/4, every 15 minutes) has failed. This fixes both failure points so the automation actually runs end-to-end, and makes the script easier/safer to run outside the pipeline.

**Root cause #1 — the observed failure.** The "Setup pnpm" step fails immediately:

```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

`pnpm/action-setup@v4` was added with no `version` input and this repo has no `packageManager` field in `package.json`. Every other workflow in this repo (`buildui.yml`, `.github/actions/deps-setup`, `.github/actions/builderui-setup`) pins `pnpm/action-setup@v6` with `version: 10` — the triage workflow just didn't follow that convention. Fixed by matching it.

**Root cause #2 — the next failure in line.** Fixing #1 uncovers a second bug: the workflow's `pnpm install --frozen-lockfile` step would fail too. `pnpm-lock.yaml` is currently out of sync with `package-tests/vue-3-test/package.json` — dependabot PR #1267 bumped `@storybook/addon-themes` to `^8.6.18` in the manifest but its merged commit never touched the lockfile, so the lockfile still pinned the old `^8.0.5` specifier. I reproduced this locally (`pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE`).

This isn't a one-off: it's the shape of PR the triage script exists to handle, and every *other* workflow in the repo already installs with `--no-frozen-lockfile` for this reason. Using `--frozen-lockfile` only in the triage workflow made it uniquely brittle to a pattern the repo already tolerates everywhere else. Fixed by switching to `--no-frozen-lockfile` (matching repo convention) and syncing the currently-drifted lockfile entry.

**Local runnability.** The script (`scripts/triage-dependabot-prs.ts`) already had no GitHub-Actions-only dependencies — it just reads `GITHUB_TOKEN` from the environment — so it was already runnable locally via `GITHUB_TOKEN=<token> pnpm triage:dependabot`. Since the whole point of running it outside the pipeline is usually to preview what it *would* do, I added a `--dry-run` flag that logs the close/update/approve-and-merge decision for each PR without making it, and documented both in a header comment on the script.

## Root cause

- `.github/workflows/triage-dependabot-prs.yml`: `pnpm/action-setup@v4` step had no `version` input and the repo has no `packageManager` field in `package.json`, so pnpm setup failed on every scheduled run (confirmed via all 4 workflow run logs since merge).
- Same file: `pnpm install --frozen-lockfile` would have failed next, because `pnpm-lock.yaml` is out of sync with `package-tests/vue-3-test/package.json` (dependabot PR #1267's merge commit didn't include a lockfile update) — reproduced locally.

## Changes

- `.github/workflows/triage-dependabot-prs.yml`: pin `pnpm/action-setup@v6` with `version: 10` (matches `buildui.yml` / `deps-setup` / `builderui-setup`); switch install to `--no-frozen-lockfile` (matches every other workflow) with a comment explaining why.
- `pnpm-lock.yaml`: sync the `@storybook/addon-themes` entry to the `^8.6.18` already in `package-tests/vue-3-test/package.json`.
- `scripts/triage-dependabot-prs.ts`: add a `--dry-run` flag (short-circuits `closePullRequest`/`updateBranch`/`approveAndMerge` with a log line instead of mutating); document local usage (`GITHUB_TOKEN=... pnpm triage:dependabot [--dry-run]`) in the header comment.

## Checks

- [x] `pnpm run check:type` — no new errors from this change (ran the full workspace check; pre-existing errors elsewhere are all from unbuilt package `dist` output, the documented stale-`dist` trap, unrelated to these files)
- [x] `pnpm run check:lint` — `oxlint scripts/triage-dependabot-prs.ts` clean
- [x] `pnpm run check:style` — `oxfmt --check` clean
- [ ] `pnpm test:dom` — N/A, no DOM surface touched
- [ ] `pnpm test:e2e` — N/A, no E2E surface touched
- [x] Reproduced both failures locally before fixing, and verified the fix: `pnpm install --no-frozen-lockfile` now succeeds; the script runs identically via `pnpm exec tsx` and via `pnpm triage:dependabot`, fails gracefully without `GITHUB_TOKEN`, and correctly forwards `--dry-run` through the pnpm script wrapper (confirmed with a throwaway invalid token against the read-only `pulls.list` call — no GitHub state was touched)

## Breaking change

- [ ] This PR introduces a breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_015hGVG7P9jRSUe72siprQLX)_