### PR TITLE
chore(release): 0.101.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,44 +38,25 @@ env:
   NPM_VERSION: '11.19.0'
 
 jobs:
-  # The release path publishes whatever the tag points at, with no gate of its
-  # own — a red main reaches npm silently. This runs the full e2e matrix
-  # against the tagged tree first, and `publish` needs it, so a browser-only
-  # regression blocks the release instead of shipping in it.
-  e2e-gate:
-    uses: ./.github/workflows/e2e.yml
-    permissions:
-      contents: read
-    with:
-      scope: full
-
-  # The same verification a pull request gets, against the tagged tree. Reused
-  # rather than reimplemented: a copy would drift, and the whole point is that
-  # what ships passed exactly what main passes. Runs beside `e2e-gate`, so it
-  # costs no extra wall clock.
-  verify:
-    uses: ./.github/workflows/buildui.yml
-    permissions:
-      contents: read
-      id-token: write
-
-  publish:
-    needs: [e2e-gate, verify]
+  # Everything the tagged checkout can answer on its own, before anything
+  # expensive starts. Whether the tag, the manifests and the changelog agree is
+  # decidable in seconds from the tree alone, so it must not sit downstream of
+  # the gates: when v0.101.0 was tagged without its release PR, this check was
+  # correct but only spoke after 88 jobs and ~25 minutes of e2e. A precondition
+  # that costs more to evaluate than the thing it guards is a precondition in
+  # name only.
+  preflight:
     runs-on: ubuntu-latest
     permissions:
-      contents: read # read the tagged source
-      id-token: write # npm Trusted Publishing (OIDC)
+      contents: read
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
-          # No repository-write credential is persisted in this job. `./publish.sh`
-          # builds all packages — arbitrary third-party build tooling — and then
-          # publishes, so any code able to read this job's filesystem would
-          # otherwise reach a credential that can write to the repository.
+          # Shallow: this job only reads the working tree. `publish` still takes
+          # full history for the build.
           persist-credentials: false
 
       - name: Resolve and validate version
@@ -103,14 +84,14 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Determined version: $VERSION"
 
-      # This replaces bumping the versions here. The bump now lands in a reviewed
-      # release PR, so the tagged commit already carries the versions being
-      # published — which is what makes the tag reproducible. Previously the bump
-      # was applied inside this runner and pushed to main only AFTER publishing,
-      # so `git checkout vX.Y.Z && ./publish.sh --build-only` rebuilt the
-      # PREVIOUS version's manifests, and no commit in history ever had both the
-      # tag and the version it published. Asserting here rather than trusting the
-      # tag keeps that guarantee enforced instead of conventional.
+      # The bump lands in a reviewed release PR, so the tagged commit already
+      # carries the versions being published — which is what makes the tag
+      # reproducible. Previously the bump was applied inside the publish runner
+      # and pushed to main only AFTER publishing, so `git checkout vX.Y.Z &&
+      # ./publish.sh --build-only` rebuilt the PREVIOUS version's manifests, and
+      # no commit in history ever had both the tag and the version it published.
+      # Asserting here rather than trusting the tag keeps that guarantee
+      # enforced instead of conventional.
       - name: Assert the tag matches what it ships
         run: |
           FAILED=0
@@ -139,6 +120,49 @@ jobs:
             exit 1
           fi
           echo "Tag, manifests and changelog all agree on $VERSION."
+
+  # The release path publishes whatever the tag points at, with no gate of its
+  # own — a red main reaches npm silently. This runs the full e2e matrix
+  # against the tagged tree first, and `publish` needs it, so a browser-only
+  # regression blocks the release instead of shipping in it. Gated on
+  # `preflight` so a tag that cannot ship is rejected before the matrix starts.
+  e2e-gate:
+    needs: preflight
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+    with:
+      scope: full
+
+  # The same verification a pull request gets, against the tagged tree. Reused
+  # rather than reimplemented: a copy would drift, and the whole point is that
+  # what ships passed exactly what main passes. Runs beside `e2e-gate`, so it
+  # costs no extra wall clock.
+  verify:
+    needs: preflight
+    uses: ./.github/workflows/buildui.yml
+    permissions:
+      contents: read
+      id-token: write
+
+  publish:
+    needs: [preflight, e2e-gate, verify]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read the tagged source
+      id-token: write # npm Trusted Publishing (OIDC)
+    outputs:
+      version: ${{ needs.preflight.outputs.version }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # No repository-write credential is persisted in this job. `./publish.sh`
+          # builds all packages — arbitrary third-party build tooling — and then
+          # publishes, so any code able to read this job's filesystem would
+          # otherwise reach a credential that can write to the repository.
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/builderui-setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.101.0] - 2026-08-05
+
+### Breaking Changes
+
+- **core:** close 1.0-readiness gaps in timing, state semantics, packaging and release ([#1375](https://github.com/atomic-testing/atomic-testing/issues/1375))
+- **core:** close the breaking-if-deferred 1.0 API gaps and run core's tests ([#1304](https://github.com/atomic-testing/atomic-testing/issues/1304))
+
+### Fixes
+
+- **ci:** assert the tag before the gates, not after them
+- **example:** migrate shadcn workspace's DangerZoneDriver off content API
+- **mui-v7-test:** correct copy-paste name/description/keywords
+- **mui:** drop unused react-18 hard-dependency from mui-v7/mui-v9
+
+### Refactoring
+
+- **fluent-v9:** one absence convention across the package ([#1305](https://github.com/atomic-testing/atomic-testing/issues/1305))
+
+### Documentation
+
+- **mui:** fix stale line-range anchor after react-18 dep removal
+
+### Other
+
+- **e2e:** unblock the e2e tier and gate it in CI ([#1303](https://github.com/atomic-testing/atomic-testing/issues/1303))
+
 ## [0.100.0] - 2026-08-02
 
 ### Breaking Changes

--- a/agent-docs/RELEASING.md
+++ b/agent-docs/RELEASING.md
@@ -27,10 +27,13 @@ X.Y.Z` and `dry_run: true`. It preflights, builds and asks npm to validate
    every tarball, uploading nothing.
 6. Create a GitHub Release with tag `vX.Y.Z`, targeting **the merged release
    commit**.
-7. The publish workflow runs the full PR verification and the full e2e matrix
-   against the tagged tree, asserts that every manifest and the changelog agree
-   with the tag, then publishes via OIDC with provenance. It writes nothing back
-   to the repository.
+7. The publish workflow first runs a **preflight** that asserts every manifest
+   and the changelog agree with the tag. It reads only the checkout, so it
+   answers in seconds and everything else depends on it — a tag that cannot ship
+   is rejected before the matrix starts, not after it. Then the full PR
+   verification and the full e2e matrix run against the tagged tree, and finally
+   it publishes via OIDC with provenance. It writes nothing back to the
+   repository.
 8. Verify: `npm view @atomic-testing/core version` → `X.Y.Z`.
 9. Float the consumers, now that the versions exist on npm:
    `pnpm bumpVersion X.Y.Z --consumers`, regenerate the standalone lockfiles (see

--- a/packages/angular-20/package.json
+++ b/packages/angular-20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-20",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Angular 20 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 20 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-21/package.json
+++ b/packages/angular-21/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-21",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Angular 21 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 21 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-22/package.json
+++ b/packages/angular-22/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-22",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Angular 22 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 22 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-core/package.json
+++ b/packages/angular-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-core",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Shared Angular adapter core for Atomic Testing: AngularInteractor plus the bootstrapApplication-based createTestEngine. Install the per-major package (@atomic-testing/angular-20/-21/-22) instead of depending on this directly.",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v20/package.json
+++ b/packages/component-driver-angular-material-v20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v20",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Angular Material v20",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v21/package.json
+++ b/packages/component-driver-angular-material-v21/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v21",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Angular Material v21",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v22/package.json
+++ b/packages/component-driver-angular-material-v22/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v22",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Angular Material v22",
   "keywords": [
     "angular",

--- a/packages/component-driver-astryx/package.json
+++ b/packages/component-driver-astryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-astryx",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Astryx (@astryxdesign/core)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-fluent-v9/package.json
+++ b/packages/component-driver-fluent-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-fluent-v9",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Fluent UI v9 (\"Fluent 2\") React components (@fluentui/react-components)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "HTML component driver for atomic-testing",
   "keywords": [
     "e2e",

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-v7/package.json
+++ b/packages/component-driver-mui-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v7",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Material-UI v7",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-mui-v9/package.json
+++ b/packages/component-driver-mui-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v9",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Material-UI v9",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-mui-x-v6/package.json
+++ b/packages/component-driver-mui-x-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v6",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v7/package.json
+++ b/packages/component-driver-mui-x-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v7",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V7 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v8/package.json
+++ b/packages/component-driver-mui-x-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v8",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V8 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v9/package.json
+++ b/packages/component-driver-mui-x-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v9",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V9 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-primevue-v4/package.json
+++ b/packages/component-driver-primevue-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-primevue-v4",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for PrimeVue 4 components (Vue 3)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-radix-v1/package.json
+++ b/packages/component-driver-radix-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-radix-v1",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Radix UI primitives (radix-ui v1)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-reka-ui-v2/package.json
+++ b/packages/component-driver-reka-ui-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-reka-ui-v2",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for Reka UI primitives (reka-ui v2, Vue 3)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-shadcn-v1/package.json
+++ b/packages/component-driver-shadcn-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-shadcn-v1",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Component driver for shadcn/ui (re-export of the Radix UI v1 drivers)",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Core library for atomic-testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/create-atomic-testing/package.json
+++ b/packages/create-atomic-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-atomic-testing",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Scaffold Atomic Testing into an existing project — detects your framework, runner and package manager and writes a working, green example test.",
   "keywords": [
     "atomic-testing",

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Core engine for HTML DOM testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/internal-interactor-conformance/package.json
+++ b/packages/internal-interactor-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-interactor-conformance",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Interactor conformance suite (TCK) proving every interactor behaves identically; not for production use",
   "keywords": [],

--- a/packages/internal-mui-x-test-fixture/package.json
+++ b/packages/internal-mui-x-test-fixture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-mui-x-test-fixture",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "license": "MIT",
   "author": "Tianzhen Lin <tangent@usa.net>",

--- a/packages/internal-react-example/package.json
+++ b/packages/internal-react-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-react-example",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Shared example components for package tests",
   "license": "MIT",

--- a/packages/internal-test-runner-jest-adapter/package.json
+++ b/packages/internal-test-runner-jest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-jest-adapter",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Jest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner-playwright-adapter/package.json
+++ b/packages/internal-test-runner-playwright-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-playwright-adapter",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Playwright adapter for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/internal-test-runner-vitest-adapter/package.json
+++ b/packages/internal-test-runner-vitest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-vitest-adapter",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Vitest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner/package.json
+++ b/packages/internal-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "private": true,
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Atomic Testing Playwright Adapter",
   "keywords": [],
   "license": "MIT",

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-18",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-19/package.json
+++ b/packages/react-19/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-19",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-core",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Shared utilities for Atomic Testing React adapters",
   "keywords": [
     "react",

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-legacy",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Adapter for testing React 17 and earlier",
   "keywords": [
     "legacy",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/storybook",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Framework-agnostic Storybook integration for atomic-testing component drivers",
   "keywords": [],
   "license": "MIT",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/vue-3",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "The @atomic-testing/vue-3 package is a Vue 3 test adapter that extends Atomic Testing's component driver pattern to Vue applications. It enables testing Vue components using the same high-level semantic APIs used across React, Playwright, and DOM environments.",
   "keywords": [
     "integration",


### PR DESCRIPTION
## Summary

Unblocks the 0.101.0 release, and fixes the reason the failure was expensive to discover.

**`v0.101.0` was tagged directly on `main`**, where every manifest still read `0.100.0` and the newest changelog section was still `## [0.100.0]`. The publish preflight refused it — correctly. That is the exact condition the new release ritual exists to catch, and it caught it. **Nothing was published**: `npm view @atomic-testing/core version` is still `0.100.0`, and the assertion runs ahead of the build/publish steps, so there is no partial release to clean up. This is a clean re-cut, not a repair.

Two commits, deliberately separate so `git log` reads as the argument:

| Commit | What |
| --- | --- |
| `32d33b1` | `fix(ci)`: move the tag/manifest/changelog assertion into a `preflight` job |
| `616a803` | `chore(release)`: bump 38 manifests to 0.101.0 + generate the changelog section |

### The preflight fix

The assertion lived in `publish`, which declares `needs: [e2e-gate, verify]`. So the failed release ran **88 jobs over ~25 minutes** (12:23:06 → 12:48:38) before reporting a mismatch that is decidable from the checkout alone, in seconds. A precondition that costs more to evaluate than the thing it guards is a precondition in name only.

Version resolution and the assertion now live in a `preflight` job with no `needs`; `e2e-gate` and `verify` depend on it. **What is asserted, and the failure message, are unchanged** — only when it runs. `publish` keeps its `version` output by sourcing it from `preflight`; nothing consumed that output, but removing it would be a gratuitous contract change. `publish.sh` reads each version from the manifests itself and never used the `VERSION` env, so moving the step out of that job leaves it untouched.

### The release commit

No `[skip ci]`, unlike the old in-CI bump commits — running full CI on this exact tree, at the exact version that will be published, is the point of moving the bump into a reviewed PR.

`examples/*` and `docs/` are deliberately untouched; they install the **published** packages, so their specifiers move in a follow-up PR via `bumpVersion --consumers` once 0.101.0 is on the registry (RELEASING.md step 9).

**Please review the generated changelog section** — this is the step where a human sees it before it ships.

## Checks

- [x] `pnpm run check:type`
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [ ] `pnpm test:dom` (relevant packages) — not run; no runtime source changed (38 version fields, a changelog, a workflow, a doc). Full suites run in CI on this PR.
- [ ] `pnpm test:e2e` (relevant packages, all three browsers) — same; the full matrix runs here and again as the release gate.

Also verified:

- [x] `pnpm check:manifests` and `pnpm check:deps-pinning` green
- [x] The preflight assertion **passes** against this tree for `0.101.0` and still **fails** for any other version (checked `0.102.0`: 31 manifest mismatches + changelog mismatch)

## Breaking change

- [ ] This PR introduces a breaking change (title uses `!`)

No API change. `0.101.0` itself ships the breaking changes already merged in #1375 and #1304, which are recorded under **Breaking Changes** in the generated section.

## After merge

1. Re-point `v0.101.0` at the merged release commit (the tag currently points at `f5251fa`, the #1375 merge) — or cut `v0.101.1`. `RELEASING.md` prefers a fresh tag on the reviewed commit.
2. Optional rehearsal: dispatch **Publish Packages on Release** with `dry_run: true`.
3. Verify `npm view @atomic-testing/core version` → `0.101.0`, then do the `--consumers` follow-up.

## Note for the reviewer

Squash-merging collapses both commits under this PR's title. `chore` is in the changelog's `EXCLUDED_TYPES`, so the release commit correctly won't appear in the *next* section — but the `fix(ci)` commit will also vanish from `git log`, even though its entry is already written into the 0.101.0 changelog here. Merging with both commits preserved keeps history matching the changelog. I was restricted to one branch, or these would have been separate PRs.

**Unrelated, found while running the gates:** `pnpm check:style` reformats 9 markdown files that are untouched on `main` (oxfmt now pads table cells). I reverted them rather than sweeping them in. It is invisible to CI because the `Linting and formatting` job runs `oxfmt` with no `--check` and no `git diff --exit-code`, so it rewrites files in the runner and discards them — that job cannot currently fail on formatting. Worth a separate fix; happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A)_