### PR TITLE
feat(component-driver-mui-x-v9): add column reorder and row detail panel APIs

### DIFF
--- a/package-tests/component-driver-mui-x-v9-test/__tests__/MasterDetailDataGridPremium.dom.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/MasterDetailDataGridPremium.dom.test.ts
@@ -1,0 +1,11 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import { jestTestAdapter } from '@atomic-testing/internal-test-runner-jest-adapter';
+import { createTestEngine } from '@atomic-testing/react-19';
+
+import { masterDetailDataGridPremiumExample, masterDetailDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(masterDetailDataGridPremiumTestSuite, jestTestAdapter, {
+  getTestEngine: (scenePart: typeof masterDetailDataGridPremiumExample.scene) => {
+    return createTestEngine(masterDetailDataGridPremiumExample.ui, scenePart);
+  },
+});

--- a/package-tests/component-driver-mui-x-v9-test/__tests__/MasterDetailDataGridPremium.e2e.test.ts
+++ b/package-tests/component-driver-mui-x-v9-test/__tests__/MasterDetailDataGridPremium.e2e.test.ts
@@ -1,0 +1,9 @@
+import { testRunner } from '@atomic-testing/internal-test-runner';
+import {
+  getTestRunnerInterface,
+  playWrightTestFrameworkMapper,
+} from '@atomic-testing/internal-test-runner-playwright-adapter';
+
+import { masterDetailDataGridPremiumTestSuite } from '../src/examples';
+
+testRunner(masterDetailDataGridPremiumTestSuite, playWrightTestFrameworkMapper, getTestRunnerInterface());

--- a/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/directory.tsx
@@ -4,6 +4,7 @@ import { basicChartsUIExample } from './examples/charts/Charts.examples';
 import { basicDataGridPremiumUIExample } from './examples/datagridpremium/BasicDataGridPremium.examples';
 import { groupedDataGridPremiumUIExample } from './examples/datagridpremium/GroupedDataGridPremium.examples';
 import { interactiveDataGridPremiumUIExample } from './examples/datagridpremium/InteractiveDataGridPremium.examples';
+import { masterDetailDataGridPremiumUIExample } from './examples/datagridpremium/MasterDetailDataGridPremium.examples';
 import { basicDateRangePickerUIExample } from './examples/datepicker/DateRangePicker.examples';
 import { basicDateTimePickerUIExample } from './examples/datepicker/DateTimePicker.examples';
 import { basicDesktopDatePickerUIExample } from './examples/datepicker/DesktopDatePicker.examples';
@@ -31,6 +32,11 @@ export const tocs: ExampleToc[] = [
     label: 'Grouped DataGrid Premium',
     path: '/datagridgrouped',
     ui: <ExampleList examples={[groupedDataGridPremiumUIExample]} />,
+  },
+  {
+    label: 'Master-Detail DataGrid Premium',
+    path: '/datagridmasterdetail',
+    ui: <ExampleList examples={[masterDetailDataGridPremiumUIExample]} />,
   },
   {
     label: 'Desktop Date Picker',

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
@@ -34,7 +34,7 @@ const deskFilterMatchCount = interactiveGridRows.filter(row => String(row.desk).
 export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interactiveDataGridPremiumExampleScenePart> = {
   title: 'Interactive DataGridPremium',
   url: '/datagridinteractive',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse, hasLayout }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
     const engine = useTestEngine(interactiveDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
 
     //#region Sorting
@@ -183,23 +183,22 @@ export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interacti
       }
     });
 
-    // Reordering is native HTML5 drag-and-drop, whose direction MUI computes from consecutive
-    // dragover events' clientX/clientY — jsdom's synthesized events carry no real coordinates,
-    // so the resulting order there is not a reliable signal (see reorderColumn's doc comment).
-    // Reaching this point without throwing is the jsdom-side assertion; the actual reorder is
-    // verified only where a layout engine produces real coordinates.
+    // "commodity" sits after "desk", so this is the "target before source" direction that
+    // genuinely reorders under jsdom too (React state, not geometry — see reorderColumn's doc
+    // comment) — the resulting header order is a real, deterministic assertion here, not just a
+    // does-it-throw check. The full real-browser reorder (drag distance, drop acceptance) is
+    // still only meaningfully exercised where a layout engine produces real coordinates.
     test('reorderColumn moves the dragged column next to the drop target', async () => {
       await engine().parts.grid.waitForLoad();
       await engine().parts.grid.reorderColumn('commodity', 'desk');
-      if (hasLayout) {
-        assertEqual(await engine().parts.grid.getHeaderText(), [
-          '',
-          'Commodity',
-          'Desk',
-          'Trader Name',
-          'Trader Email',
-        ]);
-      }
+      assertEqual(await engine().parts.grid.getHeaderText(), ['', 'Commodity', 'Desk', 'Trader Name', 'Trader Email']);
+    });
+
+    test('reorderColumn only affects its own grid instance', async () => {
+      await engine().parts.grid.waitForLoad();
+      const emptyGridHeadersBefore = await engine().parts.emptyGrid.getHeaderText();
+      await engine().parts.grid.reorderColumn('commodity', 'desk');
+      assertEqual(await engine().parts.emptyGrid.getHeaderText(), emptyGridHeadersBefore);
     });
     //#endregion
 

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/InteractiveDataGridPremium.suite.ts
@@ -34,7 +34,7 @@ const deskFilterMatchCount = interactiveGridRows.filter(row => String(row.desk).
 export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interactiveDataGridPremiumExampleScenePart> = {
   title: 'Interactive DataGridPremium',
   url: '/datagridinteractive',
-  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse, hasLayout }) => {
     const engine = useTestEngine(interactiveDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
 
     //#region Sorting
@@ -180,6 +180,25 @@ export const interactiveDataGridPremiumTestSuite: TestSuiteInfo<typeof interacti
       const after = await engine().parts.grid.getColumnWidth('desk');
       if (before > 0) {
         assertTrue(after > before);
+      }
+    });
+
+    // Reordering is native HTML5 drag-and-drop, whose direction MUI computes from consecutive
+    // dragover events' clientX/clientY — jsdom's synthesized events carry no real coordinates,
+    // so the resulting order there is not a reliable signal (see reorderColumn's doc comment).
+    // Reaching this point without throwing is the jsdom-side assertion; the actual reorder is
+    // verified only where a layout engine produces real coordinates.
+    test('reorderColumn moves the dragged column next to the drop target', async () => {
+      await engine().parts.grid.waitForLoad();
+      await engine().parts.grid.reorderColumn('commodity', 'desk');
+      if (hasLayout) {
+        assertEqual(await engine().parts.grid.getHeaderText(), [
+          '',
+          'Commodity',
+          'Desk',
+          'Trader Name',
+          'Trader Email',
+        ]);
       }
     });
     //#endregion

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.examples.tsx
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.examples.tsx
@@ -1,0 +1,52 @@
+import { IExampleUIUnit } from '@atomic-testing/core';
+import { basicGridColumnConfig, gridData } from '@atomic-testing/internal-mui-x-test-fixture';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { DataGridPremium, GridColDef, GridRowParams } from '@mui/x-data-grid-premium';
+import React, { JSX, useCallback } from 'react';
+
+const masterDetailColumns = basicGridColumnConfig.slice(0, 5) as GridColDef[];
+
+export const masterDetailGridRows = gridData.slice(0, 15);
+type MasterDetailGridRow = (typeof masterDetailGridRows)[number];
+
+// Row index 2 deliberately has no detail content, so its toggle renders disabled — the fixture
+// for testing that expandRowDetail throws rather than expanding an empty panel.
+export const noDetailRowIndex = 2;
+const noDetailRowId = masterDetailGridRows[noDetailRowIndex].id;
+
+const getDetailPanelContent = ({ row }: GridRowParams<MasterDetailGridRow>) => {
+  if (row.id === noDetailRowId) {
+    return null;
+  }
+  return (
+    <Box data-testid={`detail-panel-content-${row.id}`} sx={{ p: 2 }}>
+      <Typography>Trader email: {row.traderEmail}</Typography>
+    </Box>
+  );
+};
+
+export const MasterDetailDataGridPremium: React.FunctionComponent = () => {
+  const getDetailPanelHeight = useCallback(() => 100, []);
+  return (
+    <Box sx={{ height: 480, minWidth: 900, width: '100%' }} data-testid='master-detail-grid-premium'>
+      <DataGridPremium
+        columns={masterDetailColumns}
+        rows={masterDetailGridRows}
+        getDetailPanelContent={getDetailPanelContent}
+        getDetailPanelHeight={getDetailPanelHeight}
+        initialState={{ columns: { columnVisibilityModel: { id: false } } }}
+      />
+    </Box>
+  );
+};
+
+/**
+ * DataGridPremium demonstrating the Pro master-detail feature: every row can expand to reveal a
+ * detail panel below it via `getDetailPanelContent`.
+ * @see https://mui.com/x/react-data-grid/master-detail/
+ */
+export const masterDetailDataGridPremiumUIExample: IExampleUIUnit<JSX.Element> = {
+  title: 'Master-Detail DataGridPremium',
+  ui: <MasterDetailDataGridPremium />,
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.suite.ts
@@ -65,14 +65,53 @@ export const masterDetailDataGridPremiumTestSuite: TestSuiteInfo<typeof masterDe
 
     test('expandRowDetail throws for a row with no detail-panel content', async () => {
       await engine().parts.grid.waitForLoad();
-      let threw = false;
+      let message = '';
       try {
-        await engine().parts.grid.expandRowDetail(noDetailRowIndex, 500);
-      } catch {
-        threw = true;
+        await engine().parts.grid.expandRowDetail(noDetailRowIndex);
+      } catch (error) {
+        message = (error as Error).message;
       }
-      assertTrue(threw);
+      // Pins the specific disabled-toggle throw, not just "it threw" — a regression that made the
+      // driver fall through to the slower "never became expanded" timeout path instead would
+      // still throw, but with a different message, and should fail this test.
+      assertTrue(message.includes('has no detail-panel content to expand'));
       assertFalse(await engine().parts.grid.isRowDetailExpanded(noDetailRowIndex));
+    });
+
+    test('collapseRowDetail is a no-op on a row that is already collapsed', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertFalse(await engine().parts.grid.isRowDetailExpanded(detailedRowIndex));
+      await engine().parts.grid.collapseRowDetail(detailedRowIndex);
+      assertFalse(await engine().parts.grid.isRowDetailExpanded(detailedRowIndex));
+    });
+
+    test('isRowDetailExpanded/getRowDetailPanel/getRowDetailText throw for a row that does not exist', async () => {
+      await engine().parts.grid.waitForLoad();
+      const outOfRangeIndex = masterDetailGridRows.length + 10;
+
+      let isExpandedThrew = false;
+      try {
+        await engine().parts.grid.isRowDetailExpanded(outOfRangeIndex);
+      } catch {
+        isExpandedThrew = true;
+      }
+      assertTrue(isExpandedThrew);
+
+      let getPanelThrew = false;
+      try {
+        await engine().parts.grid.getRowDetailPanel(outOfRangeIndex);
+      } catch {
+        getPanelThrew = true;
+      }
+      assertTrue(getPanelThrew);
+
+      let getTextThrew = false;
+      try {
+        await engine().parts.grid.getRowDetailText(outOfRangeIndex);
+      } catch {
+        getTextThrew = true;
+      }
+      assertTrue(getTextThrew);
     });
   },
 };

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.suite.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/MasterDetailDataGridPremium.suite.ts
@@ -1,0 +1,78 @@
+import { DataGridPremiumDriver } from '@atomic-testing/component-driver-mui-x-v9';
+import { IExampleUnit, ScenePart, byDataTestId } from '@atomic-testing/core';
+import { TestSuiteInfo, useTestEngine } from '@atomic-testing/internal-test-runner';
+import { JSX } from 'react';
+
+import {
+  masterDetailDataGridPremiumUIExample,
+  masterDetailGridRows,
+  noDetailRowIndex,
+} from './MasterDetailDataGridPremium.examples';
+
+export const masterDetailDataGridPremiumExampleScenePart = {
+  grid: {
+    locator: byDataTestId('master-detail-grid-premium'),
+    driver: DataGridPremiumDriver,
+  },
+} satisfies ScenePart;
+
+export const masterDetailDataGridPremiumExample: IExampleUnit<
+  typeof masterDetailDataGridPremiumExampleScenePart,
+  JSX.Element
+> = {
+  ...masterDetailDataGridPremiumUIExample,
+  scene: masterDetailDataGridPremiumExampleScenePart,
+};
+
+const detailedRowIndex = 0;
+const detailedRowTraderEmail = masterDetailGridRows[detailedRowIndex].traderEmail;
+
+export const masterDetailDataGridPremiumTestSuite: TestSuiteInfo<typeof masterDetailDataGridPremiumExampleScenePart> = {
+  title: 'Master-Detail DataGridPremium',
+  url: '/datagridmasterdetail',
+  tests: (getTestEngine, { test, beforeEach, afterEach, assertEqual, assertTrue, assertFalse }) => {
+    const engine = useTestEngine(masterDetailDataGridPremiumExample.scene, getTestEngine, { beforeEach, afterEach });
+
+    test('rows start collapsed', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertFalse(await engine().parts.grid.isRowDetailExpanded(detailedRowIndex));
+    });
+
+    test('expandRowDetail reveals the panel content, collapseRowDetail hides it again', async () => {
+      await engine().parts.grid.waitForLoad();
+
+      await engine().parts.grid.expandRowDetail(detailedRowIndex);
+      assertTrue(await engine().parts.grid.isRowDetailExpanded(detailedRowIndex));
+      assertEqual(
+        await engine().parts.grid.getRowDetailText(detailedRowIndex),
+        `Trader email: ${detailedRowTraderEmail}`
+      );
+
+      await engine().parts.grid.collapseRowDetail(detailedRowIndex);
+      assertFalse(await engine().parts.grid.isRowDetailExpanded(detailedRowIndex));
+      assertEqual(await engine().parts.grid.getRowDetailText(detailedRowIndex), null);
+    });
+
+    test('getRowDetailPanel returns null before expansion and a driver over the panel content after', async () => {
+      await engine().parts.grid.waitForLoad();
+      assertEqual(await engine().parts.grid.getRowDetailPanel(detailedRowIndex), null);
+
+      await engine().parts.grid.expandRowDetail(detailedRowIndex);
+      const panel = await engine().parts.grid.getRowDetailPanel(detailedRowIndex);
+      assertTrue(panel !== null);
+      assertEqual(await panel!.getText(), `Trader email: ${detailedRowTraderEmail}`);
+    });
+
+    test('expandRowDetail throws for a row with no detail-panel content', async () => {
+      await engine().parts.grid.waitForLoad();
+      let threw = false;
+      try {
+        await engine().parts.grid.expandRowDetail(noDetailRowIndex, 500);
+      } catch {
+        threw = true;
+      }
+      assertTrue(threw);
+      assertFalse(await engine().parts.grid.isRowDetailExpanded(noDetailRowIndex));
+    });
+  },
+};

--- a/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
+++ b/package-tests/component-driver-mui-x-v9-test/src/examples/datagridpremium/index.ts
@@ -7,12 +7,18 @@ import {
   interactiveDataGridPremiumExample,
   interactiveDataGridPremiumTestSuite,
 } from './InteractiveDataGridPremium.suite';
+import {
+  masterDetailDataGridPremiumExample,
+  masterDetailDataGridPremiumTestSuite,
+} from './MasterDetailDataGridPremium.suite';
 
 export { basicDataGridPremiumExample, basicDataGridPremiumTestSuite };
 export { interactiveDataGridPremiumExample, interactiveDataGridPremiumTestSuite };
 export { groupedDataGridPremiumExample, groupedDataGridPremiumTestSuite };
+export { masterDetailDataGridPremiumExample, masterDetailDataGridPremiumTestSuite };
 export const dataGridPremiumExamples: IExampleUnit<ScenePart, JSX.Element>[] = [
   basicDataGridPremiumExample,
   interactiveDataGridPremiumExample,
   groupedDataGridPremiumExample,
+  masterDetailDataGridPremiumExample,
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -95,6 +95,11 @@ const aggregationFooterRowLocator = byCssSelector('[role="row"][data-id="auto-ge
 // separator (not HTML5 drag-and-drop), so the portable pixel-delta `drag` primitive can move it.
 const resizeSeparatorSelector = '.MuiDataGrid-columnSeparator--resizable';
 
+// Column reordering, unlike resizing, IS native HTML5 drag-and-drop (`draggable="true"` +
+// `dragstart`/`dragover`/`drop`) on the header's draggable container, so it uses `dragTo`
+// rather than the resize separator's mouse-only pixel-delta `drag`.
+const columnHeaderDraggableLocator = byCssSelector('.MuiDataGrid-columnHeaderDraggableContainer');
+
 // Both the page-size select's input-base wrapper and its inner combobox carry
 // `MuiTablePagination-select`; the role pins the combobox element itself.
 const pageSizeComboboxLocator = byCssSelector('.MuiTablePagination-select[role="combobox"]');
@@ -698,6 +703,27 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
   async getColumnWidth(field: string): Promise<number> {
     const rect = await this.interactor.getBoundingRect(this.columnHeaderLocator(field));
     return rect.width;
+  }
+
+  /**
+   * Reorder columns by dragging the `sourceField` column header and dropping it onto the
+   * `targetField` column header's position. MUI drives column reordering with native HTML5
+   * drag-and-drop on the header's draggable container — unlike {@link resizeColumn}'s resize
+   * separator, which is mouse-only — so this uses the portable `dragTo` primitive.
+   *
+   * MUI's reorder logic decides drag direction from consecutive `dragover` events'
+   * `clientX`/`clientY`, which jsdom's synthesized events carry no real values for (jsdom has no
+   * layout engine). The actual reorder is E2E-only; under jsdom this only exercises the code
+   * path and may leave the order unchanged, or change it inconsistently with the requested
+   * direction — do not assert on the resulting order there.
+   *
+   * @param sourceField The field of the column to drag.
+   * @param targetField The field of the column to drop onto.
+   */
+  async reorderColumn(sourceField: string, targetField: string): Promise<void> {
+    const source = locatorUtil.append(this.columnHeaderLocator(sourceField), columnHeaderDraggableLocator);
+    const target = locatorUtil.append(this.columnHeaderLocator(targetField), columnHeaderDraggableLocator);
+    await this.interactor.dragTo(source, target);
   }
   //#endregion Column management
 

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -709,21 +709,48 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
    * Reorder columns by dragging the `sourceField` column header and dropping it onto the
    * `targetField` column header's position. MUI drives column reordering with native HTML5
    * drag-and-drop on the header's draggable container — unlike {@link resizeColumn}'s resize
-   * separator, which is mouse-only — so this uses the portable `dragTo` primitive.
+   * separator, which is mouse-only — so this uses the portable `dragTo` primitive. Throws if
+   * either column is not currently rendered, or if the drop is not accepted (the dragged column
+   * never moved) — including MUI's own non-reorderable columns, e.g. one just pinned via
+   * {@link pinColumn}, or a checkbox-selection column.
    *
-   * MUI's reorder logic decides drag direction from consecutive `dragover` events'
-   * `clientX`/`clientY`, which jsdom's synthesized events carry no real values for (jsdom has no
-   * layout engine). The actual reorder is E2E-only; under jsdom this only exercises the code
-   * path and may leave the order unchanged, or change it inconsistently with the requested
-   * direction — do not assert on the resulting order there.
+   * MUI's reorder direction is decided from consecutive `dragover` events' `clientX`/`clientY`.
+   * jsdom's synthesized `dragover` carries no real coordinates (jsdom has no layout engine), so
+   * the comparison against the initial `{x: 0, y: 0}` cursor position always resolves to "moving
+   * left": a drag whose `targetField` sits before `sourceField` genuinely reorders under jsdom
+   * too (this is React state, not geometry, so it doesn't need a layout engine) — the reverse
+   * direction is a no-op there and this method throws. That throw is a jsdom-only artifact, not a
+   * real error; it does not happen in a real browser. Prefer the "target before source" direction
+   * when a case needs to run under both jsdom and E2E.
    *
    * @param sourceField The field of the column to drag.
    * @param targetField The field of the column to drop onto.
    */
-  async reorderColumn(sourceField: string, targetField: string): Promise<void> {
-    const source = locatorUtil.append(this.columnHeaderLocator(sourceField), columnHeaderDraggableLocator);
-    const target = locatorUtil.append(this.columnHeaderLocator(targetField), columnHeaderDraggableLocator);
-    await this.interactor.dragTo(source, target);
+  async reorderColumn(sourceField: string, targetField: string, timeoutMs: number = 10000): Promise<void> {
+    const sourceHeader = this.columnHeaderLocator(sourceField);
+    if (!(await this.interactor.exists(sourceHeader))) {
+      throw new Error(`${this.driverName}: column "${sourceField}" is not currently rendered`);
+    }
+    const targetHeader = this.columnHeaderLocator(targetField);
+    if (!(await this.interactor.exists(targetHeader))) {
+      throw new Error(`${this.driverName}: column "${targetField}" is not currently rendered`);
+    }
+    const originalIndex = await this.interactor.getAttribute(sourceHeader, 'aria-colindex');
+    await this.interactor.dragTo(
+      locatorUtil.append(sourceHeader, columnHeaderDraggableLocator),
+      locatorUtil.append(targetHeader, columnHeaderDraggableLocator)
+    );
+    const moved = await this.waitUntil({
+      probeFn: async () => (await this.interactor.getAttribute(sourceHeader, 'aria-colindex')) !== originalIndex,
+      terminateCondition: true,
+      timeoutMs,
+    });
+    if (!moved) {
+      throw new Error(
+        `${this.driverName}: column "${sourceField}" never moved — the drop may not have been accepted (e.g. ` +
+          `"${targetField}" is not reorderable, such as a pinned or checkbox-selection column)`
+      );
+    }
   }
   //#endregion Column management
 
@@ -839,15 +866,24 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
   }
 
   /**
-   * Collapse the row's detail panel by clicking its toggle (no-op when already collapsed). See
-   * {@link isRowDetailExpanded} for the row-index addressing caveat.
+   * Collapse the row's detail panel by clicking its toggle (no-op when already collapsed).
    */
   async collapseRowDetail(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
     await this.setRowDetailExpansion(rowIndex, false, timeoutMs);
   }
 
+  /**
+   * Click the toggle and wait until BOTH the toggle's `aria-expanded` AND the panel's DOM
+   * presence agree with `expanded`. MUI updates these on two separate render commits (the
+   * toggle synchronously, the panel's insertion/removal via a `useEffect`), so waiting on
+   * `aria-expanded` alone leaves a window where a caller's next read (e.g. `getRowDetailText`)
+   * can race the still-pending panel commit — this closes it by polling both signals together.
+   */
   private async setRowDetailExpansion(rowIndex: number, expanded: boolean, timeoutMs: number): Promise<void> {
-    if ((await this.isRowDetailExpanded(rowIndex)) === expanded) {
+    const isSettled = async (): Promise<boolean> =>
+      (await this.isRowDetailExpanded(rowIndex)) === expanded &&
+      (await this.interactor.exists(this.rowDetailPanelLocator(rowIndex))) === expanded;
+    if (await isSettled()) {
       return;
     }
     const toggle = locatorUtil.append(this.rowLocator(rowIndex), rowDetailToggleLocator);
@@ -855,12 +891,8 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
       throw new Error(`${this.driverName}: row ${rowIndex} has no detail-panel content to expand`);
     }
     await this.interactor.click(toggle);
-    const reached = await this.waitUntil({
-      probeFn: () => this.isRowDetailExpanded(rowIndex),
-      terminateCondition: expanded,
-      timeoutMs,
-    });
-    if (reached !== expanded) {
+    const settled = await this.waitUntil({ probeFn: isSettled, terminateCondition: true, timeoutMs });
+    if (!settled) {
       throw new Error(
         `${this.driverName}: row ${rowIndex} detail panel never became ${expanded ? 'expanded' : 'collapsed'}`
       );
@@ -868,10 +900,17 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
   }
 
   /**
-   * The driver for the row's expanded detail-panel content, or `null` when the panel is not
-   * currently expanded. The panel renders as the row's next DOM sibling within the virtualized
-   * render zone rather than nested inside the row, so it is addressed off the row locator with
-   * the CSS adjacent-sibling combinator rather than as a descendant.
+   * The driver for the row's expanded detail-panel content, or `null` when the row exists but its
+   * panel is not currently expanded. Throws when `rowIndex` does not correspond to any currently
+   * rendered row, matching {@link getRowText}/{@link getCellText} — `null` is reserved for "this
+   * row exists but its panel is collapsed."
+   *
+   * The panel renders as the row's next DOM sibling within the virtualized render zone rather than
+   * nested inside the row, so it is addressed off the row locator with the CSS adjacent-sibling
+   * combinator rather than as a descendant. Caveat: MUI's virtualizer can render an off-window row
+   * as a lone keyboard-focus placeholder (e.g. immediately after `scrollRowIntoView` moved focus
+   * elsewhere) without stitching its panel in as a sibling for that render pass, even though the
+   * row is genuinely expanded — this can transiently return `null` for such a row.
    *
    * @param rowIndex The rendered `data-rowindex` of the row.
    * @param driverClass Optional, the driver class to use for the panel content, default to HTMLElementDriver.
@@ -880,6 +919,9 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
     rowIndex: number,
     driverClass: ComponentDriverCtor<DriverT> = HTMLElementDriver as ComponentDriverCtor<DriverT>
   ): Promise<DriverT | null> {
+    if (!(await this.interactor.exists(this.rowLocator(rowIndex)))) {
+      throw new Error(`Row ${rowIndex} does not exist`);
+    }
     const panel = this.rowDetailPanelLocator(rowIndex);
     if (!(await this.interactor.exists(panel))) {
       return null;
@@ -888,9 +930,11 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
   }
 
   /**
-   * The text content of the row's expanded detail panel, or `null` when the panel is not
-   * currently expanded. Convenience wrapper over {@link getRowDetailPanel} for the common
-   * text-only case.
+   * The text content of the row's expanded detail panel, or `null` when the row exists but its
+   * panel is not currently expanded — deliberately `null` rather than a throw here, unlike
+   * {@link getRowText}/{@link getCellText}: an unexpanded panel is normal, expected state, not an
+   * invalid query. A nonexistent row still throws, via {@link getRowDetailPanel}. Convenience
+   * wrapper over {@link getRowDetailPanel} for the common text-only case.
    */
   async getRowDetailText(rowIndex: number): Promise<string | null> {
     const panel = await this.getRowDetailPanel(rowIndex);

--- a/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
+++ b/packages/component-driver-mui-x-v9/src/components/datagrid/DataGridPremiumDriver.ts
@@ -104,6 +104,13 @@ const headerCheckboxLocator = byCssSelector('[role=columnheader][data-field="__c
 const virtualScrollerLocator = byCssClass('MuiDataGrid-virtualScroller');
 const overlayWrapperLocator = byCssClass('MuiDataGrid-overlayWrapper');
 
+// Master-detail: the row's detail-panel toggle is a dedicated cell (MUI X's fixed internal
+// field name `__detail_panel_toggle__`) whose button carries its own `aria-expanded` — unlike
+// row grouping, where `aria-expanded` lives on the row itself. The expanded panel renders as
+// that row's next DOM sibling within the virtualized render zone (not nested inside the row),
+// so it is addressed with the adjacent-sibling combinator off the row rather than a descendant.
+const rowDetailToggleLocator = byCssSelector('.MuiDataGrid-detailPanelToggleCell');
+
 /** `aria-sort` attribute values mapped to the driver's sort-direction vocabulary. */
 const ariaSortToDirection: Record<string, 'asc' | 'desc' | null> = {
   ascending: 'asc',
@@ -257,6 +264,13 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
 
   private columnHeaderLocator(field: string): PartLocator {
     return locatorUtil.append(this.locator, byCssSelector(`[role=columnheader][data-field="${field}"]`));
+  }
+
+  private rowDetailPanelLocator(rowIndex: number): PartLocator {
+    return locatorUtil.append(
+      this.locator,
+      byCssSelector(`[role=row][data-rowindex="${rowIndex}"] + .MuiDataGrid-detailPanel`)
+    );
   }
 
   private cellLocator(query: DataGridCellQuery): PartLocator {
@@ -771,6 +785,92 @@ export class DataGridPremiumDriver extends ComponentDriver<typeof parts> {
     return text == null || text.trim().length === 0 ? null : text.trim();
   }
   //#endregion Row grouping and aggregation
+
+  //#region Row detail panel (master-detail)
+  /**
+   * Whether the row at the given index has its detail panel expanded, read from the panel
+   * toggle's `aria-expanded`. Requires the grid's `getDetailPanelContent` (Pro/Premium
+   * master-detail) — throws when the row has no detail-panel toggle rendered (e.g. the
+   * community DataGrid, or `getDetailPanelContent` not configured).
+   *
+   * @param rowIndex The rendered `data-rowindex` of the row.
+   */
+  async isRowDetailExpanded(rowIndex: number): Promise<boolean> {
+    const toggle = locatorUtil.append(this.rowLocator(rowIndex), rowDetailToggleLocator);
+    if (!(await this.interactor.exists(toggle))) {
+      throw new Error(`${this.driverName}: row ${rowIndex} has no detail-panel toggle`);
+    }
+    return (await this.interactor.getAttribute(toggle, 'aria-expanded')) === 'true';
+  }
+
+  /**
+   * Expand the row's detail panel by clicking its toggle (no-op when already expanded). Throws
+   * when the row's `getDetailPanelContent` returned no content for it — the toggle is disabled
+   * in that case, the same way MUI disables it in the browser.
+   */
+  async expandRowDetail(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
+    await this.setRowDetailExpansion(rowIndex, true, timeoutMs);
+  }
+
+  /**
+   * Collapse the row's detail panel by clicking its toggle (no-op when already collapsed). See
+   * {@link isRowDetailExpanded} for the row-index addressing caveat.
+   */
+  async collapseRowDetail(rowIndex: number, timeoutMs: number = 10000): Promise<void> {
+    await this.setRowDetailExpansion(rowIndex, false, timeoutMs);
+  }
+
+  private async setRowDetailExpansion(rowIndex: number, expanded: boolean, timeoutMs: number): Promise<void> {
+    if ((await this.isRowDetailExpanded(rowIndex)) === expanded) {
+      return;
+    }
+    const toggle = locatorUtil.append(this.rowLocator(rowIndex), rowDetailToggleLocator);
+    if (expanded && (await this.interactor.isDisabled(toggle))) {
+      throw new Error(`${this.driverName}: row ${rowIndex} has no detail-panel content to expand`);
+    }
+    await this.interactor.click(toggle);
+    const reached = await this.waitUntil({
+      probeFn: () => this.isRowDetailExpanded(rowIndex),
+      terminateCondition: expanded,
+      timeoutMs,
+    });
+    if (reached !== expanded) {
+      throw new Error(
+        `${this.driverName}: row ${rowIndex} detail panel never became ${expanded ? 'expanded' : 'collapsed'}`
+      );
+    }
+  }
+
+  /**
+   * The driver for the row's expanded detail-panel content, or `null` when the panel is not
+   * currently expanded. The panel renders as the row's next DOM sibling within the virtualized
+   * render zone rather than nested inside the row, so it is addressed off the row locator with
+   * the CSS adjacent-sibling combinator rather than as a descendant.
+   *
+   * @param rowIndex The rendered `data-rowindex` of the row.
+   * @param driverClass Optional, the driver class to use for the panel content, default to HTMLElementDriver.
+   */
+  async getRowDetailPanel<DriverT extends ComponentDriver = HTMLElementDriver>(
+    rowIndex: number,
+    driverClass: ComponentDriverCtor<DriverT> = HTMLElementDriver as ComponentDriverCtor<DriverT>
+  ): Promise<DriverT | null> {
+    const panel = this.rowDetailPanelLocator(rowIndex);
+    if (!(await this.interactor.exists(panel))) {
+      return null;
+    }
+    return new driverClass(panel, this.interactor, this.commutableOption);
+  }
+
+  /**
+   * The text content of the row's expanded detail panel, or `null` when the panel is not
+   * currently expanded. Convenience wrapper over {@link getRowDetailPanel} for the common
+   * text-only case.
+   */
+  async getRowDetailText(rowIndex: number): Promise<string | null> {
+    const panel = await this.getRowDetailPanel(rowIndex);
+    return panel == null ? null : ((await panel.getText()) ?? null);
+  }
+  //#endregion Row detail panel (master-detail)
 
   //#region Page size and overlays
   /**


### PR DESCRIPTION
## Summary

Added two new feature sets to `DataGridPremiumDriver`:

1. **Column reordering** via `reorderColumn(sourceField, targetField)` — drags a column header to a new position using HTML5 drag-and-drop. Validates that both columns are rendered, waits for the column's `aria-colindex` to change, and throws if the drop is not accepted (e.g., pinned or checkbox-selection columns).

2. **Row detail panel (master-detail)** via four new methods:
   - `isRowDetailExpanded(rowIndex)` — reads the toggle's `aria-expanded`
   - `expandRowDetail(rowIndex)` / `collapseRowDetail(rowIndex)` — click the toggle and wait for both the toggle state and panel DOM presence to settle (closes a race window between MUI's synchronous toggle update and async panel insertion/removal)
   - `getRowDetailPanel(rowIndex, driverClass?)` — returns a driver over the expanded panel content, or `null` if collapsed
   - `getRowDetailText(rowIndex)` — convenience wrapper returning the panel's text content or `null`

All methods include comprehensive error handling and detailed JSDoc explaining edge cases (e.g., jsdom's synthesized `dragover` coordinates, MUI's virtualizer rendering off-window rows without their panels).

Added full test coverage:
- DOM tests (`MasterDetailDataGridPremium.dom.test.ts`) validating expansion/collapse, panel access, error cases, and nonexistent rows
- E2E tests (`MasterDetailDataGridPremium.e2e.test.ts`) for real-browser behavior
- Interactive tests for `reorderColumn` in the existing `InteractiveDataGridPremium` suite
- Example UI and test fixtures demonstrating both features

## Checks

- [ ] `pnpm run check:type`
- [ ] `pnpm run check:lint`
- [ ] `pnpm run check:style`
- [ ] `pnpm test:dom` (component-driver-mui-x-v9-test)
- [ ] `pnpm test:e2e` (component-driver-mui-x-v9-test, all three browsers)

## Breaking change

- [ ] This PR introduces a breaking change

https://claude.ai/code/session_01AR5d7hzaovTA8zKPjSFdfy