### PR TITLE
fix(ci): offset dependabot triage cron off the top-of-hour minutes

### DIFF
--- a/.github/workflows/triage-dependabot-prs.yml
+++ b/.github/workflows/triage-dependabot-prs.yml
@@ -2,7 +2,12 @@ name: Triage dependabot PRs
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    # Offset off :00/:15/:30/:45 - GitHub's scheduler queues everyone's on-the-hour
+    # crons together and delays/drops runs under that load (documented behavior:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).
+    # Actual runs since this workflow shipped landed 1-4 hours apart despite the
+    # */15 config; an off-beat minute is GitHub's own recommended mitigation.
+    - cron: '7,22,37,52 * * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Follow-up to #1272. The triage workflow now runs successfully (verified in Actions after merge — it correctly triggered branch updates and closed a real merge-conflicted PR), but it isn't firing on the schedule it's configured for.

## Root cause

The workflow is configured for `*/15 * * * *`, but its actual run history since merging is 1–4 hours apart, not 15 minutes:

| Run | Time | Gap |
|---|---|---|
| 1 | 21:51 | — |
| 2 | 22:52 | ~61 min |
| 3 | 23:53 | ~61 min |
| 4 | 02:07 | ~2h14m |
| 5 | 05:59 | ~3h52m |

This isn't a bug in the workflow itself — GitHub's own docs note that scheduled workflows can be delayed or dropped under load, and that load concentrates at on-the-hour minutes (`:00`, `:15`, `:30`, `:45`) because every repo's `*/5`/`*/15`/`*/30` cron fires at the same instant. GitHub's documented mitigation is to offset to a different minute.

## Changes

- `.github/workflows/triage-dependabot-prs.yml`: `cron: '*/15 * * * *'` → `cron: '7,22,37,52 * * * *'`, with a comment explaining why.

## Checks

- [x] `pnpm run check:type` — N/A, YAML-only change
- [x] `pnpm run check:lint` — N/A, YAML-only change
- [x] `pnpm run check:style` — N/A, YAML-only change
- [ ] `pnpm test:dom` — N/A
- [ ] `pnpm test:e2e` — N/A
- [x] Validated YAML syntax parses correctly

## Breaking change

- [ ] This PR introduces a breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_015hGVG7P9jRSUe72siprQLX)_