### PR TITLE
ci(publish): isolate version-bump credential, validate semver tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,8 +48,10 @@ jobs:
           # Tag is expected to look like "v0.56.0".
           VERSION="${GITHUB_REF#refs/tags/v}"
           # Fail closed: bumpVersion writes this string verbatim into every
-          # package manifest, so a malformed ref must never reach it.
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+          # package manifest, so a malformed ref must never reach it. The
+          # prerelease class includes '-' because SemVer prerelease identifiers
+          # are [0-9A-Za-z-] (e.g. 1.2.3-alpha-1), not just alphanumerics.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "ERROR: refusing to publish — '$VERSION' is not a bare semver version." >&2
             echo "Expected a tag of the form v1.2.3 (got ref '$GITHUB_REF')." >&2
             exit 1
@@ -79,8 +81,11 @@ jobs:
   # Split out from `publish` on purpose: this is the only job holding a credential
   # that can write to `main`, and it installs NO dependencies. `bumpVersion.js` and
   # `generateChangelog.js` use only Node built-ins (fs / path / child_process), so
-  # no third-party code — not even a dependency's install script — ever runs while
-  # that credential is present.
+  # no third-party npm package — not even a dependency's install script — is ever
+  # installed or executed while that credential is present. The only external code
+  # here is the two GitHub-published actions below (`actions/checkout`,
+  # `actions/setup-node`); the point of the split is that the dependency tree,
+  # which is what `publish` necessarily exposes itself to, never enters this job.
   commit-version:
     needs: publish
     runs-on: ubuntu-latest
@@ -113,4 +118,17 @@ jobs:
           node scripts/generateChangelog.js "$VERSION"
           git add -A
           git diff --cached --quiet || git commit -m "chore: bump version to $VERSION [skip ci]"
-          git push origin HEAD:main
+          # The packages are already on npm by the time this runs, so dropping this
+          # commit would leave the repo's manifests disagreeing with the published
+          # versions and corrupt the next release's changelog range. If main
+          # advanced while this job ran, rebase onto it and retry rather than
+          # failing the release on a non-fast-forward.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (main advanced); rebasing and retrying ($attempt/3)…"
+            git pull --rebase origin main
+          done
+          echo "ERROR: could not push the version bump to main after 3 attempts." >&2
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           # builds all packages — arbitrary third-party build tooling — and then
           # publishes, so any code able to read this job's filesystem would
           # otherwise reach a credential that can write to the repository. The
-          # push happens in `commit-version`, which runs no third-party code.
+          # push happens in `commit-version`, which installs no dependencies.
           persist-credentials: false
 
       - name: Resolve and validate version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,59 +4,112 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-  id-token: write
+# Deny by default; each job grants only the scopes it actually needs. Notably the
+# `publish` job runs WITHOUT repository write access — the version-bump commit is
+# isolated in `commit-version` below.
+permissions: {}
+
+env:
+  # `pnpm publish` shells out to npm, and OIDC trusted publishing requires
+  # npm >= 11.5.1: the Node 22 runner ships npm 10.x, which doesn't attempt the
+  # OIDC token exchange and fails with ENEEDAUTH.
+  #
+  # Pinned EXACTLY rather than `npm@latest` for two reasons: a release must never
+  # silently adopt an npm the pipeline has never been run against, and `latest` is
+  # currently npm 12.x, whose OIDC path is unvalidated here. Bump this
+  # deliberately, as a reviewed change.
+  #
+  # Keep pnpm on 10.x — pnpm 11 has a known OIDC regression.
+  NPM_VERSION: '11.19.0'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # read the tagged source
+      id-token: write # npm Trusted Publishing (OIDC)
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          persist-credentials: true
-          token: ${{ secrets.CODEMOD_TOKEN }}
+          # No repository-write credential is persisted in this job. `./publish.sh`
+          # builds all packages — arbitrary third-party build tooling — and then
+          # publishes, so any code able to read this job's filesystem would
+          # otherwise reach a credential that can write to the repository. The
+          # push happens in `commit-version`, which runs no third-party code.
+          persist-credentials: false
+
+      - name: Resolve and validate version
+        id: get_version
+        run: |
+          # Tag is expected to look like "v0.56.0".
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          # Fail closed: bumpVersion writes this string verbatim into every
+          # package manifest, so a malformed ref must never reach it.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "ERROR: refusing to publish — '$VERSION' is not a bare semver version." >&2
+            echo "Expected a tag of the form v1.2.3 (got ref '$GITHUB_REF')." >&2
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Determined version: $VERSION"
 
       - name: Setup
         uses: ./.github/actions/builderui-setup
 
-      - name: Extract version from release tag
-        id: get_version
-        run: |
-          # Assuming the tag is like "v0.56.0"
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "Determined version: $VERSION"
-
       - name: Set package versions
-        run: pnpm bumpVersion $VERSION
+        run: pnpm bumpVersion "$VERSION"
 
       - name: Upgrade npm for OIDC trusted publishing
-        # `pnpm publish` shells out to npm, and OIDC trusted publishing requires
-        # npm >= 11.5.1. The Node 22 runner ships npm 10.x, which doesn't attempt
-        # the OIDC token exchange and fails with ENEEDAUTH. Keep pnpm on 10.x —
-        # pnpm 11 has a known OIDC regression.
-        run: npm install -g npm@latest
+        run: npm install -g "npm@${NPM_VERSION}"
 
       - name: Publish packages
         # Auth via npm Trusted Publishing (OIDC) — no NPM_TOKEN needed.
         # Requires `id-token: write` (above) plus a Trusted Publisher configured
         # for every @atomic-testing/* package on npmjs.com (org: atomic-testing,
-        # repo: atomic-testing, workflow file: publish.yml).
+        # repo: atomic-testing, workflow file: publish.yml). npm attaches the
+        # provenance attestation automatically on this path, so no extra flag is
+        # needed — and `pnpm publish` exposes none.
         run: ./publish.sh
 
+  # Split out from `publish` on purpose: this is the only job holding a credential
+  # that can write to `main`, and it installs NO dependencies. `bumpVersion.js` and
+  # `generateChangelog.js` use only Node built-ins (fs / path / child_process), so
+  # no third-party code — not even a dependency's install script — ever runs while
+  # that credential is present.
+  commit-version:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
+        with:
+          # Latest main, so the bump fast-forwards even if main advanced (e.g. a
+          # merge) while the release was building. Full history + tags are
+          # required: generateChangelog.js resolves the previous release from
+          # `refs/tags` and walks `<prev>..HEAD`.
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.CODEMOD_TOKEN }}
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Commit version updates
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Re-apply the bump onto the latest main so the push fast-forwards even
-          # if main advanced (e.g. a merge) while this release was building.
-          git fetch origin main
-          git reset --hard
-          git checkout -B main origin/main
-          pnpm bumpVersion "$VERSION"
+          node scripts/bumpVersion.js "$VERSION"
           node scripts/generateChangelog.js "$VERSION"
           git add -A
           git diff --cached --quiet || git commit -m "chore: bump version to $VERSION [skip ci]"


### PR DESCRIPTION
## Summary

Refactors the release publishing workflow to reduce credential exposure and to validate the release tag before it reaches package manifests:

1. **Credential isolation**: Splits the monolithic `publish` job into two jobs with minimal permissions:
   - `publish`: reads the tagged source and publishes via OIDC, with **no repository write access** (`persist-credentials: false`, no PAT). This is the job that runs `./publish.sh`, i.e. every package's build tooling.
   - `commit-version`: holds the repository write credential and pushes the version bump, and **installs no dependencies** — `bumpVersion.js` and `generateChangelog.js` use only Node built-ins, so no third-party npm package is installed or executed while that credential is present. (The two GitHub-published actions it uses, `actions/checkout` and `actions/setup-node`, do run in that job; the point of the split is that the *dependency tree* — the exposure `publish` necessarily accepts — never reaches the credential.)
   - Workflow-level `contents: write` is replaced with deny-by-default `permissions: {}` plus per-job least privilege.

2. **Semver validation**: Adds fail-closed validation of the release tag before `bumpVersion` writes the string verbatim into all 31 manifests. Previously a ref like `refs/tags/1.0.0` (missing the `v`) would have written `refs/tags/1.0.0` into every one. Prerelease identifiers containing hyphens (`v1.2.3-alpha-1`) are accepted, per SemVer.

3. **npm version pinning**: Pins npm exactly (`NPM_VERSION`) instead of `npm@latest`, which currently resolves to npm 12.x — a major this pipeline has never run against. Keeps pnpm on 10.x to avoid a known OIDC regression in pnpm 11.

4. **Push robustness**: The version-bump push now rebases and retries (bounded, 3 attempts) if `main` advanced during the job. By that point the packages are already on npm, so silently dropping the commit would leave the manifests disagreeing with the registry and corrupt the next release's changelog range.

5. **Documentation**: Comments explaining the security model, the pinning rationale, and why the jobs are split.

### Deliberately not changed

- `--no-git-checks` in `publish.sh` stays: the tree is intentionally dirty from the in-CI bump, so removing it needs the bump-before-tag restructure tracked in #1297 (B8), not a flag change.
- No `--provenance` flag: npm attaches the provenance attestation automatically under Trusted Publishing, and `pnpm publish` exposes no such flag.

## Checks

- [x] No runtime code changes — workflow-only
- [x] YAML validated; per-job permission scopes verified (`publish` has no `contents: write`; `commit-version` has no `id-token`)
- [x] Semver guard tested both directions: accepts `1.2.3`, `1.2.3-rc.1`, `1.2.3-alpha-1`, `1.2.3-x-y-z.4`; rejects `1.0.0` (no `v`), `v1.0`, `vfoo`, `v1.0.0-`, `refs/heads/main`, and a command-injection-shaped ref
- [x] npm version pinned deliberately, with rationale documented
- [x] Review feedback addressed (3 comments, all valid) in 4bea6e8 and f707e9d

https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A