### PR TITLE
fix(packaging): gate the advertised peer ranges instead of declaring them

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -493,6 +493,14 @@ jobs:
       - name: Peer-range coherence check
         run: pnpm check:peer-floors
 
+      # The gates' own detection tests. A check that only ever runs against a
+      # healthy tree proves it executed, not that it can still SEE the defect it
+      # was written for — so each rule carries a fixture reintroducing the
+      # original manifest. Without this step those fixtures would be a
+      # development-time convenience rather than a standing guarantee.
+      - name: Gate detection tests
+        run: pnpm test:scripts
+
       - name: Run unit tests
         run: pnpm test:dom
         working-directory: ./packages/create-atomic-testing

--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -484,6 +484,15 @@ jobs:
       - name: Absence-convention check
         run: pnpm check:absence
 
+      # Peer-range coherence gate (PEER-*): ADR-006 §3 makes the advertised peer
+      # ranges part of the 1.0 contract, so a wrong one can only be corrected in a
+      # major. Nothing exercises them otherwise — `auto-install-peers=true` plus
+      # `pnpm install --no-frozen-lockfile` means every CI install resolves the
+      # NEWEST satisfying version, so the declared floors are pure prose until this
+      # compares them to each other.
+      - name: Peer-range coherence check
+        run: pnpm check:peer-floors
+
       - name: Run unit tests
         run: pnpm test:dom
         working-directory: ./packages/create-atomic-testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The local SCM may be **Git, Sapling (`sl`), or any git-compatible system** — t
 ## Commands
 
 ```bash
-pnpm install                    # Install dependencies (Node.js >=22.12, pnpm >=10)
+pnpm install                    # Install dependencies (Node.js >=22.13, pnpm >=10)
 pnpm run check:type             # Type check all packages with tsc (TypeScript 7 native)
 pnpm run check:lint             # oxlint with auto-fix (config: .oxlintrc.json)
 pnpm run check:style            # Format with oxfmt (JS/TS/JSX/JSON only; .md/.mdx/.css/.yaml left as-is)
@@ -284,6 +284,8 @@ export class MyDriver extends ComponentDriver<{}> implements IInputDriver<string
 > **Shipping a new component-driver _package_ (a new design system) or a framework engine?** Register it with the scaffolder so `create atomic-testing` offers it and it shows up in the generated **Framework & Runner Support** matrix (that matrix is derived from the same registry): add or extend a plugin in `packages/create-atomic-testing/src/registry/` (`designSystems.ts` / `frameworks.ts`) plus a `compatibility.ts` row. The `check:coverage` (COV-\*) CI gate fails if a shipped `component-driver-*` package isn't registered — **and separately if no CI job runs its tests**, so a new driver needs a `package-tests/*` package wired into `buildui.yml`'s matrix, not just a registry entry. Details: [`packages/create-atomic-testing/CLAUDE.md`](packages/create-atomic-testing/CLAUDE.md).
 
 > **Its `package.json`'s peer/framework dependencies** — don't copy a sibling package's `dependencies`/`peerDependencies` verbatim. Check the actual peerDependencies of the third-party library the new package wraps (its published `package.json`) and declare the framework-major range it really supports; don't assume it matches whatever an existing sibling declared. Only hard-depend on one specific `@atomic-testing/react-N`/`vue-N`/`angular-N` engine package if the wrapped design system's major is genuinely locked to that one framework major (e.g. Angular Material) — otherwise leave the framework as an open peerDependencies floor. `check:deps-pinning` (DEP-PIN-02) fails the build if a `component-driver-*` package's hard-depended engine major doesn't match its own. See [ADR-003](agent-docs/adr/003-version-specific-packages.md) for the mui-v7/mui-v9 case this guards against.
+
+> **And the ranges themselves** — `check:peer-floors` (PEER-01…04, [`scripts/check-peer-floors.mjs`](scripts/check-peer-floors.mjs)) holds the advertised peer ranges to the three rules ADR-006 §3 states: never advertise a range wider than one your own dependencies advertise for the same peer (a consumer in the gap satisfies you and breaks them), never declare a library as both a `dependency` and a `peerDependency` (the hard dep wins, so the peer is inert and a consumer gets a nested duplicate), and — for the `react-N`/`vue-N`/`angular-N` engines only — always bound the framework peer to your own major. Nothing else checks these: `auto-install-peers=true` plus `--no-frozen-lockfile` means every install resolves newest-satisfying, so a declared floor is prose that no CI run has ever executed.
 
 ## Testing Pattern
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ These steps are for working **on** Atomic Testing (this monorepo), not for using
 it in your own project — for that, see
 [Add Atomic Testing to your project](#add-atomic-testing-to-your-project) above.
 
-1. Install Node.js (v22.12 or newer) and [pnpm](https://pnpm.io/) (v10 or newer).
+1. Install Node.js (v22.13 or newer) and [pnpm](https://pnpm.io/) (v10 or newer).
 2. Install the dependencies:
 
    ```bash

--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -108,7 +108,7 @@ coherent tree:
 | `vue-3`        | Vue `>=3 <4`                        |                                                                                                                                                |
 | `playwright`   | `@playwright/test >=1.50 <2` (peer) | Browser driver only; see boundary below.                                                                                                       |
 
-Node `>=22.12`, pnpm `>=10` for development (per root `package.json` `engines`).
+Node `>=22.13`, pnpm `>=10` for development (per root `package.json` `engines`).
 
 **Every per-major adapter bounds its major.** An earlier revision of this table
 ratified unbounded `>=19` / `>=3.0.0` / `>=1.50.0` forms, which contradicted
@@ -125,20 +125,33 @@ they said `10.2.0` and `10.4.0`, which let a consumer on `10.3.0` satisfy
 `react-19` while violating `dom-core`. Separately, a library declared as **both** a
 `dependency` and a `peerDependency` makes the peer inert and forces a nested
 duplicate on a consumer already holding a satisfying copy, so those are peer-only:
-`@testing-library/dom` and `@testing-library/react` in `react-19`;
+`@testing-library/dom` and `@testing-library/react` in `react-19` and `react-18`;
 `@testing-library/dom`, `@testing-library/vue` and `@vue/compiler-sfc` in `vue-3`.
 `react-core`'s hard `@testing-library/react` dependency is deliberate and stays.
 
-**The floors are not yet machine-verified.** `.npmrc` sets `auto-install-peers=true`
-and CI installs newest-satisfying, so nothing today proves a consumer pinned at a
-declared floor gets a working tree — the ranges above are reviewed prose, correct by
-inspection only. pnpm's `resolution-mode=lowest-direct` does **not** close this: it
-lowers a project's _direct_ dependencies, while these libraries reach the workspace
-as peers satisfied by caret-pinned devDependencies, so it resolves the same
-newest-satisfying tree and yields a green job that exercised nothing. Verifying a
-floor needs a purpose-built fixture that installs a published adapter against
-explicitly pinned floor versions — tracked separately, and a prerequisite for calling
-§3 enforced rather than declared.
+**The ranges are machine-checked against each other.** `check:peer-floors`
+(PEER-01…04, [`scripts/check-peer-floors.mjs`](../../scripts/check-peer-floors.mjs),
+CI job _Peer-range coherence check_) reads the manifests and fails the build on the
+three mistakes this section is made of: a range wider than one a package it depends
+on advertises for the same peer (PEER-01), a library declared as both a dependency
+and a peer (PEER-02), and a per-major adapter whose framework peer is unbounded or
+bounded at the wrong major (PEER-03). Every rule above was a live defect before it
+existed, so each is covered by a fixture that reintroduces the original manifest and
+confirms the gate rejects it — a green run means the rules were evaluated, not that
+they were skipped (PEER-04 fails on any range the checker cannot parse, so an
+unreadable range is a red build rather than a silent pass).
+
+**What that still does not prove.** Coherence is not resolvability: the gate shows
+the declared ranges do not contradict each other, never that a consumer pinned _at_
+a floor gets a working tree. `.npmrc` sets `auto-install-peers=true` and CI installs
+newest-satisfying, so no install here has ever exercised a floor. pnpm's
+`resolution-mode=lowest-direct` does **not** close that gap either: it lowers a
+project's _direct_ dependencies, while these libraries reach the workspace as peers
+satisfied by caret-pinned devDependencies, so it resolves the same newest-satisfying
+tree and yields a green job that exercised nothing. Doing it properly needs a
+purpose-built fixture that installs a published adapter against explicitly pinned
+floor versions — tracked separately, and the remaining step before §3 is enforced
+rather than merely consistent.
 
 ### 4. Internal vs. stable boundary (resolves B1)
 

--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -135,11 +135,16 @@ CI job _Peer-range coherence check_) reads the manifests and fails the build on 
 three mistakes this section is made of: a range wider than one a package it depends
 on advertises for the same peer (PEER-01), a library declared as both a dependency
 and a peer (PEER-02), and a per-major adapter whose framework peer is unbounded or
-bounded at the wrong major (PEER-03). Every rule above was a live defect before it
-existed, so each is covered by a fixture that reintroduces the original manifest and
-confirms the gate rejects it — a green run means the rules were evaluated, not that
-they were skipped (PEER-04 fails on any range the checker cannot parse, so an
-unreadable range is a red build rather than a silent pass).
+bounded at the wrong major (PEER-03). PEER-04 fails on any range the checker cannot
+parse, so a form it does not understand is a red build rather than a silent pass.
+
+Every rule above was a live defect before the gate existed, and a gate that only
+ever runs against a healthy tree proves it executed rather than that it can still
+see the bug it was written for. So each rule carries a fixture in
+[`scripts/check-peer-floors.test.mjs`](../../scripts/check-peer-floors.test.mjs)
+that reintroduces the original manifest and asserts the gate rejects it; those run
+in CI (`pnpm test:scripts`), so blinding a rule turns the build red instead of
+quietly passing forever.
 
 **What that still does not prove.** Coherence is not resolvability: the gate shows
 the declared ranges do not contradict each other, never that a consumer pinned _at_

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "bumpVersion": "node scripts/bumpVersion.js",
     "changelog": "node scripts/generateChangelog.js",
     "triage:dependabot": "tsx scripts/triage-dependabot-prs.ts",
-    "check:absence": "node scripts/check-absence-convention.mjs"
+    "check:absence": "node scripts/check-absence-convention.mjs",
+    "check:peer-floors": "node scripts/check-peer-floors.mjs"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:skill-sync": "node scripts/skills/check-skill-sync.mjs",
     "gen:skill-content": "node scripts/skills/gen-skill-content.mjs",
     "test:skills": "node --test scripts/skills/*.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "typedoc": "typedoc --out typedocs",
     "bumpVersion": "node scripts/bumpVersion.js",
     "changelog": "node scripts/generateChangelog.js",

--- a/packages/internal-test-runner-playwright-adapter/package.json
+++ b/packages/internal-test-runner-playwright-adapter/package.json
@@ -42,6 +42,6 @@
     "@types/node": "^24.0.3"
   },
   "peerDependencies": {
-    "@playwright/test": ">=1.50.0"
+    "@playwright/test": ">=1.50.0 <2.0.0"
   }
 }

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -42,8 +42,7 @@
   "dependencies": {
     "@atomic-testing/core": "workspace:*",
     "@atomic-testing/dom-core": "workspace:*",
-    "@atomic-testing/react-core": "workspace:*",
-    "@testing-library/react": "^16.3.2"
+    "@atomic-testing/react-core": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1916,7 +1916,7 @@ importers:
         specifier: '>=10.4.1'
         version: 10.4.1
       '@testing-library/react':
-        specifier: ^16.3.2
+        specifier: '>=16.2.0'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: '>=14.0.0'

--- a/scripts/check-peer-floors.mjs
+++ b/scripts/check-peer-floors.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+// Peer-range coherence gate (PEER-*). Fails CI when the peer ranges a package
+// advertises cannot all be satisfied at once by the tree that installing it
+// actually produces.
+//
+// ADR-006 §3 states that "the advertised peer ranges are part of the 1.0
+// contract", which makes a wrong range expensive in a way a wrong pin is not:
+// narrowing one after the tag REMOVES support the contract promised, so it can
+// only be fixed in a major. That is the whole reason this runs before the tag
+// rather than after the first bug report.
+//
+// Nothing else checks this. `.npmrc` sets `auto-install-peers=true` and both CI
+// composite actions end in `pnpm install --no-frozen-lockfile`, so CI always
+// resolves the NEWEST satisfying version of every peer — the declared floors are
+// never exercised by any install this repo performs. They are prose until
+// something compares them to each other.
+//
+// PEER-01  a package advertises a peer range wider than a package it hard-depends
+//          on advertises for that same peer. Installing the first installs the
+//          second, so the consumer must satisfy BOTH; any version in the gap
+//          satisfies the advertised contract and breaks the resulting tree.
+//          Live example this gate is built from (1.0 readiness audit, A4):
+//          react-19 peered `@testing-library/dom: >=10.2.0` while the dom-core it
+//          depends on peered `>=10.4.1`, so a consumer on 10.3.0 satisfied
+//          react-19 and violated dom-core. Checked in both directions — a floor
+//          that is too low and a ceiling that is too high (or absent) are the same
+//          bug, and the second is easier to introduce because "no upper bound"
+//          does not look like a claim.
+//
+// PEER-02  a package declares the same third-party name in BOTH `dependencies`
+//          and `peerDependencies`. The hard dependency always wins, which makes
+//          the peer declaration inert: it neither warns nor constrains, and a
+//          consumer already on a lower satisfying version silently gets a nested
+//          duplicate copy instead of the deduped single instance the peer was
+//          written to request. Two copies of a testing library in one tree is not
+//          a hypothetical failure — a dual-instance `vue` is exactly what took
+//          the reka-ui suites to 100% red (#1379).
+//
+// PEER-03  a per-major engine package (`react-19`, `vue-3`, `angular-22`) leaves
+//          its own framework peer unbounded, or bounds it at the wrong major.
+//          ADR-003:26-31 rejects "a peer-dep range spanning majors" — a react-19
+//          that advertises React 20 defeats the reason the package exists — and
+//          ADR-006 §3 now ratifies that every per-major adapter bounds its major.
+//          Both said so in prose while `react-19: >=19.0.0` and `vue-3: >=3.0.0`
+//          shipped unbounded, so this is the sentence made executable.
+//
+//          Scoped to the engine packages ONLY. A `component-driver-*` package's
+//          `react`/`vue` peer is an intentionally open floor: a design system's
+//          major and a framework's major are independent axes, so pinning one to
+//          the other is the DEP-PIN-02 bug, not this one.
+//
+// Only peers BOTH packages declare are compared. A package that declines to
+// re-advertise a dependency's peer at all (storybook depends on dom-core without
+// repeating its `@testing-library/dom` peer) is making no claim to contradict,
+// and is deliberately not this check's business.
+//
+// Dependency-free Node ESM, modelled on scripts/check-dependency-pinning.mjs.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = resolve(repoRoot, 'packages');
+
+// PEER-02 exemptions: a hard dependency that is ALSO advertised as a peer on
+// purpose. Keyed `<package>:<dependency>`, valued with the reason, which must
+// name what makes the duplicate correct rather than merely tolerated.
+//
+// Currently empty, and that is the point — every case the 1.0 audit found has
+// been resolved by dropping one of the two declarations. The map exists so the
+// next genuine exception is recorded with a reason instead of silently widening
+// the rule, matching DRIVER_ALLOWLIST (check-scaffolder-coverage.mjs) and EXEMPT
+// (check-absence-convention.mjs).
+const DUPLICATE_EXEMPT = new Map();
+
+// PEER-03: the framework peers each per-major engine family must bound to its own
+// major. Deliberately a separate table from check-dependency-pinning.mjs's
+// FAMILIES: that one governs CONCRETE pins (a devDependency bumped past a major
+// boundary), this one governs ADVERTISED ranges. They answer different questions
+// about different manifest fields and are free to diverge — sharing one table
+// would couple two gates that have no reason to move together.
+const ENGINE_FAMILIES = [
+  { pattern: /^react-(\d+)$/, peers: ['react', 'react-dom'] },
+  { pattern: /^vue-(\d+)$/, peers: ['vue', '@vue/compiler-sfc'] },
+  {
+    pattern: /^angular-(\d+)$/,
+    peers: ['@angular/core', '@angular/common', '@angular/compiler', '@angular/platform-browser'],
+  },
+];
+
+/** Parse `1.2.3`, `1.2`, `1` into a comparable [major, minor, patch]. */
+function parseVersion(text) {
+  const match = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(text.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
+}
+
+function compare(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+const format = version => version.join('.');
+
+/**
+ * The next version a caret range excludes, following npm's rule that the
+ * leftmost NON-ZERO component is the one held stable: `^1.2.3` → `2.0.0`, but
+ * `^0.15.0` → `0.16.0` and `^0.0.3` → `0.0.4`. Getting this wrong would matter
+ * here — `zone.js: >=0.15.0` is a real peer in the angular packages.
+ */
+function caretCeiling([major, minor, patch]) {
+  if (major !== 0) return [major + 1, 0, 0];
+  if (minor !== 0) return [0, minor + 1, 0];
+  return [0, 0, patch + 1];
+}
+
+/**
+ * Reduce a range to the interval it spans: `{ floor, ceiling }`, where a null
+ * bound means unbounded in that direction and `ceiling` is exclusive.
+ *
+ * Deliberately an OVER-approximation. A union (`^16 || ^17`) collapses to the
+ * hull of its alternatives rather than staying a disjoint set, and `>x` is read
+ * as `>=x`. Both directions of that error are safe for this gate: a hull is
+ * never narrower than the real range, so a comparison can only ever fail to
+ * report a genuine violation — never invent one. This is a linter for a mistake
+ * class, not a semver implementation, and no peer range in this repo is a
+ * disjoint union that a hull would misjudge.
+ *
+ * Returns null when nothing at all is parseable, which the caller reports rather
+ * than skips: silence is what let the floors drift in the first place.
+ */
+function parseRange(range) {
+  // One alternative: a space-separated AND of comparators, e.g. `>=18.0.0 <19.0.0`.
+  // The optional space after an operator is real here — jest is peered `">= 26.0.0"`.
+  const parseAlternative = text => {
+    let floor = null;
+    let ceiling = null;
+    let matched = false;
+    for (const [, operator, version] of text.matchAll(/(\^|~|>=|<=|>|<|=)?\s*(\d[\d.]*)/g)) {
+      const parsed = parseVersion(version);
+      if (!parsed) continue;
+      matched = true;
+      switch (operator) {
+        case '^':
+          floor = parsed;
+          ceiling = caretCeiling(parsed);
+          break;
+        case '~':
+          floor = parsed;
+          ceiling = [parsed[0], parsed[1] + 1, 0];
+          break;
+        case '>=':
+        case '>':
+          floor = parsed;
+          break;
+        case '<':
+        case '<=':
+          ceiling = parsed;
+          break;
+        default:
+          // A bare `1.2.3` pins exactly; as a half-open interval that is
+          // [1.2.3, 1.2.4).
+          floor = parsed;
+          ceiling = [parsed[0], parsed[1], parsed[2] + 1];
+      }
+    }
+    return matched ? { floor, ceiling } : null;
+  };
+
+  const alternatives = range.split('||').map(part => parseAlternative(part.trim()));
+  if (alternatives.some(alternative => alternative == null)) return null;
+
+  // The hull. A single unbounded alternative leaves the union unbounded in that
+  // direction, which is why these are `some` checks rather than reductions.
+  return {
+    floor: alternatives.some(a => a.floor == null)
+      ? null
+      : alternatives.reduce((low, a) => (compare(a.floor, low) < 0 ? a.floor : low), alternatives[0].floor),
+    ceiling: alternatives.some(a => a.ceiling == null)
+      ? null
+      : alternatives.reduce((high, a) => (compare(a.ceiling, high) > 0 ? a.ceiling : high), alternatives[0].ceiling),
+  };
+}
+
+function readManifest(dir, dirName) {
+  const path = join(dir, 'package.json');
+  if (!existsSync(path)) return null;
+  try {
+    return { path, dirName, json: JSON.parse(readFileSync(path, 'utf8')) };
+  } catch {
+    return null;
+  }
+}
+
+const manifests = new Map();
+for (const dirName of readdirSync(packagesDir)) {
+  const manifest = readManifest(join(packagesDir, dirName), dirName);
+  if (manifest?.json.name) manifests.set(manifest.json.name, manifest);
+}
+
+/**
+ * Every workspace package reachable through `dependencies` — the set a consumer
+ * installs along with `name`. peerDependencies are deliberately not traversed:
+ * they are the consumer's own tree, not something this package drags in.
+ */
+function workspaceDependencyClosure(name) {
+  const seen = new Set();
+  const queue = [name];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const dependency of Object.keys(manifests.get(current)?.json.dependencies ?? {})) {
+      if (!manifests.has(dependency) || seen.has(dependency)) continue;
+      seen.add(dependency);
+      queue.push(dependency);
+    }
+  }
+  return seen;
+}
+
+const errors = [];
+const unparseable = [];
+let comparisons = 0;
+
+for (const [name, manifest] of manifests) {
+  const peers = manifest.json.peerDependencies ?? {};
+  const relPath = manifest.path.slice(repoRoot.length + 1);
+
+  for (const [peer, range] of Object.entries(peers)) {
+    if (parseRange(range) == null) unparseable.push(`${relPath} → ${peer}: "${range}"`);
+  }
+
+  // PEER-02 — an inert peer declaration.
+  for (const dependency of Object.keys(manifest.json.dependencies ?? {})) {
+    if (!(dependency in peers) || manifests.has(dependency)) continue;
+    if (DUPLICATE_EXEMPT.has(`${name.replace('@atomic-testing/', '')}:${dependency}`)) continue;
+    errors.push(
+      `PEER-02: ${relPath} declares ${dependency} in BOTH dependencies ` +
+        `("${manifest.json.dependencies[dependency]}") and peerDependencies ("${peers[dependency]}"). ` +
+        `The hard dependency wins, so the peer neither warns nor constrains — and a consumer already ` +
+        `on a lower satisfying version gets a second nested copy instead of the single deduped ` +
+        `instance the peer asks for. Drop one: the peer if the dependency is genuinely required, ` +
+        `the dependency if the consumer is meant to supply it.`
+    );
+  }
+
+  // PEER-03 — a per-major engine that does not bound its own major.
+  for (const family of ENGINE_FAMILIES) {
+    const match = family.pattern.exec(manifest.dirName);
+    if (!match) continue;
+    const major = Number(match[1]);
+    for (const peer of family.peers) {
+      const range = peers[peer];
+      if (range == null) continue;
+      const parsed = parseRange(range);
+      if (parsed == null) continue;
+      if (parsed.ceiling == null || compare(parsed.ceiling, [major + 1, 0, 0]) > 0) {
+        errors.push(
+          `PEER-03: ${relPath} peers ${peer} "${range}", which admits majors above ${major}. ` +
+            `This package exists only to pin one framework major (ADR-003), so a range reaching ` +
+            `into ${major + 1} promises support that belongs to the sibling package for that ` +
+            `major — and defeats this package's own reason to exist. Bound it at <${major + 1}.0.0.`
+        );
+      }
+      if (parsed.floor == null || parsed.floor[0] !== major) {
+        errors.push(
+          `PEER-03: ${relPath} peers ${peer} "${range}", whose floor is not in major ${major}. ` +
+            `A per-major adapter's floor is its own major — anything else silently supports a ` +
+            `version this package was not built against.`
+        );
+      }
+    }
+  }
+
+  // PEER-01 — a claim wider than the tree it produces can honour.
+  for (const dependencyName of workspaceDependencyClosure(name)) {
+    const dependencyPeers = manifests.get(dependencyName).json.peerDependencies ?? {};
+    for (const [peer, range] of Object.entries(peers)) {
+      const theirRange = dependencyPeers[peer];
+      if (theirRange == null) continue;
+      const ours = parseRange(range);
+      const theirs = parseRange(theirRange);
+      if (ours == null || theirs == null) continue;
+      comparisons++;
+
+      const shortName = dependencyName.replace('@atomic-testing/', '');
+      if (theirs.floor != null && (ours.floor == null || compare(ours.floor, theirs.floor) < 0)) {
+        const witness = ours.floor == null ? `below ${format(theirs.floor)}` : format(ours.floor);
+        errors.push(
+          `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
+            `"${theirRange}" — a lower floor. A consumer on ${witness} satisfies ${name} and violates ` +
+            `${dependencyName}, so the advertised range promises a tree that cannot install. Raise this ` +
+            `floor to at least ${format(theirs.floor)}, or lower ${shortName}'s.`
+        );
+      }
+      if (theirs.ceiling != null && (ours.ceiling == null || compare(ours.ceiling, theirs.ceiling) > 0)) {
+        const witness = ours.ceiling == null ? `above ${format(theirs.ceiling)}` : `up to ${format(ours.ceiling)}`;
+        errors.push(
+          `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
+            `"${theirRange}" — a lower ceiling. This package advertises support ${witness} that ` +
+            `${dependencyName} refuses, so the two cannot both be satisfied. Bound this range at ` +
+            `${format(theirs.ceiling)}, or raise ${shortName}'s ceiling.`
+        );
+      }
+    }
+  }
+}
+
+// An unreadable range is a hole in the check, not a pass. Reported rather than
+// skipped so "the gate was green" can never mean "the gate never looked".
+for (const entry of unparseable) {
+  errors.push(
+    `PEER-04: ${entry} is not a range this check can read, so its coherence went unverified. ` +
+      `Rewrite it in the comparator/caret/tilde/union forms the rest of the repo uses, or teach ` +
+      `parseRange() the new form.`
+  );
+}
+
+if (errors.length > 0) {
+  console.error(`[peer-floors] ${errors.length} problem(s):`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[peer-floors] OK — ${manifests.size} package(s), ${comparisons} shared peer range(s) checked ` +
+    `against the packages that install them.\n`
+);

--- a/scripts/check-peer-floors.mjs
+++ b/scripts/check-peer-floors.mjs
@@ -57,7 +57,7 @@
 // Dependency-free Node ESM, modelled on scripts/check-dependency-pinning.mjs.
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packagesDir = resolve(repoRoot, 'packages');
@@ -116,61 +116,93 @@ function caretCeiling([major, minor, patch]) {
   return [0, 0, patch + 1];
 }
 
+/** The version immediately after `v`, used to turn an inclusive bound exclusive. */
+const nextPatch = ([major, minor, patch]) => [major, minor, patch + 1];
+
+/**
+ * One comparator: an optional operator, optional space, then a partial or full
+ * version. The space is real here — jest is peered as `">= 26.0.0"`. Sticky, so
+ * the caller can require that the WHOLE alternative is consumed.
+ */
+const COMPARATOR = /\s*(\^|~|>=|<=|>|<|=)?\s*(\d+(?:\.\d+)?(?:\.\d+)?)\s*/y;
+
 /**
  * Reduce a range to the interval it spans: `{ floor, ceiling }`, where a null
- * bound means unbounded in that direction and `ceiling` is exclusive.
+ * bound means unbounded in that direction and **`ceiling` is always exclusive**
+ * (`<=20.0.0` normalizes to `< 20.0.1`, `>19.0.0` to `>= 19.0.1`), so every
+ * comparison downstream is a single half-open-interval test.
  *
- * Deliberately an OVER-approximation. A union (`^16 || ^17`) collapses to the
- * hull of its alternatives rather than staying a disjoint set, and `>x` is read
- * as `>=x`. Both directions of that error are safe for this gate: a hull is
- * never narrower than the real range, so a comparison can only ever fail to
- * report a genuine violation — never invent one. This is a linter for a mistake
- * class, not a semver implementation, and no peer range in this repo is a
- * disjoint union that a hull would misjudge.
+ * Comparators within one alternative are INTERSECTED — floors by `max`, ceilings
+ * by `min` — because `>=18 >=19` means both, not whichever was written last.
+ * Assigning in encounter order instead would let comparator order change the
+ * verdict: `>=19 <20 >=18` would keep a floor of 18 and be rejected by PEER-03,
+ * while a reversed caret would widen a ceiling and hide a real violation.
  *
- * Returns null when nothing at all is parseable, which the caller reports rather
- * than skips: silence is what let the floors drift in the first place.
+ * Alternatives across `||` are UNIONED as their hull (`^16 || ^17` → `[16, 18)`),
+ * which is an over-approximation: a hull is never narrower than the real range,
+ * so it can only fail to report a genuine violation, never invent one. No peer
+ * range in this repo is a disjoint union a hull would misjudge.
+ *
+ * Returns null for anything outside that grammar — hyphen ranges (`1.2.3 - 2.0.0`),
+ * `x`/`*` wildcards, prerelease tags. The caller reports those as PEER-04 rather
+ * than skipping them: a form this cannot read must not be mistaken for one it
+ * read and approved, which is the exact failure the whole gate exists to prevent.
  */
-function parseRange(range) {
-  // One alternative: a space-separated AND of comparators, e.g. `>=18.0.0 <19.0.0`.
-  // The optional space after an operator is real here — jest is peered `">= 26.0.0"`.
+export function parseRange(range) {
   const parseAlternative = text => {
     let floor = null;
     let ceiling = null;
     let matched = false;
-    for (const [, operator, version] of text.matchAll(/(\^|~|>=|<=|>|<|=)?\s*(\d[\d.]*)/g)) {
-      const parsed = parseVersion(version);
-      if (!parsed) continue;
+
+    const lower = candidate => (floor == null || compare(candidate, floor) > 0 ? candidate : floor);
+    const upper = candidate => (ceiling == null || compare(candidate, ceiling) < 0 ? candidate : ceiling);
+
+    COMPARATOR.lastIndex = 0;
+    let position = 0;
+    while (position < text.length) {
+      COMPARATOR.lastIndex = position;
+      const match = COMPARATOR.exec(text);
+      // Sticky: a null match, or one that did not start exactly here, means
+      // unsupported syntax is present. Bail rather than skip past it.
+      if (!match || match.index !== position) return null;
+      position = COMPARATOR.lastIndex;
+
+      const parsed = parseVersion(match[2]);
+      if (!parsed) return null;
       matched = true;
-      switch (operator) {
+
+      switch (match[1]) {
         case '^':
-          floor = parsed;
-          ceiling = caretCeiling(parsed);
+          floor = lower(parsed);
+          ceiling = upper(caretCeiling(parsed));
           break;
         case '~':
-          floor = parsed;
-          ceiling = [parsed[0], parsed[1] + 1, 0];
+          floor = lower(parsed);
+          ceiling = upper([parsed[0], parsed[1] + 1, 0]);
           break;
         case '>=':
+          floor = lower(parsed);
+          break;
         case '>':
-          floor = parsed;
+          floor = lower(nextPatch(parsed));
           break;
         case '<':
+          ceiling = upper(parsed);
+          break;
         case '<=':
-          ceiling = parsed;
+          ceiling = upper(nextPatch(parsed));
           break;
         default:
-          // A bare `1.2.3` pins exactly; as a half-open interval that is
-          // [1.2.3, 1.2.4).
-          floor = parsed;
-          ceiling = [parsed[0], parsed[1], parsed[2] + 1];
+          // A bare or `=`-prefixed `1.2.3` pins exactly: [1.2.3, 1.2.4).
+          floor = lower(parsed);
+          ceiling = upper(nextPatch(parsed));
       }
     }
     return matched ? { floor, ceiling } : null;
   };
 
   const alternatives = range.split('||').map(part => parseAlternative(part.trim()));
-  if (alternatives.some(alternative => alternative == null)) return null;
+  if (alternatives.length === 0 || alternatives.some(alternative => alternative == null)) return null;
 
   // The hull. A single unbounded alternative leaves the union unbounded in that
   // direction, which is why these are `some` checks rather than reductions.
@@ -194,136 +226,161 @@ function readManifest(dir, dirName) {
   }
 }
 
-const manifests = new Map();
-for (const dirName of readdirSync(packagesDir)) {
-  const manifest = readManifest(join(packagesDir, dirName), dirName);
-  if (manifest?.json.name) manifests.set(manifest.json.name, manifest);
-}
-
 /**
- * Every workspace package reachable through `dependencies` — the set a consumer
- * installs along with `name`. peerDependencies are deliberately not traversed:
- * they are the consumer's own tree, not something this package drags in.
+ * Decide the verdict for an already-read set of manifests, keyed by package name
+ * and each carrying `{ path, dirName, json }`.
+ *
+ * Separated from reading the tree so the rules can be exercised against
+ * hand-built manifests — see check-peer-floors.test.mjs, which reintroduces each
+ * historical defect and asserts the matching rule fires. A gate nothing ever
+ * proves can DETECT is only evidence that it ran.
  */
-function workspaceDependencyClosure(name) {
-  const seen = new Set();
-  const queue = [name];
-  while (queue.length > 0) {
-    const current = queue.shift();
-    for (const dependency of Object.keys(manifests.get(current)?.json.dependencies ?? {})) {
-      if (!manifests.has(dependency) || seen.has(dependency)) continue;
-      seen.add(dependency);
-      queue.push(dependency);
+export function evaluate(manifests) {
+  /**
+   * Every workspace package reachable through `dependencies` — the set a consumer
+   * installs along with `name`. peerDependencies are deliberately not traversed:
+   * they are the consumer's own tree, not something this package drags in.
+   */
+  const workspaceDependencyClosure = name => {
+    const seen = new Set();
+    const queue = [name];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      for (const dependency of Object.keys(manifests.get(current)?.json.dependencies ?? {})) {
+        if (!manifests.has(dependency) || seen.has(dependency)) continue;
+        seen.add(dependency);
+        queue.push(dependency);
+      }
+    }
+    return seen;
+  };
+
+  const errors = [];
+  const unparseable = [];
+  let comparisons = 0;
+
+  for (const [name, manifest] of manifests) {
+    const peers = manifest.json.peerDependencies ?? {};
+    const relPath = manifest.path;
+
+    for (const [peer, range] of Object.entries(peers)) {
+      if (parseRange(range) == null) unparseable.push(`${relPath} → ${peer}: "${range}"`);
+    }
+
+    // PEER-02 — an inert peer declaration.
+    for (const dependency of Object.keys(manifest.json.dependencies ?? {})) {
+      if (!(dependency in peers) || manifests.has(dependency)) continue;
+      if (DUPLICATE_EXEMPT.has(`${name.replace('@atomic-testing/', '')}:${dependency}`)) continue;
+      errors.push(
+        `PEER-02: ${relPath} declares ${dependency} in BOTH dependencies ` +
+          `("${manifest.json.dependencies[dependency]}") and peerDependencies ("${peers[dependency]}"). ` +
+          `The hard dependency wins, so the peer neither warns nor constrains — and a consumer already ` +
+          `on a lower satisfying version gets a second nested copy instead of the single deduped ` +
+          `instance the peer asks for. Drop one: the peer if the dependency is genuinely required, ` +
+          `the dependency if the consumer is meant to supply it.`
+      );
+    }
+
+    // PEER-03 — a per-major engine that does not bound its own major.
+    for (const family of ENGINE_FAMILIES) {
+      const match = family.pattern.exec(manifest.dirName);
+      if (!match) continue;
+      const major = Number(match[1]);
+      for (const peer of family.peers) {
+        const range = peers[peer];
+        if (range == null) continue;
+        const parsed = parseRange(range);
+        if (parsed == null) continue;
+        if (parsed.ceiling == null || compare(parsed.ceiling, [major + 1, 0, 0]) > 0) {
+          errors.push(
+            `PEER-03: ${relPath} peers ${peer} "${range}", which admits majors above ${major}. ` +
+              `This package exists only to pin one framework major (ADR-003), so a range reaching ` +
+              `into ${major + 1} promises support that belongs to the sibling package for that ` +
+              `major — and defeats this package's own reason to exist. Bound it at <${major + 1}.0.0.`
+          );
+        }
+        if (parsed.floor == null || parsed.floor[0] !== major) {
+          errors.push(
+            `PEER-03: ${relPath} peers ${peer} "${range}", whose floor is not in major ${major}. ` +
+              `A per-major adapter's floor is its own major — anything else silently supports a ` +
+              `version this package was not built against.`
+          );
+        }
+      }
+    }
+
+    // PEER-01 — a claim wider than the tree it produces can honour.
+    for (const dependencyName of workspaceDependencyClosure(name)) {
+      const dependencyPeers = manifests.get(dependencyName).json.peerDependencies ?? {};
+      for (const [peer, range] of Object.entries(peers)) {
+        const theirRange = dependencyPeers[peer];
+        if (theirRange == null) continue;
+        const ours = parseRange(range);
+        const theirs = parseRange(theirRange);
+        if (ours == null || theirs == null) continue;
+        comparisons++;
+
+        const shortName = dependencyName.replace('@atomic-testing/', '');
+        if (theirs.floor != null && (ours.floor == null || compare(ours.floor, theirs.floor) < 0)) {
+          const witness = ours.floor == null ? `below ${format(theirs.floor)}` : format(ours.floor);
+          errors.push(
+            `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
+              `"${theirRange}" — a lower floor. A consumer on ${witness} satisfies ${name} and violates ` +
+              `${dependencyName}, so the advertised range promises a tree that cannot install. Raise this ` +
+              `floor to at least ${format(theirs.floor)}, or lower ${shortName}'s.`
+          );
+        }
+        if (theirs.ceiling != null && (ours.ceiling == null || compare(ours.ceiling, theirs.ceiling) > 0)) {
+          const witness = ours.ceiling == null ? `above ${format(theirs.ceiling)}` : `up to ${format(ours.ceiling)}`;
+          errors.push(
+            `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
+              `"${theirRange}" — a lower ceiling. This package advertises support ${witness} that ` +
+              `${dependencyName} refuses, so the two cannot both be satisfied. Bound this range at ` +
+              `${format(theirs.ceiling)}, or raise ${shortName}'s ceiling.`
+          );
+        }
+      }
     }
   }
-  return seen;
-}
 
-const errors = [];
-const unparseable = [];
-let comparisons = 0;
-
-for (const [name, manifest] of manifests) {
-  const peers = manifest.json.peerDependencies ?? {};
-  const relPath = manifest.path.slice(repoRoot.length + 1);
-
-  for (const [peer, range] of Object.entries(peers)) {
-    if (parseRange(range) == null) unparseable.push(`${relPath} → ${peer}: "${range}"`);
-  }
-
-  // PEER-02 — an inert peer declaration.
-  for (const dependency of Object.keys(manifest.json.dependencies ?? {})) {
-    if (!(dependency in peers) || manifests.has(dependency)) continue;
-    if (DUPLICATE_EXEMPT.has(`${name.replace('@atomic-testing/', '')}:${dependency}`)) continue;
+  // An unreadable range is a hole in the check, not a pass. Reported rather than
+  // skipped so "the gate was green" can never mean "the gate never looked".
+  for (const entry of unparseable) {
     errors.push(
-      `PEER-02: ${relPath} declares ${dependency} in BOTH dependencies ` +
-        `("${manifest.json.dependencies[dependency]}") and peerDependencies ("${peers[dependency]}"). ` +
-        `The hard dependency wins, so the peer neither warns nor constrains — and a consumer already ` +
-        `on a lower satisfying version gets a second nested copy instead of the single deduped ` +
-        `instance the peer asks for. Drop one: the peer if the dependency is genuinely required, ` +
-        `the dependency if the consumer is meant to supply it.`
+      `PEER-04: ${entry} is not a range this check can read, so its coherence went unverified. ` +
+        `Rewrite it in the comparator/caret/tilde/union forms the rest of the repo uses, or teach ` +
+        `parseRange() the new form.`
     );
   }
 
-  // PEER-03 — a per-major engine that does not bound its own major.
-  for (const family of ENGINE_FAMILIES) {
-    const match = family.pattern.exec(manifest.dirName);
-    if (!match) continue;
-    const major = Number(match[1]);
-    for (const peer of family.peers) {
-      const range = peers[peer];
-      if (range == null) continue;
-      const parsed = parseRange(range);
-      if (parsed == null) continue;
-      if (parsed.ceiling == null || compare(parsed.ceiling, [major + 1, 0, 0]) > 0) {
-        errors.push(
-          `PEER-03: ${relPath} peers ${peer} "${range}", which admits majors above ${major}. ` +
-            `This package exists only to pin one framework major (ADR-003), so a range reaching ` +
-            `into ${major + 1} promises support that belongs to the sibling package for that ` +
-            `major — and defeats this package's own reason to exist. Bound it at <${major + 1}.0.0.`
-        );
-      }
-      if (parsed.floor == null || parsed.floor[0] !== major) {
-        errors.push(
-          `PEER-03: ${relPath} peers ${peer} "${range}", whose floor is not in major ${major}. ` +
-            `A per-major adapter's floor is its own major — anything else silently supports a ` +
-            `version this package was not built against.`
-        );
-      }
-    }
-  }
-
-  // PEER-01 — a claim wider than the tree it produces can honour.
-  for (const dependencyName of workspaceDependencyClosure(name)) {
-    const dependencyPeers = manifests.get(dependencyName).json.peerDependencies ?? {};
-    for (const [peer, range] of Object.entries(peers)) {
-      const theirRange = dependencyPeers[peer];
-      if (theirRange == null) continue;
-      const ours = parseRange(range);
-      const theirs = parseRange(theirRange);
-      if (ours == null || theirs == null) continue;
-      comparisons++;
-
-      const shortName = dependencyName.replace('@atomic-testing/', '');
-      if (theirs.floor != null && (ours.floor == null || compare(ours.floor, theirs.floor) < 0)) {
-        const witness = ours.floor == null ? `below ${format(theirs.floor)}` : format(ours.floor);
-        errors.push(
-          `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
-            `"${theirRange}" — a lower floor. A consumer on ${witness} satisfies ${name} and violates ` +
-            `${dependencyName}, so the advertised range promises a tree that cannot install. Raise this ` +
-            `floor to at least ${format(theirs.floor)}, or lower ${shortName}'s.`
-        );
-      }
-      if (theirs.ceiling != null && (ours.ceiling == null || compare(ours.ceiling, theirs.ceiling) > 0)) {
-        const witness = ours.ceiling == null ? `above ${format(theirs.ceiling)}` : `up to ${format(ours.ceiling)}`;
-        errors.push(
-          `PEER-01: ${relPath} peers ${peer} "${range}", but it depends on ${shortName}, which peers ` +
-            `"${theirRange}" — a lower ceiling. This package advertises support ${witness} that ` +
-            `${dependencyName} refuses, so the two cannot both be satisfied. Bound this range at ` +
-            `${format(theirs.ceiling)}, or raise ${shortName}'s ceiling.`
-        );
-      }
-    }
-  }
+  return { errors, comparisons };
 }
 
-// An unreadable range is a hole in the check, not a pass. Reported rather than
-// skipped so "the gate was green" can never mean "the gate never looked".
-for (const entry of unparseable) {
-  errors.push(
-    `PEER-04: ${entry} is not a range this check can read, so its coherence went unverified. ` +
-      `Rewrite it in the comparator/caret/tilde/union forms the rest of the repo uses, or teach ` +
-      `parseRange() the new form.`
+/** Read every `packages/*` manifest, keyed by package name. */
+export function readManifests(root = packagesDir) {
+  const manifests = new Map();
+  for (const dirName of readdirSync(root)) {
+    const manifest = readManifest(join(root, dirName), dirName);
+    if (manifest?.json.name) manifests.set(manifest.json.name, manifest);
+  }
+  return manifests;
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  const manifests = readManifests();
+  for (const manifest of manifests.values()) {
+    manifest.path = manifest.path.slice(repoRoot.length + 1);
+  }
+  const { errors, comparisons } = evaluate(manifests);
+
+  if (errors.length > 0) {
+    console.error(`[peer-floors] ${errors.length} problem(s):`);
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `[peer-floors] OK — ${manifests.size} package(s), ${comparisons} shared peer range(s) checked ` +
+      `against the packages that install them.\n`
   );
 }
-
-if (errors.length > 0) {
-  console.error(`[peer-floors] ${errors.length} problem(s):`);
-  for (const error of errors) console.error(`  - ${error}`);
-  process.exit(1);
-}
-
-process.stdout.write(
-  `[peer-floors] OK — ${manifests.size} package(s), ${comparisons} shared peer range(s) checked ` +
-    `against the packages that install them.\n`
-);

--- a/scripts/check-peer-floors.test.mjs
+++ b/scripts/check-peer-floors.test.mjs
@@ -1,0 +1,205 @@
+// Unit tests for the peer-range coherence gate. Run with `node --test`.
+//
+// The point of these is DETECTION, not coverage. A gate that only ever runs
+// against a healthy tree proves it executed, never that it can still see the bug
+// it was written for — and every rule here guards a defect this repo actually
+// shipped. So each one gets a fixture that reintroduces the original manifest and
+// asserts the gate rejects it; if a refactor blinds a rule, these go red instead
+// of the gate quietly passing forever.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { evaluate, parseRange } from './check-peer-floors.mjs';
+
+/** Build the manifest map `evaluate` expects from a terse literal. */
+function manifestsOf(entries) {
+  return new Map(
+    Object.entries(entries).map(([dirName, json]) => {
+      const name = json.name ?? `@atomic-testing/${dirName}`;
+      return [name, { path: `packages/${dirName}/package.json`, dirName, json: { ...json, name } }];
+    })
+  );
+}
+
+const codesOf = manifests => evaluate(manifests).errors.map(error => error.slice(0, 7));
+
+test('parses the comparator forms the repo actually uses', () => {
+  assert.deepEqual(parseRange('>=10.4.1'), { floor: [10, 4, 1], ceiling: null });
+  assert.deepEqual(parseRange('>=18.0.0 <19.0.0'), { floor: [18, 0, 0], ceiling: [19, 0, 0] });
+  // The space after the operator is real — jest is peered `">= 26.0.0"`.
+  assert.deepEqual(parseRange('>= 26.0.0'), { floor: [26, 0, 0], ceiling: null });
+  assert.deepEqual(parseRange('^10.0.0'), { floor: [10, 0, 0], ceiling: [11, 0, 0] });
+  // Partial versions.
+  assert.deepEqual(parseRange('>=11'), { floor: [11, 0, 0], ceiling: null });
+});
+
+test('holds the leftmost non-zero component stable for caret ranges', () => {
+  // zone.js is peered `>=0.15.0`, so a 0.x caret must not widen to 1.0.0.
+  assert.deepEqual(parseRange('^0.15.0'), { floor: [0, 15, 0], ceiling: [0, 16, 0] });
+  assert.deepEqual(parseRange('^0.0.3'), { floor: [0, 0, 3], ceiling: [0, 0, 4] });
+  assert.deepEqual(parseRange('^1.2.3'), { floor: [1, 2, 3], ceiling: [2, 0, 0] });
+});
+
+test('takes the hull of a union', () => {
+  // react-legacy peers `^16 || ^17`.
+  assert.deepEqual(parseRange('^16 || ^17'), { floor: [16, 0, 0], ceiling: [18, 0, 0] });
+});
+
+test('intersects comparators rather than letting the last one win', () => {
+  // Encounter-order assignment would leave a floor of 18 here, which PEER-03
+  // would then reject as "not in major 19" — a verdict that depends on the order
+  // the comparators happen to be written in.
+  assert.deepEqual(parseRange('>=19.0.0 <20.0.0 >=18.0.0'), { floor: [19, 0, 0], ceiling: [20, 0, 0] });
+  // Same in the other direction: a wider ceiling written second must not widen
+  // the range and hide a violation.
+  assert.deepEqual(parseRange('<19.0.0 <25.0.0'), { floor: null, ceiling: [19, 0, 0] });
+});
+
+test('normalizes inclusive and exclusive bounds so the ceiling is always exclusive', () => {
+  // `<=20.0.0` ADMITS 20.0.0. Storing it as an exclusive 20.0.0 would let
+  // `>=19.0.0 <=20.0.0` pass PEER-03 while admitting React 20.
+  assert.deepEqual(parseRange('>=19.0.0 <=20.0.0'), { floor: [19, 0, 0], ceiling: [20, 0, 1] });
+  // `>1.0.0` excludes 1.0.0 itself.
+  assert.deepEqual(parseRange('>1.0.0'), { floor: [1, 0, 1], ceiling: null });
+  // An exact pin is the half-open interval containing only itself.
+  assert.deepEqual(parseRange('1.2.3'), { floor: [1, 2, 3], ceiling: [1, 2, 4] });
+});
+
+test('refuses forms it cannot read instead of guessing an interval', () => {
+  // Each of these contains digits a scanning parser would happily pick up while
+  // ignoring the syntax that changes their meaning — the exact way an unverified
+  // range gets mistaken for a verified one.
+  for (const range of ['1.x', '1.2.3 - 2.0.0', '*', 'latest', '~>1.2', '1.0.0-beta.1', '']) {
+    assert.equal(parseRange(range), null, `expected "${range}" to be rejected`);
+  }
+});
+
+test('PEER-01 fires on a floor lower than a dependency advertises', () => {
+  // react-19 peered `>=10.2.0` while the dom-core under it peered `>=10.4.1`, so
+  // a consumer on 10.3.0 satisfied react-19 and violated dom-core.
+  const manifests = manifestsOf({
+    'react-19': {
+      dependencies: { '@atomic-testing/dom-core': 'workspace:*' },
+      peerDependencies: { '@testing-library/dom': '>=10.2.0', react: '>=19.0.0 <20.0.0' },
+    },
+    'dom-core': { peerDependencies: { '@testing-library/dom': '>=10.4.1' } },
+  });
+
+  const { errors } = evaluate(manifests);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /^PEER-01/);
+  // The consumer version that slips through is named, not left to be derived.
+  assert.match(errors[0], /consumer on 10\.2\.0/);
+});
+
+test('PEER-01 fires on a ceiling higher than a dependency advertises', () => {
+  // internal-test-runner-playwright-adapter peered `>=1.50.0` (open) while
+  // depending on playwright, which peers `>=1.50.0 <2.0.0`.
+  const manifests = manifestsOf({
+    'internal-test-runner-playwright-adapter': {
+      dependencies: { '@atomic-testing/playwright': 'workspace:*' },
+      peerDependencies: { '@playwright/test': '>=1.50.0' },
+    },
+    playwright: { peerDependencies: { '@playwright/test': '>=1.50.0 <2.0.0' } },
+  });
+
+  assert.deepEqual(codesOf(manifests), ['PEER-01']);
+});
+
+test('PEER-01 stays quiet when the dependent is strictly narrower', () => {
+  const manifests = manifestsOf({
+    'react-19': {
+      dependencies: { '@atomic-testing/react-core': 'workspace:*' },
+      peerDependencies: { react: '>=19.0.0 <20.0.0' },
+    },
+    // The shared base is deliberately open (`React >=18`, ADR-006 §3) — a
+    // narrower dependent is the intended shape, not a violation.
+    'react-core': { peerDependencies: { react: '>=18.0.0' } },
+  });
+
+  assert.deepEqual(codesOf(manifests), []);
+});
+
+test('PEER-01 ignores a peer the dependency never declares', () => {
+  // storybook depends on dom-core without restating its `@testing-library/dom`
+  // peer. Declining to make a claim is not a claim to contradict.
+  const manifests = manifestsOf({
+    storybook: {
+      dependencies: { '@atomic-testing/dom-core': 'workspace:*' },
+      peerDependencies: { storybook: '^10.0.0' },
+    },
+    'dom-core': { peerDependencies: { '@testing-library/dom': '>=10.4.1' } },
+  });
+
+  assert.deepEqual(codesOf(manifests), []);
+});
+
+test('PEER-02 fires on a library declared as both a dependency and a peer', () => {
+  const manifests = manifestsOf({
+    'react-18': {
+      dependencies: { '@testing-library/react': '^16.3.2' },
+      peerDependencies: { '@testing-library/react': '>=16.2.0', react: '>=18.0.0 <19.0.0' },
+    },
+  });
+
+  assert.deepEqual(codesOf(manifests), ['PEER-02']);
+});
+
+test('PEER-02 does not count a workspace dependency as a duplicate', () => {
+  const manifests = manifestsOf({
+    'react-18': {
+      dependencies: { '@atomic-testing/react-core': 'workspace:*' },
+      peerDependencies: { react: '>=18.0.0 <19.0.0' },
+    },
+    'react-core': { peerDependencies: { react: '>=18.0.0' } },
+  });
+
+  assert.deepEqual(codesOf(manifests), []);
+});
+
+test('PEER-03 fires on a per-major engine that leaves its framework peer unbounded', () => {
+  const unbounded = manifestsOf({
+    'react-19': { peerDependencies: { react: '>=19.0.0', 'react-dom': '>=19.0.0' } },
+  });
+  assert.deepEqual(codesOf(unbounded), ['PEER-03', 'PEER-03']);
+
+  const vue = manifestsOf({ 'vue-3': { peerDependencies: { vue: '>=3.0.0' } } });
+  assert.deepEqual(codesOf(vue), ['PEER-03']);
+});
+
+test('PEER-03 fires on an inclusive ceiling that admits the next major', () => {
+  // The bug an exclusive-only reading of `<=` would hide entirely.
+  const manifests = manifestsOf({
+    'react-19': { peerDependencies: { react: '>=19.0.0 <=20.0.0' } },
+  });
+
+  assert.deepEqual(codesOf(manifests), ['PEER-03']);
+});
+
+test('PEER-03 accepts a correctly bounded engine and ignores driver packages', () => {
+  const bounded = manifestsOf({
+    'react-19': { peerDependencies: { react: '>=19.0.0 <20.0.0', 'react-dom': '>=19.0.0 <20.0.0' } },
+    'angular-20': { peerDependencies: { '@angular/core': '>=20.0.0 <21.0.0' } },
+  });
+  assert.deepEqual(codesOf(bounded), []);
+
+  // A design system's major and a framework's major are independent axes, so a
+  // driver's open framework floor is deliberate (ADR-003) — PEER-03 must not
+  // reach it.
+  const driver = manifestsOf({
+    'component-driver-mui-v7': { peerDependencies: { react: '>=18.0.0', 'react-dom': '>=18.0.0' } },
+  });
+  assert.deepEqual(codesOf(driver), []);
+});
+
+test('PEER-04 reports an unreadable range rather than passing it', () => {
+  const manifests = manifestsOf({ 'vue-3': { peerDependencies: { vue: 'latest' } } });
+
+  const { errors } = evaluate(manifests);
+  // PEER-03 also fires (an unreadable range certainly is not a bounded major),
+  // but PEER-04 is the one that says the range went unverified.
+  assert.ok(
+    errors.some(error => error.startsWith('PEER-04')),
+    `expected a PEER-04 among: ${errors.join(' | ')}`
+  );
+});


### PR DESCRIPTION
Closes the peer-dependency half of the 1.0 readiness audit — #1297, **A4**.

## Summary

ADR-006 §3 says *"the advertised peer ranges are part of the 1.0 contract"*, which makes a wrong range expensive in a way a wrong pin is not: narrowing one after the tag **removes support the contract promised**, so it can only be corrected in a major.

Nothing exercised them. `.npmrc` sets `auto-install-peers=true` and both CI composite actions end in `pnpm install --no-frozen-lockfile`, so every install resolves the *newest* satisfying version — no declared floor has ever been executed by anything. They were reviewed prose.

Most of what A4 lists had already landed (`react-19` at `>=19 <20`, `vue-3` at `>=3 <4`, `playwright` at `>=1.50 <2`, every `@testing-library/dom` floor at `>=10.4.1`, ADR-003 reconciled with ADR-006 §3). What was missing was anything that keeps it that way.

### The gate

`check:peer-floors` (`scripts/check-peer-floors.mjs`) reads the manifests and fails on the three mistakes §3 is made of:

| Rule | Fails when |
| --- | --- |
| **PEER-01** | a package advertises a range wider than one it *depends on* advertises for the same peer. Installing the first installs the second, so a consumer in the gap satisfies the contract and gets a tree that cannot install — how `react-19` peered `@testing-library/dom: >=10.2.0` over a `dom-core` peering `>=10.4.1`. Checked in both directions: a floor too low and a ceiling too high are the same bug, and the second is easier to introduce because "no upper bound" doesn't look like a claim. |
| **PEER-02** | a library is declared in both `dependencies` and `peerDependencies`. The hard dep wins, so the peer neither warns nor constrains, and a consumer already holding a satisfying copy gets a nested duplicate instead. |
| **PEER-03** | a per-major engine (`react-N`/`vue-N`/`angular-N`) leaves its framework peer unbounded. ADR-003:26-31 rejects "a peer-dep range spanning majors"; both ADRs said so in prose while `react-19: >=19.0.0` and `vue-3: >=3.0.0` shipped unbounded. Scoped to engines only — a `component-driver-*`'s open framework floor is deliberate (DEP-PIN-02 governs that axis). |
| **PEER-04** | a range the checker cannot parse. Reported, never skipped — an unverified range must not read as a verified one. |

### Two live defects it found on its first run

- **`internal-test-runner-playwright-adapter`** peered `@playwright/test: >=1.50.0` while depending on `@atomic-testing/playwright`, which peers `>=1.50.0 <2.0.0`. Not in the audit's list; the gate found it unprompted.
- **`react-18`** declared `@testing-library/react` as both a dependency and a peer. It is a four-line re-export that never imports it — `react-core` holds the ratified hard dependency, and `react-19` already had the peer-only shape. The lockfile diff confirms no tree change: same resolved `16.3.2`, now reached through the peer.

### Also

ADR-006 §3, `README.md` and `CLAUDE.md` all quoted Node `>=22.12` against a root `engines` of `>=22.13` — and ADR-006 cited that file by name while misquoting it. Corrected in all three.

## What this does not claim

Coherence is not resolvability, and §3 now says so plainly: this proves the declared ranges don't contradict each other, never that a consumer pinned *at* a floor gets a working tree.

`resolution-mode=lowest-direct` does not close that gap — it lowers a project's *direct* dependencies, while these libraries arrive as peers satisfied by caret-pinned devDependencies, so it resolves the same newest-satisfying tree and yields a green job that exercised nothing. (ADR-006 already made this argument; the change keeps it and adds what the static gate does cover.) A purpose-built floor fixture stays tracked as the remaining step.

## Verification

Every rule is one the repo has already broken, so none was trusted green until it was shown to fire. Each historical manifest was reintroduced and the gate confirmed to reject it:

| Reintroduced defect | Result |
| --- | --- |
| `react-19` `@testing-library/dom: >=10.2.0` | PEER-01, naming `10.2.0` as the consumer version that slips through |
| `react-19` `react: >=19.0.0` | PEER-03 |
| `vue-3` `vue: >=3.0.0` | PEER-03 |
| `react-18` `@testing-library/react` as dep+peer | PEER-02 |
| an unreadable range (`vue: latest`) | PEER-04 |

## Checks

- [x] `pnpm run check:type` — 0 errors, and all 38 packages carry the script (no silent skips)
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm check:peer-floors` / `check:deps-pinning` / `check:absence` / `check:manifests` / `check:api`
- [x] `pnpm --filter @atomic-testing/react-18 build` + `check:api` after the dependency removal
- [ ] `pnpm test:dom` / `test:e2e` — no source changes; manifests, one new script, and docs only

## Breaking change

- [ ] No. `react-18` still resolves `@testing-library/react@16.3.2` (via `react-core`'s ratified hard dependency); the playwright-adapter ceiling excludes a major that does not exist.

## Notes for review

- **This conflicts with #1297's B13 PR** in `package.json` and `.github/workflows/buildui.yml` — both add a script and a CI step at the same anchor. I merged all three branches locally and verified the combination: the resolution is to keep both lines, and every gate, `check:type` and `check:api` pass on the merged result.
- Surfaced, not fixed: `pnpm check:style` (oxfmt) now reformats markdown tables, contradicting CLAUDE.md's "`.md`/`.mdx`/`.css`/`.yaml` left as-is" — running the documented command produces ~120 lines of unrelated churn. I reverted all of it. Worth either correcting the doc or adding `.md` to `.oxfmtignore`; I didn't pick one unilaterally.
- Also surfaced: `@angular/core@20` wants `zone.js@~0.15.0` while the angular packages peer `>=0.15.0` and devDepend `^0.16.2`, so `pnpm install` reports an unmet peer. Same bug family, but between our range and a *third-party* peer, which this gate does not read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A)_