### PR TITLE
refactor(fluent-v9): one absence convention across the package

### DIFF
--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -192,6 +192,13 @@ This extends §5: that section governs _mutative_ methods, which throw on a
 missing locator; this one governs reads, which report absence in the return type
 wherever the type can carry it.
 
+The rule is written for the frozen packages, but the **driver packages follow it
+too** — not because they are frozen (§1 puts them outside), but because a package
+that mixes both spellings makes the distinction meaningless. `component-driver-fluent-v9`
+is the worked example: every lookup answering "which item?" returns `Optional`,
+while `RadioDriver.getValue` and `RatingDriver.getValue` return `Nullable`, because
+an unset control genuinely holds a null value.
+
 ## Consequences
 
 - ✅ The public surface is explicit, reviewed, and CI-enforced; incidental

--- a/package-tests/component-driver-fluent-v9-test/src/examples/accordion/Accordion.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/accordion/Accordion.suite.ts
@@ -69,7 +69,7 @@ export const accordionExampleTestSuite: TestSuiteInfo<typeof accordionExample.sc
         assertEqual(await openItem!.getPanelText(), 'Section one content');
 
         const closedItem = await engine().parts.accordionA.getItemByIndex(1);
-        assertEqual(await closedItem!.getPanelText(), null);
+        assertEqual(await closedItem!.getPanelText(), undefined);
       });
 
       test('AccordionItemDriver.expand()/collapse() toggle a single item directly', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/accordion/Accordion.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/accordion/Accordion.suite.ts
@@ -64,7 +64,7 @@ export const accordionExampleTestSuite: TestSuiteInfo<typeof accordionExample.sc
         assertFalse(await disabledItem!.isExpanded());
       });
 
-      test('getPanelText reads the expanded panel; returns null while collapsed', async () => {
+      test('getPanelText reads the expanded panel; returns undefined while collapsed', async () => {
         const openItem = await engine().parts.accordionA.getItemByIndex(0);
         assertEqual(await openItem!.getPanelText(), 'Section one content');
 

--- a/package-tests/component-driver-fluent-v9-test/src/examples/breadcrumb/Breadcrumb.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/breadcrumb/Breadcrumb.suite.ts
@@ -30,21 +30,21 @@ export const breadcrumbExampleTestSuite: TestSuiteInfo<typeof breadcrumbExample.
         assertEqual(await engine().parts.breadcrumbB.getItemLabels(), ['Root', 'Locked']);
       });
 
-      test('getItemByIndex/getItemByLabel resolve items, or null when absent', async () => {
+      test('getItemByIndex/getItemByLabel resolve items, or undefined when absent', async () => {
         const home = await engine().parts.breadcrumbA.getItemByIndex(0);
         assertEqual(await home?.getLabel(), 'Home');
-        assertEqual(await engine().parts.breadcrumbA.getItemByIndex(99), null);
+        assertEqual(await engine().parts.breadcrumbA.getItemByIndex(99), undefined);
 
         const library = await engine().parts.breadcrumbA.getItemByLabel('Library');
         assertEqual(await library?.getButton().getHref(), '/home/library');
-        assertEqual(await engine().parts.breadcrumbA.getItemByLabel('Nonexistent'), null);
+        assertEqual(await engine().parts.breadcrumbA.getItemByLabel('Nonexistent'), undefined);
       });
 
-      test('getCurrentItem finds the crumb marked current, or null when none is', async () => {
+      test('getCurrentItem finds the crumb marked current, or undefined when none is', async () => {
         const current = await engine().parts.breadcrumbA.getCurrentItem();
         assertEqual(await current?.getLabel(), 'Data');
 
-        assertEqual(await engine().parts.breadcrumbB.getCurrentItem(), null);
+        assertEqual(await engine().parts.breadcrumbB.getCurrentItem(), undefined);
       });
 
       test('isDisabled reflects the disabled crumb only', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/combobox/Combobox.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/combobox/Combobox.suite.ts
@@ -45,16 +45,16 @@ export const comboboxExampleTestSuite: TestSuiteInfo<typeof comboboxExample.scen
 
       test('reads per-option disabled state', async () => {
         const fish = await engine().parts.animals.getOptionByLabel('Fish');
-        assertNotEqual(fish, null);
+        assertNotEqual(fish, undefined);
         assertTrue(await fish!.isDisabled());
 
         const cat = await engine().parts.animals.getOptionByLabel('Cat');
-        assertNotEqual(cat, null);
+        assertNotEqual(cat, undefined);
         assertFalse(await cat!.isDisabled());
       });
 
-      test('getOptionByLabel returns null for a label with no matching option', async () => {
-        assertEqual(await engine().parts.animals.getOptionByLabel('Zebra'), null);
+      test('getOptionByLabel returns undefined for a label with no matching option', async () => {
+        assertEqual(await engine().parts.animals.getOptionByLabel('Zebra'), undefined);
       });
 
       test('selectByLabel clicks the option, closes the listbox, and mirrors its text onto the value', async () => {
@@ -70,8 +70,8 @@ export const comboboxExampleTestSuite: TestSuiteInfo<typeof comboboxExample.scen
 
         const cat = await engine().parts.animals.getOptionByLabel('Cat');
         const dog = await engine().parts.animals.getOptionByLabel('Dog');
-        assertNotEqual(cat, null);
-        assertNotEqual(dog, null);
+        assertNotEqual(cat, undefined);
+        assertNotEqual(dog, undefined);
         assertTrue(await cat!.isSelected());
         assertFalse(await dog!.isSelected());
       });
@@ -99,7 +99,7 @@ export const comboboxExampleTestSuite: TestSuiteInfo<typeof comboboxExample.scen
       test('an empty combobox has no options and resolves no match', async () => {
         assertEqual(await engine().parts.empty.getOptionCount(), 0);
         assertEqual(await engine().parts.empty.getOptionLabels(), []);
-        assertEqual(await engine().parts.empty.getOptionByLabel('Anything'), null);
+        assertEqual(await engine().parts.empty.getOptionByLabel('Anything'), undefined);
       });
 
       test('two simultaneously open instances resolve independent listboxes (locator disambiguation)', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/data-grid/DataGrid.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/data-grid/DataGrid.suite.ts
@@ -141,7 +141,7 @@ export const dataGridExampleTestSuite: TestSuiteInfo<typeof dataGridExample.scen
         const headerRow = await engine().parts.gridA.getHeaderRow();
         assertTrue(headerRow != null);
         assertEqual(await headerRow!.getCellCount(), 3);
-        assertEqual(await headerRow!.getCell(99), null);
+        assertEqual(await headerRow!.getCell(99), undefined);
       });
 
       test('keyboard-accessible resize: entering via the app-wired trigger enables arrow-key adjust and Escape exit', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/dialog/Dialog.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/dialog/Dialog.suite.ts
@@ -90,7 +90,7 @@ export const dialogExampleTestSuite: TestSuiteInfo<typeof dialogExample.scene> =
       test('getTitle returns null when DialogTitle is absent', async () => {
         await engine().parts.noTitleTrigger.click();
         await engine().parts.dialogNoTitle.waitForOpen();
-        assertEqual(await engine().parts.dialogNoTitle.getTitle(), null);
+        assertEqual(await engine().parts.dialogNoTitle.getTitle(), undefined);
       });
     });
   },

--- a/package-tests/component-driver-fluent-v9-test/src/examples/dialog/Dialog.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/dialog/Dialog.suite.ts
@@ -87,7 +87,7 @@ export const dialogExampleTestSuite: TestSuiteInfo<typeof dialogExample.scene> =
         assertEqual(await engine().parts.dialogA.getTitle(), 'Dialog A');
       });
 
-      test('getTitle returns null when DialogTitle is absent', async () => {
+      test('getTitle returns undefined when DialogTitle is absent', async () => {
         await engine().parts.noTitleTrigger.click();
         await engine().parts.dialogNoTitle.waitForOpen();
         assertEqual(await engine().parts.dialogNoTitle.getTitle(), undefined);

--- a/package-tests/component-driver-fluent-v9-test/src/examples/flat-tree/FlatTree.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/flat-tree/FlatTree.suite.ts
@@ -43,11 +43,11 @@ export const flatTreeExampleTestSuite: TestSuiteInfo<typeof flatTreeExample.scen
         assertEqual(await engine().parts.flatTreeA.getItemByIndex(99), undefined);
       });
 
-      test('getItemByValue finds an item by its Fluent-stamped value at any level; absent value is null', async () => {
+      test('getItemByValue finds an item by its Fluent-stamped value at any level; absent value is undefined', async () => {
         const citrus = await engine().parts.flatTreeA.getItemByValue('citrus');
         assertEqual(await citrus!.getLabel(), 'Citrus');
         assertEqual(await citrus!.getValue(), 'citrus');
-        assertEqual(await engine().parts.flatTreeA.getItemByValue('does-not-exist'), null);
+        assertEqual(await engine().parts.flatTreeA.getItemByValue('does-not-exist'), undefined);
       });
 
       test('getItemByValue matches by value, not incidentally by label, when two items share a visible label', async () => {
@@ -96,8 +96,8 @@ export const flatTreeExampleTestSuite: TestSuiteInfo<typeof flatTreeExample.scen
       });
 
       test('a collapsed branch’s descendants are absent from the flat list until expand()ed', async () => {
-        assertEqual(await engine().parts.flatTreeA.getItemByValue('orange'), null);
-        assertEqual(await engine().parts.flatTreeA.getItemByValue('lemon'), null);
+        assertEqual(await engine().parts.flatTreeA.getItemByValue('orange'), undefined);
+        assertEqual(await engine().parts.flatTreeA.getItemByValue('lemon'), undefined);
 
         const citrus = await engine().parts.flatTreeA.getItemByValue('citrus');
         assertFalse(await citrus!.isExpanded());
@@ -112,7 +112,7 @@ export const flatTreeExampleTestSuite: TestSuiteInfo<typeof flatTreeExample.scen
 
         await citrus!.collapse();
         assertFalse(await citrus!.isExpanded());
-        assertEqual(await engine().parts.flatTreeA.getItemByValue('orange'), null);
+        assertEqual(await engine().parts.flatTreeA.getItemByValue('orange'), undefined);
       });
 
       test('expand()/collapse() no-op on a leaf item (nothing to toggle)', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/nav/Nav.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/nav/Nav.suite.ts
@@ -31,12 +31,12 @@ export const navExampleTestSuite: TestSuiteInfo<typeof navExample.scene> = {
         assertEqual(await engine().parts.navB.getItemCount(), 2);
       });
 
-      test('getItemByLabel resolves a leaf item, or null when absent', async () => {
+      test('getItemByLabel resolves a leaf item, or undefined when absent', async () => {
         const home = await engine().parts.navA.getItemByLabel('Home');
         assertTrue(await home!.isSelected());
 
-        assertEqual(await engine().parts.navA.getItemByLabel('Nonexistent'), null);
-        assertEqual(await engine().parts.navB.getItemByLabel('Home'), null);
+        assertEqual(await engine().parts.navA.getItemByLabel('Nonexistent'), undefined);
+        assertEqual(await engine().parts.navB.getItemByLabel('Home'), undefined);
       });
 
       test('getSelectedLabel reads the selected item per instance', async () => {
@@ -50,7 +50,7 @@ export const navExampleTestSuite: TestSuiteInfo<typeof navExample.scene> = {
         assertTrue(await reports!.isExpanded());
         assertEqual(await reports!.getSubItemCount(), 2);
 
-        assertEqual(await engine().parts.navB.getCategoryByLabel('Reports'), null);
+        assertEqual(await engine().parts.navB.getCategoryByLabel('Reports'), undefined);
       });
 
       test('NavCategoryItemDriver.collapse()/expand() toggle the category and its sub-items reachability', async () => {
@@ -63,7 +63,7 @@ export const navExampleTestSuite: TestSuiteInfo<typeof navExample.scene> = {
 
         const daily = await reports!.getSubItemByLabel('Daily');
         assertEqual(await daily?.getLabel(), 'Daily');
-        assertEqual(await reports!.getSubItemByLabel('Nonexistent'), null);
+        assertEqual(await reports!.getSubItemByLabel('Nonexistent'), undefined);
       });
 
       test('selectByLabel clicks the matching item without throwing, scoped to its own Nav', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/overflow/Overflow.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/overflow/Overflow.suite.ts
@@ -26,12 +26,12 @@ export const overflowExampleTestSuite: TestSuiteInfo<typeof overflowExample.scen
         assertEqual(await engine().parts.row.getItemLabels(), ['Item one', 'Item two', 'Item three']);
       });
 
-      test('getItemByLabel resolves an item, or null when absent', async () => {
+      test('getItemByLabel resolves an item, or undefined when absent', async () => {
         const item = await engine().parts.row.getItemByLabel('Item two');
         assertEqual(await item?.getLabel(), 'Item two');
         assertFalse(await item!.isOverflowing());
 
-        assertEqual(await engine().parts.row.getItemByLabel('Nonexistent'), null);
+        assertEqual(await engine().parts.row.getItemByLabel('Nonexistent'), undefined);
       });
 
       test('no items overflow when the row has enough room (default layout)', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/swatch-picker/SwatchPicker.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/swatch-picker/SwatchPicker.suite.ts
@@ -88,7 +88,7 @@ export const swatchPickerExampleTestSuite: TestSuiteInfo<typeof swatchPickerExam
       });
 
       test('selectByIndex/selectByColor throw when no swatch matches', async () => {
-        assertEqual(await engine().parts.pickerOne.getSwatchByIndex(99), null);
+        assertEqual(await engine().parts.pickerOne.getSwatchByIndex(99), undefined);
 
         let threwOnIndex = false;
         try {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/tabs/TabList.examples.tsx
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/tabs/TabList.examples.tsx
@@ -10,6 +10,10 @@ import React, { JSX } from 'react';
  * exercise `getOrientation()`. Both are uncontrolled (`defaultSelectedValue`)
  * — selection state after a driven `click()` is read straight back off the
  * DOM, no app-level state needed.
+ *
+ * List C carries NO `defaultSelectedValue`, so nothing is selected: the only
+ * fixture covering the "nothing selected" branch of `getSelectedLabel` /
+ * `getSelectedValue`, which returns `undefined` per ADR-006 §7.
  */
 const TabListExample = () => (
   <FluentProvider theme={webLightTheme}>
@@ -24,6 +28,11 @@ const TabListExample = () => (
     <TabList data-testid='tab-list-b' vertical defaultSelectedValue='overview'>
       <Tab value='overview'>Overview</Tab>
       <Tab value='details'>Details</Tab>
+    </TabList>
+
+    <TabList data-testid='tab-list-c'>
+      <Tab value='alpha'>Alpha</Tab>
+      <Tab value='beta'>Beta</Tab>
     </TabList>
   </FluentProvider>
 );

--- a/package-tests/component-driver-fluent-v9-test/src/examples/tabs/TabList.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/tabs/TabList.suite.ts
@@ -8,6 +8,7 @@ import { tabListUIExample } from './TabList.examples';
 export const tabListExampleScenePart = {
   listA: { locator: byDataTestId('tab-list-a'), driver: TabListDriver },
   listB: { locator: byDataTestId('tab-list-b'), driver: TabListDriver },
+  listNoSelection: { locator: byDataTestId('tab-list-c'), driver: TabListDriver },
 } satisfies ScenePart;
 
 export const tabListExample: IExampleUnit<typeof tabListExampleScenePart, JSX.Element> = {
@@ -36,6 +37,15 @@ export const tabListExampleTestSuite: TestSuiteInfo<typeof tabListExample.scene>
         assertEqual(await engine().parts.listA.getSelectedIndex(), 0);
         assertEqual(await engine().parts.listA.getSelectedLabel(), 'Home');
         assertEqual(await engine().parts.listA.getSelectedValue(), 'home');
+      });
+
+      // "no tab is selected" is a lookup miss, not a value the tab list holds, so
+      // both reads answer `undefined` — ADR-006 §7. Without this fixture the branch
+      // has no coverage at all: every other list here has a defaultSelectedValue.
+      test('a list with nothing selected reads undefined, not null', async () => {
+        assertEqual(await engine().parts.listNoSelection.getTabCount(), 2);
+        assertEqual(await engine().parts.listNoSelection.getSelectedLabel(), undefined);
+        assertEqual(await engine().parts.listNoSelection.getSelectedValue(), undefined);
       });
 
       test('selectByIndex selects a different tab, leaving the other list untouched', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/tag-picker/TagPicker.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/tag-picker/TagPicker.suite.ts
@@ -47,8 +47,8 @@ export const tagPickerExampleTestSuite: TestSuiteInfo<typeof tagPickerExample.sc
         assertEqual(await engine().parts.one.getOptionLabels(), ['Cherry', 'Date', 'Elderberry']);
       });
 
-      test('getOptionByLabel returns null for a label with no matching option', async () => {
-        assertEqual(await engine().parts.one.getOptionByLabel('Nonexistent'), null);
+      test('getOptionByLabel returns undefined for a label with no matching option', async () => {
+        assertEqual(await engine().parts.one.getOptionByLabel('Nonexistent'), undefined);
       });
 
       test('selectByLabel adds the option to the selected tags and closes the list', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/tags/Tags.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/tags/Tags.suite.ts
@@ -54,7 +54,7 @@ export const tagsExampleTestSuite: TestSuiteInfo<typeof tagsExample.scene> = {
       test('has zero tags for an empty group', async () => {
         assertEqual(await engine().parts.groupEmpty.getTagCount(), 0);
         assertEqual(await engine().parts.groupEmpty.getTagLabels(), []);
-        assertEqual(await engine().parts.groupEmpty.getTagByIndex(0), null);
+        assertEqual(await engine().parts.groupEmpty.getTagByIndex(0), undefined);
       });
 
       test('getTagByIndex resolves the concrete driver matching each position', async () => {
@@ -66,7 +66,7 @@ export const tagsExampleTestSuite: TestSuiteInfo<typeof tagsExample.scene> = {
         assertTrue(third instanceof InteractionTagDriver);
         assertEqual(await third?.getLabel(), 'Gamma');
 
-        assertEqual(await engine().parts.groupA.getTagByIndex(99), null);
+        assertEqual(await engine().parts.groupA.getTagByIndex(99), undefined);
       });
 
       test('dismiss() removes only the targeted InteractionTag from its own group', async () => {

--- a/package-tests/component-driver-fluent-v9-test/src/examples/toast/Toast.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/toast/Toast.suite.ts
@@ -54,7 +54,7 @@ export const toastExampleTestSuite: TestSuiteInfo<typeof toastExample.scene> = {
         assertEqual(await toast?.getBodyText(), 'Second toast body');
       });
 
-      test('getToastByIndex is null out of range', async () => {
+      test('getToastByIndex is undefined out of range', async () => {
         const toast = await engine().parts.toaster.getToastByIndex(0);
         assertEqual(toast, undefined);
       });

--- a/package-tests/component-driver-fluent-v9-test/src/examples/toast/Toast.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/toast/Toast.suite.ts
@@ -56,7 +56,7 @@ export const toastExampleTestSuite: TestSuiteInfo<typeof toastExample.scene> = {
 
       test('getToastByIndex is null out of range', async () => {
         const toast = await engine().parts.toaster.getToastByIndex(0);
-        assertEqual(toast, null);
+        assertEqual(toast, undefined);
       });
     });
   },

--- a/package-tests/component-driver-fluent-v9-test/src/examples/toolbar/Toolbar.suite.ts
+++ b/package-tests/component-driver-fluent-v9-test/src/examples/toolbar/Toolbar.suite.ts
@@ -44,7 +44,7 @@ export const toolbarExampleTestSuite: TestSuiteInfo<typeof toolbarExample.scene>
         assertEqual(await engine().parts.toolbarB.getDividerCount(), 1);
       });
 
-      test('getButtonByLabel resolves a plain or grouped button, or null when absent', async () => {
+      test('getButtonByLabel resolves a plain or grouped button, or undefined when absent', async () => {
         const cut = await engine().parts.toolbarA.getButtonByLabel('Cut');
         assertFalse(await cut!.isDisabled());
 
@@ -54,8 +54,8 @@ export const toolbarExampleTestSuite: TestSuiteInfo<typeof toolbarExample.scene>
         const left = await engine().parts.toolbarA.getButtonByLabel('Left');
         assertTrue(left != null);
 
-        assertEqual(await engine().parts.toolbarA.getButtonByLabel('Nonexistent'), null);
-        assertEqual(await engine().parts.toolbarB.getButtonByLabel('Cut'), null);
+        assertEqual(await engine().parts.toolbarA.getButtonByLabel('Nonexistent'), undefined);
+        assertEqual(await engine().parts.toolbarB.getButtonByLabel('Cut'), undefined);
       });
 
       test('ToolbarDividerDriver reports its own axis, inverted relative to its toolbar', async () => {

--- a/packages/component-driver-fluent-v9/src/components/AccordionItemDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/AccordionItemDriver.ts
@@ -37,7 +37,7 @@ const defaultTransitionDuration = 1000;
  * never opened never mounts at all, and toggling open→closed plays the exit
  * animation before removing it from the DOM — a STRONGER case than Radix's
  * accordion, whose content wrapper stays mounted with lazily-rendered
- * children. {@link getPanelText} therefore returns `null` whenever the panel
+ * children. {@link getPanelText} therefore returns `undefined` whenever the panel
  * isn't currently present (collapsed, or mid-exit-animation under a real
  * browser's timing), not merely when the item has never been opened.
  *
@@ -75,13 +75,13 @@ export class AccordionItemDriver extends ComponentDriver<{}> implements IDisable
     return this.interactor.isDisabled(this.headerButtonLocator);
   }
 
-  /** The panel's text content, or `null` when the panel is not currently mounted — see class doc. */
-  async getPanelText(): Promise<string | null> {
+  /** The panel's text content, or `undefined` when the panel is not currently mounted — see class doc. */
+  async getPanelText(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.panelLocator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.interactor.getText(this.panelLocator)) ?? null;
+    return (await this.interactor.getText(this.panelLocator)) ?? undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/BreadcrumbDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/BreadcrumbDriver.ts
@@ -47,8 +47,8 @@ export class BreadcrumbDriver extends ComponentDriver<{}> {
     return labels;
   }
 
-  /** The item at the given zero-based index, or `null` when out of range. */
-  async getItemByIndex(index: number): Promise<BreadcrumbItemDriver | null> {
+  /** The item at the given zero-based index, or `undefined` when out of range. */
+  async getItemByIndex(index: number): Promise<Optional<BreadcrumbItemDriver>> {
     let position = 0;
     for await (const item of this.iterateItems()) {
       if (position === index) {
@@ -56,27 +56,27 @@ export class BreadcrumbDriver extends ComponentDriver<{}> {
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
-  /** The first item whose visible label equals `label`, or `null` when absent. */
-  async getItemByLabel(label: string): Promise<BreadcrumbItemDriver | null> {
+  /** The first item whose visible label equals `label`, or `undefined` when absent. */
+  async getItemByLabel(label: string): Promise<Optional<BreadcrumbItemDriver>> {
     for await (const item of this.iterateItems()) {
       if ((await item.getLabel()) === label) {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
-  /** The item marked as the current page (`aria-current="page"`), or `null` when none is. */
-  async getCurrentItem(): Promise<BreadcrumbItemDriver | null> {
+  /** The item marked as the current page (`aria-current="page"`), or `undefined` when none is. */
+  async getCurrentItem(): Promise<Optional<BreadcrumbItemDriver>> {
     for await (const item of this.iterateItems()) {
       if (await item.isCurrent()) {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/CarouselDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/CarouselDriver.ts
@@ -128,7 +128,7 @@ export class CarouselDriver<ItemT extends CarouselCardDriver = CarouselCardDrive
   }
 
   /**
-   * The `CarouselNav` this carousel renders, or `null` when it has none.
+   * The `CarouselNav` this carousel renders, or `undefined` when it has none.
    * Container existence is portable; its item surface is E2E-only — see
    * {@link CarouselNavDriver}'s class doc.
    *
@@ -141,11 +141,11 @@ export class CarouselDriver<ItemT extends CarouselCardDriver = CarouselCardDrive
    * race, not a jsdom-only approximation issue (see class doc's jsdom
    * caveat, which is a separate, permanent gap).
    */
-  async getNav(): Promise<CarouselNavDriver | null> {
+  async getNav(): Promise<Optional<CarouselNavDriver>> {
     const resolvedNavLocator = locatorUtil.append(this.locator, navLocator);
     const exists = await this.interactor.exists(resolvedNavLocator);
     if (!exists) {
-      return null;
+      return undefined;
     }
     await this.interactor.waitUntil({
       probeFn: () => this.interactor.getElementCount(locatorUtil.append(resolvedNavLocator, navButtonLocator)),

--- a/packages/component-driver-fluent-v9/src/components/ComboboxDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/ComboboxDriver.ts
@@ -1,5 +1,5 @@
 import { HTMLTextInputDriver } from '@atomic-testing/component-driver-html';
-import { byLinkedElement, childListHelper, ComponentDriver, PartLocator } from '@atomic-testing/core';
+import { byLinkedElement, childListHelper, ComponentDriver, PartLocator, Optional } from '@atomic-testing/core';
 
 import { MenuItemNotFoundError } from '../errors/MenuItemNotFoundError';
 import { ComboboxOptionDriver } from './ComboboxOptionDriver';
@@ -145,18 +145,18 @@ export class ComboboxDriver extends HTMLTextInputDriver {
   }
 
   /**
-   * The option whose visible label matches `label`, or `null` when absent
+   * The option whose visible label matches `label`, or `undefined` when absent
    * (e.g. no option has that text, or the listbox is empty). Opens the
    * listbox first — Fluent only mounts options while open.
    */
-  async getOptionByLabel(label: string): Promise<ComboboxOptionDriver | null> {
+  async getOptionByLabel(label: string): Promise<Optional<ComboboxOptionDriver>> {
     await this.open();
     for await (const option of this.iterateOptions()) {
       if ((await option.getLabel()) === label) {
         return option;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/DataGridDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/DataGridDriver.ts
@@ -87,11 +87,11 @@ export class DataGridDriver<ItemT extends DataGridRowDriver = DataGridRowDriver>
     return this.getItemByIndex(index);
   }
 
-  /** The header row as a {@link DataGridHeaderRowDriver}, or `null` when the grid has no header (`DataGridHeader` wasn't rendered). */
-  async getHeaderRow(): Promise<DataGridHeaderRowDriver | null> {
+  /** The header row as a {@link DataGridHeaderRowDriver}, or `undefined` when the grid has no header (`DataGridHeader` wasn't rendered). */
+  async getHeaderRow(): Promise<Optional<DataGridHeaderRowDriver>> {
     const locator = locatorUtil.append(this.locator, headerRowLocator);
     if (!(await this.interactor.exists(locator))) {
-      return null;
+      return undefined;
     }
     return new DataGridHeaderRowDriver(locator, this.interactor, this.commutableOption);
   }

--- a/packages/component-driver-fluent-v9/src/components/DataGridRowDriverBase.ts
+++ b/packages/component-driver-fluent-v9/src/components/DataGridRowDriverBase.ts
@@ -1,4 +1,4 @@
-import { childListHelper, ComponentDriver, ComponentDriverCtor } from '@atomic-testing/core';
+import { childListHelper, ComponentDriver, ComponentDriverCtor, Optional } from '@atomic-testing/core';
 
 /**
  * Shared cell-iteration surface for the Fluent v9 `DataGrid` row family —
@@ -45,8 +45,8 @@ export abstract class DataGridRowDriverBase<ItemT extends ComponentDriver> exten
     return childListHelper.countMatchingChildren(this.interactor, this.locator, this.getCellSelector());
   }
 
-  /** The cell driver at the given zero-based column index, or `null` when out of range. */
-  async getCell(index: number): Promise<ItemT | null> {
+  /** The cell driver at the given zero-based column index, or `undefined` when out of range. */
+  async getCell(index: number): Promise<Optional<ItemT>> {
     let position = 0;
     for await (const cell of childListHelper.iterateMatchingChildren(
       this,
@@ -59,7 +59,7 @@ export abstract class DataGridRowDriverBase<ItemT extends ComponentDriver> exten
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
   /** The text of every cell, in column order. */

--- a/packages/component-driver-fluent-v9/src/components/DialogDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/DialogDriver.ts
@@ -75,13 +75,13 @@ export class DialogDriver extends ComponentDriver<typeof dialogParts> {
     return 'Same';
   }
 
-  /** The dialog's title text, or `null` when `DialogTitle` is absent. */
-  async getTitle(): Promise<string | null> {
+  /** The dialog's title text, or `undefined` when `DialogTitle` is absent. */
+  async getTitle(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.title.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.title.getText()) ?? null;
+    return (await this.parts.title.getText()) ?? undefined;
   }
 
   /** Whether this dialog is modal (`aria-modal="true"`) or non-modal (`"false"`). */

--- a/packages/component-driver-fluent-v9/src/components/DrawerDriverBase.ts
+++ b/packages/component-driver-fluent-v9/src/components/DrawerDriverBase.ts
@@ -6,6 +6,7 @@ import {
   Interactor,
   PartLocator,
   ScenePart,
+  Optional,
 } from '@atomic-testing/core';
 
 export const drawerParts = {
@@ -44,22 +45,22 @@ export abstract class DrawerDriverBase extends ComponentDriver<typeof drawerPart
     });
   }
 
-  /** The drawer header's title text, or `null` when `DrawerHeaderTitle` is absent. */
-  async getHeaderTitle(): Promise<string | null> {
+  /** The drawer header's title text, or `undefined` when `DrawerHeaderTitle` is absent. */
+  async getHeaderTitle(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.headerTitle.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.headerTitle.getText()) ?? null;
+    return (await this.parts.headerTitle.getText()) ?? undefined;
   }
 
-  /** The drawer body's text content, or `null` when `DrawerBody` is absent. */
-  async getBodyText(): Promise<string | null> {
+  /** The drawer body's text content, or `undefined` when `DrawerBody` is absent. */
+  async getBodyText(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.body.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.body.getText()) ?? null;
+    return (await this.parts.body.getText()) ?? undefined;
   }
 
   /** Whether the drawer is mounted. Fluent mounts a drawer's root only while open. */

--- a/packages/component-driver-fluent-v9/src/components/DropdownDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/DropdownDriver.ts
@@ -30,7 +30,7 @@ const optionSelector = '[role="option"]';
  * `FluentProvider` on `document.body` (the same recipe every Wave 2 overlay
  * uses). Every method that reads the option list — {@link getOptionCount},
  * {@link getOptionLabels}, {@link getOptionByLabel} — guards the listbox
- * resolution and simply returns the empty result (`0`/`[]`/`null`) while the
+ * resolution and simply returns the empty result (`0`/`[]`/`undefined`) while the
  * dropdown is closed, rather than requiring a prior {@link open} call; only
  * {@link selectByLabel} throws when closed, since no option can ever match
  * with nothing mounted to search.
@@ -134,14 +134,14 @@ export class DropdownDriver extends ComponentDriver<{}> implements IDisableableD
     return labels.filter((label): label is string => label != null);
   }
 
-  /** The option whose visible label matches `label`, or `null` when absent (or while closed). */
-  async getOptionByLabel(label: string): Promise<DropdownOptionDriver | null> {
+  /** The option whose visible label matches `label`, or `undefined` when absent (or while closed). */
+  async getOptionByLabel(label: string): Promise<Optional<DropdownOptionDriver>> {
     for (const option of await this.getOptions()) {
       if ((await option.getLabel()) === label) {
         return option;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/FlatTreeDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/FlatTreeDriver.ts
@@ -5,6 +5,7 @@ import {
   ListComponentDriver,
   ListComponentDriverSpecificOption,
   PartLocator,
+  Optional,
 } from '@atomic-testing/core';
 
 import { treeItemChildLocator } from '../internal/treeLocators';
@@ -65,20 +66,20 @@ export class FlatTreeDriver<ItemT extends FlatTreeItemDriver = FlatTreeItemDrive
 
   /**
    * The first item (at ANY level) whose Fluent-stamped `value` (see
-   * {@link FlatTreeItemDriver.getValue}) matches, or `null` when absent —
+   * {@link FlatTreeItemDriver.getValue}) matches, or `undefined` when absent —
    * the natural lookup key for a flat tree: the inherited `getItemByLabel`
    * only matches by visible label text, which a real flat dataset (the
    * scenario `FlatTree` exists for) commonly repeats across branches, while
    * `value` is the app's own stable per-item identifier.
    */
-  async getItemByValue<ItemClass extends ItemT = ItemT>(value: string): Promise<ItemClass | null> {
+  async getItemByValue<ItemClass extends ItemT = ItemT>(value: string): Promise<Optional<ItemClass>> {
     const driverClass = this.getItemClass<ItemClass>();
     for await (const item of listHelper.getListItemIterator(this, this.getItemLocator(), driverClass)) {
       if ((await item.getValue()) === value) {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   override get driverName(): string {

--- a/packages/component-driver-fluent-v9/src/components/MenuDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/MenuDriver.ts
@@ -4,6 +4,7 @@ import {
   IComponentDriverOption,
   Interactor,
   PartLocator,
+  Optional,
 } from '@atomic-testing/core';
 
 import { MenuItemNotFoundError } from '../errors/MenuItemNotFoundError';
@@ -118,8 +119,8 @@ export class MenuDriver extends ComponentDriver<{}> {
     return this.waitForClose(timeoutMs);
   }
 
-  /** The item whose visible label matches `label`, or `null` when absent (matches plain, checkbox, and radio items alike). */
-  async getMenuItemByLabel(label: string): Promise<MenuItemDriver | null> {
+  /** The item whose visible label matches `label`, or `undefined` when absent (matches plain, checkbox, and radio items alike). */
+  async getMenuItemByLabel(label: string): Promise<Optional<MenuItemDriver>> {
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
       this.locator,
@@ -131,7 +132,7 @@ export class MenuDriver extends ComponentDriver<{}> {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   /** Click the item whose visible label matches `label`. @throws {MenuItemNotFoundError} when absent. */
@@ -149,8 +150,8 @@ export class MenuDriver extends ComponentDriver<{}> {
     return childListHelper.countMatchingChildren(this.interactor, this.locator, menuItemSelector);
   }
 
-  /** The item at the given zero-based index, or `null` if out of range. */
-  async getMenuItemByIndex(index: number): Promise<MenuItemDriver | null> {
+  /** The item at the given zero-based index, or `undefined` if out of range. */
+  async getMenuItemByIndex(index: number): Promise<Optional<MenuItemDriver>> {
     let position = 0;
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
@@ -163,11 +164,11 @@ export class MenuDriver extends ComponentDriver<{}> {
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
-  /** The `MenuItemCheckbox` whose visible label matches `label`, or `null` when absent. */
-  async getCheckboxItemByLabel(label: string): Promise<MenuItemCheckboxDriver | null> {
+  /** The `MenuItemCheckbox` whose visible label matches `label`, or `undefined` when absent. */
+  async getCheckboxItemByLabel(label: string): Promise<Optional<MenuItemCheckboxDriver>> {
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
       this.locator,
@@ -178,11 +179,11 @@ export class MenuDriver extends ComponentDriver<{}> {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
-  /** The `MenuItemRadio` whose visible label matches `label`, or `null` when absent. */
-  async getRadioItemByLabel(label: string): Promise<MenuItemRadioDriver | null> {
+  /** The `MenuItemRadio` whose visible label matches `label`, or `undefined` when absent. */
+  async getRadioItemByLabel(label: string): Promise<Optional<MenuItemRadioDriver>> {
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
       this.locator,
@@ -193,7 +194,7 @@ export class MenuDriver extends ComponentDriver<{}> {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-fluent-v9/src/components/NavCategoryItemDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/NavCategoryItemDriver.ts
@@ -1,4 +1,4 @@
-import { byCssSelector, childListHelper, locatorUtil, PartLocator } from '@atomic-testing/core';
+import { byCssSelector, childListHelper, locatorUtil, PartLocator, Optional } from '@atomic-testing/core';
 
 import { NavItemDriver } from './NavItemDriver';
 
@@ -71,10 +71,10 @@ export class NavCategoryItemDriver extends NavItemDriver {
 
   /**
    * The first sub-item (direct `NavSubItem` or nested `NavCategoryItem`)
-   * whose visible label matches `label`, or `null` when absent. Expands
+   * whose visible label matches `label`, or `undefined` when absent. Expands
    * first, per {@link getSubItemCount}.
    */
-  async getSubItemByLabel(label: string): Promise<NavItemDriver | null> {
+  async getSubItemByLabel(label: string): Promise<Optional<NavItemDriver>> {
     await this.expand();
     try {
       for await (const item of childListHelper.iterateMatchingChildren(
@@ -90,7 +90,7 @@ export class NavCategoryItemDriver extends NavItemDriver {
     } catch {
       // Not currently mounted even after a best-effort expand — no sub-items reachable.
     }
-    return null;
+    return undefined;
   }
 
   private async setExpanded(expanded: boolean, timeoutMs: number): Promise<void> {

--- a/packages/component-driver-fluent-v9/src/components/NavDriverBase.ts
+++ b/packages/component-driver-fluent-v9/src/components/NavDriverBase.ts
@@ -1,4 +1,4 @@
-import { ComponentDriver } from '@atomic-testing/core';
+import { ComponentDriver, Optional } from '@atomic-testing/core';
 
 import { NavItemNotFoundError } from '../errors/NavItemNotFoundError';
 import * as navLocators from '../internal/navLocators';
@@ -31,22 +31,22 @@ export abstract class NavDriverBase extends ComponentDriver<{}> {
     return labels;
   }
 
-  /** The first item (leaf or category trigger) whose visible label matches `label`, or `null` when absent. */
-  async getItemByLabel(label: string): Promise<NavItemDriver | null> {
+  /** The first item (leaf or category trigger) whose visible label matches `label`, or `undefined` when absent. */
+  async getItemByLabel(label: string): Promise<Optional<NavItemDriver>> {
     return navLocators.getNavItemByLabel(this, this.locator, label);
   }
 
   /**
    * The first `NavCategoryItem` whose visible label matches `label`, or
-   * `null` when absent — use this (rather than {@link getItemByLabel}) to
+   * `undefined` when absent — use this (rather than {@link getItemByLabel}) to
    * reach the expand/collapse-capable driver. See {@link NavCategoryItemDriver}.
    */
-  async getCategoryByLabel(label: string): Promise<NavCategoryItemDriver | null> {
+  async getCategoryByLabel(label: string): Promise<Optional<NavCategoryItemDriver>> {
     return navLocators.getNavCategoryByLabel(this, this.locator, label);
   }
 
-  /** The label of the currently selected item, or `null` when none is selected. */
-  async getSelectedLabel(): Promise<string | null> {
+  /** The label of the currently selected item, or `undefined` when none is selected. */
+  async getSelectedLabel(): Promise<Optional<string>> {
     return navLocators.getSelectedNavItemLabel(this, this.locator);
   }
 

--- a/packages/component-driver-fluent-v9/src/components/OverflowDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/OverflowDriver.ts
@@ -1,4 +1,11 @@
-import { byCssSelector, childListHelper, ComponentDriver, locatorUtil, PartLocator } from '@atomic-testing/core';
+import {
+  byCssSelector,
+  childListHelper,
+  ComponentDriver,
+  locatorUtil,
+  PartLocator,
+  Optional,
+} from '@atomic-testing/core';
 
 import { MenuDriver } from './MenuDriver';
 import { OverflowItemDriver } from './OverflowItemDriver';
@@ -48,14 +55,14 @@ export class OverflowDriver extends ComponentDriver<{}> {
     return labels;
   }
 
-  /** The first registered item whose visible label matches `label`, or `null` when absent. */
-  async getItemByLabel(label: string): Promise<OverflowItemDriver | null> {
+  /** The first registered item whose visible label matches `label`, or `undefined` when absent. */
+  async getItemByLabel(label: string): Promise<Optional<OverflowItemDriver>> {
     for await (const item of this.iterateItems()) {
       if ((await item.getLabel()) === label) {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   /** The visible labels of items currently overflowed (hidden behind the "+N" trigger). */

--- a/packages/component-driver-fluent-v9/src/components/RadioDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/RadioDriver.ts
@@ -1,4 +1,4 @@
-import { ComponentDriver, IDisableableDriver, IToggleDriver, Optional } from '@atomic-testing/core';
+import { ComponentDriver, IDisableableDriver, IToggleDriver, Optional, Nullable } from '@atomic-testing/core';
 
 import { resolveLinkedLabelText } from '../internal/linkedLocators';
 
@@ -50,7 +50,7 @@ export class RadioDriver extends ComponentDriver<{}> implements IToggleDriver, I
   }
 
   /** The `value` this radio represents (native `value` attribute). */
-  async getValue(): Promise<string | null> {
+  async getValue(): Promise<Nullable<string>> {
     return (await this.interactor.getAttribute(this.locator, 'value')) ?? null;
   }
 

--- a/packages/component-driver-fluent-v9/src/components/RatingDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/RatingDriver.ts
@@ -7,6 +7,7 @@ import {
   IInputDriver,
   locatorUtil,
   PartLocator,
+  Nullable,
 } from '@atomic-testing/core';
 
 /**
@@ -64,7 +65,7 @@ export class RatingDriver extends ComponentDriver<{}> implements IInputDriver<nu
   }
 
   /** The currently selected value, or `null` when no item is selected ("no rating"). */
-  async getValue(): Promise<number | null> {
+  async getValue(): Promise<Nullable<number>> {
     const value = await this.interactor.getAttribute(this.checkedInputLocator, 'value');
     return value == null ? null : Number.parseFloat(value);
   }

--- a/packages/component-driver-fluent-v9/src/components/SwatchPickerDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/SwatchPickerDriver.ts
@@ -35,8 +35,8 @@ export class SwatchPickerDriver extends ComponentDriver<{}> {
     return childListHelper.countMatchingChildren(this.interactor, this.locator, swatchSelector);
   }
 
-  /** The swatch driver at the given zero-based index, or `null` if out of range. */
-  async getSwatchByIndex(index: number): Promise<SwatchPickerItemDriver | null> {
+  /** The swatch driver at the given zero-based index, or `undefined` if out of range. */
+  async getSwatchByIndex(index: number): Promise<Optional<SwatchPickerItemDriver>> {
     let position = 0;
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
@@ -49,7 +49,7 @@ export class SwatchPickerDriver extends ComponentDriver<{}> {
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
   /** The rendered color of every swatch, in DOM order (see {@link SwatchPickerItemDriver.getColor}). */

--- a/packages/component-driver-fluent-v9/src/components/TabListDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TabListDriver.ts
@@ -5,8 +5,8 @@ import {
   ListComponentDriver,
   ListComponentDriverSpecificOption,
   listHelper,
-  Nullable,
   PartLocator,
+  Optional,
 } from '@atomic-testing/core';
 
 import { TabDriver } from './TabDriver';
@@ -84,24 +84,24 @@ export class TabListDriver<ItemT extends TabDriver = TabDriver> extends ListComp
     return -1;
   }
 
-  /** Label of the selected tab, or `null` when no tab is selected. */
-  async getSelectedLabel(): Promise<Nullable<string>> {
+  /** Label of the selected tab, or `undefined` when no tab is selected. */
+  async getSelectedLabel(): Promise<Optional<string>> {
     for await (const tab of listHelper.getListItemIterator(this, this.getItemLocator(), this.getItemClass())) {
       if (await tab.isSelected()) {
-        return (await tab.getText())?.trim() ?? null;
+        return (await tab.getText())?.trim() ?? undefined;
       }
     }
-    return null;
+    return undefined;
   }
 
-  /** The `value` of the selected tab (see {@link TabDriver.getValue}), or `null` when no tab is selected. */
-  async getSelectedValue(): Promise<Nullable<string>> {
+  /** The `value` of the selected tab (see {@link TabDriver.getValue}), or `undefined` when no tab is selected. */
+  async getSelectedValue(): Promise<Optional<string>> {
     for await (const tab of listHelper.getListItemIterator(this, this.getItemLocator(), this.getItemClass())) {
       if (await tab.isSelected()) {
-        return (await tab.getValue()) ?? null;
+        return (await tab.getValue()) ?? undefined;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/TableDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TableDriver.ts
@@ -72,11 +72,11 @@ export class TableDriver<ItemT extends TableRowDriver = TableRowDriver> extends 
     return this.getItemByIndex(index);
   }
 
-  /** The header row as a {@link TableHeaderRowDriver}, or `null` when the table has no header. */
-  async getHeaderRow(): Promise<TableHeaderRowDriver | null> {
+  /** The header row as a {@link TableHeaderRowDriver}, or `undefined` when the table has no header. */
+  async getHeaderRow(): Promise<Optional<TableHeaderRowDriver>> {
     const locator = locatorUtil.append(this.locator, headerRowLocator);
     if (!(await this.interactor.exists(locator))) {
-      return null;
+      return undefined;
     }
     return new TableHeaderRowDriver(locator, this.interactor, this.commutableOption);
   }

--- a/packages/component-driver-fluent-v9/src/components/TagGroupDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TagGroupDriver.ts
@@ -80,8 +80,8 @@ export class TagGroupDriver extends ComponentDriver<{}> implements IDisableableD
     return labels;
   }
 
-  /** The tag at the given zero-based index, or `null` when out of range. Returns whichever concrete driver matches that position. */
-  async getTagByIndex(index: number): Promise<TagDriver | InteractionTagDriver | null> {
+  /** The tag at the given zero-based index, or `undefined` when out of range. Returns whichever concrete driver matches that position. */
+  async getTagByIndex(index: number): Promise<Optional<TagDriver | InteractionTagDriver>> {
     let position = 0;
     for await (const tag of this.iterateTags()) {
       if (position === index) {
@@ -89,7 +89,7 @@ export class TagGroupDriver extends ComponentDriver<{}> implements IDisableableD
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
   /** Walk direct children positionally, yielding a {@link TagDriver} or {@link InteractionTagDriver} per matching child. */

--- a/packages/component-driver-fluent-v9/src/components/TagPickerDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TagPickerDriver.ts
@@ -136,11 +136,16 @@ export class TagPickerDriver
   }
 
   /**
-   * The freeform input's current filter text (a native `<input>`'s own
-   * `.value`, so genuinely empty reads back as `''`, never `undefined` in
-   * practice — `undefined` is only the theoretical "locator matched nothing" case,
-   * mirroring `HTMLTextInputDriver.getValue`'s identical `string | null`
-   * contract and `ComboboxDriver.getValue`'s own observed `''` default).
+   * The freeform input's current filter text (a native `<input>`'s own `.value`,
+   * so genuinely empty reads back as `''`, never absent in practice — absence is
+   * only the theoretical "locator matched nothing" case, the same `''` default
+   * `ComboboxDriver.getValue` shows).
+   *
+   * That "matched nothing" reading is why this is `Optional` per ADR-006 §7, and
+   * it is a deliberate divergence from `HTMLTextInputDriver.getValue`, which still
+   * answers `null`. The html field drivers are outside this package and stay on
+   * the form-value spelling; converting them would change the frozen surface of
+   * `component-driver-html` and belongs to that decision, not this one.
    */
   async getFilterText(): Promise<Optional<string>> {
     const value = await this.interactor.getInputValue(this.inputLocator);

--- a/packages/component-driver-fluent-v9/src/components/TagPickerDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TagPickerDriver.ts
@@ -10,6 +10,7 @@ import {
   IValidatableDriver,
   locatorUtil,
   PartLocator,
+  Optional,
 } from '@atomic-testing/core';
 
 import { TagPickerOptionNotFoundError } from '../errors/TagPickerOptionNotFoundError';
@@ -136,14 +137,14 @@ export class TagPickerDriver
 
   /**
    * The freeform input's current filter text (a native `<input>`'s own
-   * `.value`, so genuinely empty reads back as `''`, never `null` in
-   * practice — `null` is only the theoretical "locator matched nothing" case,
+   * `.value`, so genuinely empty reads back as `''`, never `undefined` in
+   * practice — `undefined` is only the theoretical "locator matched nothing" case,
    * mirroring `HTMLTextInputDriver.getValue`'s identical `string | null`
    * contract and `ComboboxDriver.getValue`'s own observed `''` default).
    */
-  async getFilterText(): Promise<string | null> {
+  async getFilterText(): Promise<Optional<string>> {
     const value = await this.interactor.getInputValue(this.inputLocator);
-    return value ?? null;
+    return value ?? undefined;
   }
 
   /** Replace the freeform input's filter text. */
@@ -204,17 +205,17 @@ export class TagPickerDriver
 
   /**
    * The option whose visible label matches `label` — opens the list first if
-   * not already open (see class doc); `null` when no option matches, or when
+   * not already open (see class doc); `undefined` when no option matches, or when
    * the listbox still can't be resolved after that best-effort open, not
    * merely because the picker started closed.
    */
-  async getOptionByLabel(label: string): Promise<TagPickerOptionDriver | null> {
+  async getOptionByLabel(label: string): Promise<Optional<TagPickerOptionDriver>> {
     for await (const option of this.iterateOptions()) {
       if ((await option.getLabel()) === label) {
         return option;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/components/TeachingPopoverDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/TeachingPopoverDriver.ts
@@ -70,31 +70,31 @@ export class TeachingPopoverDriver extends ComponentDriver<typeof teachingPopove
     return 'Same';
   }
 
-  /** The header's text (icon excluded — it renders no text node), or `null` when `TeachingPopoverHeader` is absent. */
-  async getHeaderText(): Promise<string | null> {
+  /** The header's text (icon excluded — it renders no text node), or `undefined` when `TeachingPopoverHeader` is absent. */
+  async getHeaderText(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.header.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.header.getText()) ?? null;
+    return (await this.parts.header.getText()) ?? undefined;
   }
 
-  /** The popover's title text, or `null` when `TeachingPopoverTitle` is absent. */
-  async getTitle(): Promise<string | null> {
+  /** The popover's title text, or `undefined` when `TeachingPopoverTitle` is absent. */
+  async getTitle(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.title.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.title.getText()) ?? null;
+    return (await this.parts.title.getText()) ?? undefined;
   }
 
-  /** The popover's body text, or `null` when `TeachingPopoverBody` is absent. */
-  async getBodyText(): Promise<string | null> {
+  /** The popover's body text, or `undefined` when `TeachingPopoverBody` is absent. */
+  async getBodyText(): Promise<Optional<string>> {
     const exists = await this.interactor.exists(this.parts.body.locator);
     if (!exists) {
-      return null;
+      return undefined;
     }
-    return (await this.parts.body.getText()) ?? null;
+    return (await this.parts.body.getText()) ?? undefined;
   }
 
   /** Whether the popover's surface is mounted. */

--- a/packages/component-driver-fluent-v9/src/components/ToastDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/ToastDriver.ts
@@ -1,4 +1,11 @@
-import { byCssClass, ComponentDriver, IComponentDriverOption, Interactor, PartLocator } from '@atomic-testing/core';
+import {
+  byCssClass,
+  ComponentDriver,
+  IComponentDriverOption,
+  Interactor,
+  PartLocator,
+  Optional,
+} from '@atomic-testing/core';
 
 import { readOptionalDescendantText } from '../internal/optionalText';
 
@@ -39,14 +46,14 @@ export class ToastDriver extends ComponentDriver<{}> {
     });
   }
 
-  /** The toast's title text, or `null` when `ToastTitle` is absent. */
-  async getTitle(): Promise<string | null> {
-    return (await readOptionalDescendantText(this.interactor, this.locator, titleLocator)) ?? null;
+  /** The toast's title text, or `undefined` when `ToastTitle` is absent. */
+  async getTitle(): Promise<Optional<string>> {
+    return (await readOptionalDescendantText(this.interactor, this.locator, titleLocator)) ?? undefined;
   }
 
-  /** The toast's body text, or `null` when `ToastBody` is absent. */
-  async getBodyText(): Promise<string | null> {
-    return (await readOptionalDescendantText(this.interactor, this.locator, bodyLocator)) ?? null;
+  /** The toast's body text, or `undefined` when `ToastBody` is absent. */
+  async getBodyText(): Promise<Optional<string>> {
+    return (await readOptionalDescendantText(this.interactor, this.locator, bodyLocator)) ?? undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-fluent-v9/src/components/ToasterDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/ToasterDriver.ts
@@ -59,8 +59,8 @@ export class ToasterDriver extends ComponentDriver<{}> {
     );
   }
 
-  /** The toast at the given zero-based index (in display order), or `null` if out of range. */
-  async getToastByIndex(index: number): Promise<ToastDriver | null> {
+  /** The toast at the given zero-based index (in display order), or `undefined` if out of range. */
+  async getToastByIndex(index: number): Promise<Optional<ToastDriver>> {
     let position = 0;
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
@@ -74,11 +74,11 @@ export class ToasterDriver extends ComponentDriver<{}> {
       }
       position++;
     }
-    return null;
+    return undefined;
   }
 
-  /** The first toast whose title matches `title`, or `null` when absent. */
-  async getToastByTitle(title: string): Promise<ToastDriver | null> {
+  /** The first toast whose title matches `title`, or `undefined` when absent. */
+  async getToastByTitle(title: string): Promise<Optional<ToastDriver>> {
     for await (const item of childListHelper.iterateMatchingChildren(
       this,
       this.locator,
@@ -90,7 +90,7 @@ export class ToasterDriver extends ComponentDriver<{}> {
         return item;
       }
     }
-    return null;
+    return undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-fluent-v9/src/components/ToolbarDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/ToolbarDriver.ts
@@ -1,4 +1,4 @@
-import { childListHelper, ComponentDriver } from '@atomic-testing/core';
+import { childListHelper, ComponentDriver, Optional } from '@atomic-testing/core';
 
 import { ToolbarButtonDriver } from './ToolbarButtonDriver';
 
@@ -49,9 +49,9 @@ export class ToolbarDriver extends ComponentDriver<{}> {
 
   /**
    * The first button (of any kind — see class doc) whose visible label
-   * matches `label`, or `null` when absent.
+   * matches `label`, or `undefined` when absent.
    */
-  async getButtonByLabel(label: string): Promise<ToolbarButtonDriver | null> {
+  async getButtonByLabel(label: string): Promise<Optional<ToolbarButtonDriver>> {
     for await (const button of childListHelper.iterateMatchingChildren(
       this,
       this.locator,
@@ -64,7 +64,7 @@ export class ToolbarDriver extends ComponentDriver<{}> {
         return button;
       }
     }
-    return null;
+    return undefined;
   }
 
   get driverName(): string {

--- a/packages/component-driver-fluent-v9/src/components/ToolbarRadioGroupDriver.ts
+++ b/packages/component-driver-fluent-v9/src/components/ToolbarRadioGroupDriver.ts
@@ -5,8 +5,8 @@ import {
   ListComponentDriver,
   ListComponentDriverSpecificOption,
   listHelper,
-  Nullable,
   PartLocator,
+  Optional,
 } from '@atomic-testing/core';
 
 import { ToolbarRadioButtonDriver } from './ToolbarRadioButtonDriver';
@@ -64,14 +64,14 @@ export class ToolbarRadioGroupDriver<
     return labels;
   }
 
-  /** Label of the selected option, or `null` when none is selected. */
-  async getSelectedLabel(): Promise<Nullable<string>> {
+  /** Label of the selected option, or `undefined` when none is selected. */
+  async getSelectedLabel(): Promise<Optional<string>> {
     for await (const item of listHelper.getListItemIterator(this, this.getItemLocator(), this.getItemClass())) {
       if (await item.isSelected()) {
-        return (await item.getText())?.trim() ?? null;
+        return (await item.getText())?.trim() ?? undefined;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/packages/component-driver-fluent-v9/src/internal/navLocators.ts
+++ b/packages/component-driver-fluent-v9/src/internal/navLocators.ts
@@ -1,4 +1,4 @@
-import { childListHelper, ComponentDriver, Interactor, PartLocator } from '@atomic-testing/core';
+import { childListHelper, ComponentDriver, Interactor, PartLocator, Optional } from '@atomic-testing/core';
 
 import { NavCategoryItemDriver } from '../components/NavCategoryItemDriver';
 import { NavItemDriver } from '../components/NavItemDriver';
@@ -46,43 +46,43 @@ export function iterateNavCategoryItems(
   );
 }
 
-/** The first item (of any kind) whose visible label matches `label`, or `null` when absent. */
+/** The first item (of any kind) whose visible label matches `label`, or `undefined` when absent. */
 export async function getNavItemByLabel(
   host: ComponentDriver,
   containerLocator: PartLocator,
   label: string
-): Promise<NavItemDriver | null> {
+): Promise<Optional<NavItemDriver>> {
   for await (const item of iterateNavItems(host, containerLocator)) {
     if ((await item.getLabel()) === label) {
       return item;
     }
   }
-  return null;
+  return undefined;
 }
 
-/** The first `NavCategoryItem` whose visible label matches `label`, or `null` when absent. */
+/** The first `NavCategoryItem` whose visible label matches `label`, or `undefined` when absent. */
 export async function getNavCategoryByLabel(
   host: ComponentDriver,
   containerLocator: PartLocator,
   label: string
-): Promise<NavCategoryItemDriver | null> {
+): Promise<Optional<NavCategoryItemDriver>> {
   for await (const item of iterateNavCategoryItems(host, containerLocator)) {
     if ((await item.getLabel()) === label) {
       return item;
     }
   }
-  return null;
+  return undefined;
 }
 
-/** The label of the selected item (`aria-current="page"`), or `null` when none is selected. */
+/** The label of the selected item (`aria-current="page"`), or `undefined` when none is selected. */
 export async function getSelectedNavItemLabel(
   host: ComponentDriver,
   containerLocator: PartLocator
-): Promise<string | null> {
+): Promise<Optional<string>> {
   for await (const item of iterateNavItems(host, containerLocator)) {
     if (await item.isSelected()) {
-      return (await item.getLabel()) ?? null;
+      return (await item.getLabel()) ?? undefined;
     }
   }
-  return null;
+  return undefined;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1304, and **stacked on it** — base is `claude/library-1-0-readiness-u861ca`, so GitHub will retarget this to `main` once that merges. Review #1304 first; the diff here is only the fluent-v9 commit.

Converting the core list lookups to `Optional` in #1304 left this package speaking both dialects at once:

```ts
TableRowDriverBase.getCell(index)     // delegates to core  → undefined
DataGridRowDriverBase.getCell(index)  // hand-rolled loop    → null
```

Two cell reads, same shape, different answer for "no such cell" — and nothing at the call site tells you which one you're holding. That is precisely the footgun ADR-006 §7 exists to remove (`if (x === undefined)` silently always-false), reproduced one layer down.

### What changed

Every lookup answering **"which item?"** now returns `Optional`: the breadcrumb, combobox, dropdown, menu, nav, overflow, swatch-picker, tag-group, tag-picker, toaster and toolbar lookups; both `getHeaderRow`s; `getCell`, `getNav`, `getCurrentItem`, `getItemByValue`; and the text reads that were only ever coercing an absent element to `null` — `getTitle`, `getBodyText`, `getPanelText`, `getHeaderTitle`, `getHeaderText`, `getFilterText`, `getSelectedLabel`. Several of those were literally `(await …) ?? null`, converting an `Optional` to a `null` for no reason.

**Two reads deliberately keep `null`**, and now say so as `Nullable<T>` rather than a bare `| null`:

| Read | Why it stays null |
|---|---|
| `RadioDriver.getValue` | an unset radio genuinely holds a null `value` — data, not a lookup miss |
| `RatingDriver.getValue` | same, via the checked input's `value` |

`CheckboxDriver` inherits `HTMLCheckboxDriver`'s form-value contract from `component-driver-html`, which #1304 deliberately left on `null`, so it is unchanged too. The one test I over-converted while sweeping — `reads the value attribute (null when unset)` — is reverted, and it is worth noting the test caught it rather than a reviewer.

ADR-006 §7 gains a short note that the driver packages follow this rule as well — not because they are frozen (§1 explicitly puts them outside), but because a package mixing both spellings makes the distinction meaningless.

### Why this is a separate PR

`component-driver-fluent-v9` is outside the 1.0 freeze, so none of this is tag-blocking, and none of it is `breaking-if-deferred` the way #1304's items are. It is a consistency change with a 39-file diff that would have obscured the six audit items in that PR.

## Checks

- [x] `pnpm run check:type` — repo-wide
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm test:dom` (relevant packages) — fluent-v9 **279 passing across 54 suites**
- [ ] `pnpm test:e2e` (relevant packages, all three browsers) — **not run locally**: this environment's proxy blocks Playwright's browser CDN, so only chromium is installable. Left to the e2e tier.

Also run: `check:api` (unchanged — fluent-v9 is not in the frozen set, so no report moves).

## Breaking change

- [ ] This PR introduces a breaking change (title uses `!`, e.g. `feat(core)!: ...`)

Not marked breaking: `component-driver-fluent-v9` sits outside the ADR-006 §1 frozen surface and is governed by the per-major driver policy. It *is* a behavioral change for anyone comparing these reads against `null` — called out here so it lands in the changelog copy rather than surprising someone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A)_