### PR TITLE
docs(freeze): make the frozen package set one answer, and keep it that way

### DIFF
--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -493,6 +493,13 @@ jobs:
       - name: Frozen-set agreement check
         run: pnpm check:frozen-set
 
+      # The gates' own detection tests. A check that only ever runs against a
+      # reconciled tree proves it executed, not that it can still SEE the drift it
+      # was written for — so each rule carries a fixture reintroducing the original
+      # disagreement, including B13 exactly as filed.
+      - name: Gate detection tests
+        run: pnpm test:scripts
+
       - name: Run unit tests
         run: pnpm test:dom
         working-directory: ./packages/create-atomic-testing

--- a/.github/workflows/buildui.yml
+++ b/.github/workflows/buildui.yml
@@ -484,6 +484,15 @@ jobs:
       - name: Absence-convention check
         run: pnpm check:absence
 
+      # Frozen-set agreement gate (FROZEN-*): the 1.0 frozen package set was
+      # defined three different ways at once — ADR-006 §1 and the root README named
+      # 9, `check:api` gated 14, and 10 package READMEs promised stability. Each
+      # definition lived somewhere different and nothing compared them. ADR-006 §1's
+      # marked list is now the source of truth and this fails the build when the
+      # gate, the committed reports or any README disagrees with it.
+      - name: Frozen-set agreement check
+        run: pnpm check:frozen-set
+
       - name: Run unit tests
         run: pnpm test:dom
         working-directory: ./packages/create-atomic-testing

--- a/README.md
+++ b/README.md
@@ -30,13 +30,21 @@ including but not limited to:
 
 ## Stability & version support policy
 
-The stable public API is the `.` barrel exports of the in-scope packages —
+The stable public API is the `.` barrel exports of the in-scope packages:
+
+<!-- frozen-set:start -->
+
 `core`, `dom-core`, `react-core`, `react-18`, `react-19`, `react-legacy`,
-`vue-3`, `playwright`, and `component-driver-html`. That surface is frozen under
-SemVer, machine-checked by a committed [API Extractor](https://api-extractor.com/)
-report per package (`etc/<package>.api.md`), and governed by a documented
-deprecation lifecycle. Anything else — every `@atomic-testing/internal-*` package
-and every export tagged `@internal` — is not covered by the guarantee.
+`vue-3`, `angular-core`, `angular-20`, `angular-21`, `angular-22`, `playwright`,
+`storybook`, and `component-driver-html`.
+
+<!-- frozen-set:end -->
+
+That surface is frozen under SemVer, machine-checked by a committed
+[API Extractor](https://api-extractor.com/) report per package
+(`etc/<package>.api.md`), and governed by a documented deprecation lifecycle.
+Anything else — every `@atomic-testing/internal-*` package and every export
+tagged `@internal` — is not covered by the guarantee.
 Full policy, including the framework/Playwright/Node support matrix:
 [ADR-006](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).
 

--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -89,6 +89,12 @@ acquires a gate without being declared here. Adding a package to the freeze is
 therefore one edit plus whatever the gate then demands, and prose and enforcement
 can no longer drift apart silently.
 
+Since a gate that only ever runs against a reconciled tree repeats B13's mistake
+one level up — looking authoritative while nothing checks it — each rule carries a
+fixture in [`scripts/check-frozen-set.test.mjs`](../../scripts/check-frozen-set.test.mjs)
+that reintroduces the drift it was written for, B13 as filed included. Those run in
+CI (`pnpm test:scripts`).
+
 Incidental exports are **demoted, not removed** (removal would itself be the
 breaking change the freeze exists to prevent): they keep their current names but
 carry an `@internal` TSDoc tag, which the report records. The first demotions are

--- a/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
+++ b/agent-docs/adr/006-1.0-api-freeze-and-evolution.md
@@ -33,12 +33,36 @@ freeze forces them to be made on purpose rather than inherited by accident.
 The stable 1.0 API is **exactly the `.` barrel exports of the in-scope packages**,
 and nothing else:
 
-`core`, `dom-core`, `react-core`, `react-18`, `react-19`, `react-legacy`, `vue-3`,
-`playwright`, `component-driver-html`.
+<!-- frozen-set:start -->
+
+`core`, `dom-core`, `react-core`, `react-18`, `react-19`, `react-legacy`,
+`vue-3`, `angular-core`, `angular-20`, `angular-21`, `angular-22`, `playwright`,
+`storybook`, `component-driver-html`.
+
+<!-- frozen-set:end -->
 
 Everything else — every `@atomic-testing/internal-*` package, every non-`.`
 import path, and every export tagged `@internal` — is **not** covered by the 1.0
 guarantee and may change in any release.
+
+**The Angular and Storybook adapters are in.** This list named nine packages
+while `check:api` gated fourteen: the four Angular packages and `storybook` each
+commit an `etc/*.api.md` that every pull request enforces, and `storybook`'s
+README already promised a surface "frozen under SemVer" and linked here. So a
+consumer could not tell whether `angular-core`'s `createTestEngine` was covered —
+the Hyrum's-Law accident this ADR exists to prevent, reintroduced by the ADR going
+stale against the gate it created. Ratifying the gate's answer is both the smaller
+change and the safer one: these packages ship, carry bounded peer ranges, and are
+documented, so by this ADR's own premise their surfaces become de-facto contracts
+at the tag whether or not this list names them. Deleting five working gates to
+keep the list short would trade real verification for tidiness.
+
+The behavioral caveat below applies to them with more force than to the rest:
+`angular-core` ships the library's only **async** `createTestEngine`
+([ADR-013](013-angular-shared-core-thin-packages.md)), and no conformance leg
+exercises any Angular or Storybook interactor. What is frozen for them is a
+signature, not a behavior. That is a conformance-coverage gap to close, not a
+reason to leave a shipped surface undeclared.
 
 The published MUI and Astryx driver packages (`component-driver-mui-*`,
 `component-driver-mui-x-*`, `component-driver-astryx`) are deliberately **out of
@@ -53,6 +77,17 @@ package's exported surface drifts from its committed report. Adding, removing, o
 changing the signature of any export is therefore a visible, reviewed diff — the
 report **is** the contract. Regenerate intentionally with `api-extractor run
 --local` per package (or after a `pnpm -r build`).
+
+Because that list had already drifted from the gate once, the two are now checked
+against each other. `check:frozen-set` (FROZEN-01…05,
+[`scripts/check-frozen-set.mjs`](../../scripts/check-frozen-set.mjs)) treats the
+marked list above as the single source of truth and fails the build when the
+packages carrying a `check:api` script, the committed `etc/*.api.md` reports, the
+package READMEs promising a frozen surface, or the root README's restatement of
+the list disagree with it in either direction — including a package that quietly
+acquires a gate without being declared here. Adding a package to the freeze is
+therefore one edit plus whatever the gate then demands, and prose and enforcement
+can no longer drift apart silently.
 
 Incidental exports are **demoted, not removed** (removal would itself be the
 breaking change the freeze exists to prevent): they keep their current names but

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "bumpVersion": "node scripts/bumpVersion.js",
     "changelog": "node scripts/generateChangelog.js",
     "triage:dependabot": "tsx scripts/triage-dependabot-prs.ts",
-    "check:absence": "node scripts/check-absence-convention.mjs"
+    "check:absence": "node scripts/check-absence-convention.mjs",
+    "check:frozen-set": "node scripts/check-frozen-set.mjs"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:skill-sync": "node scripts/skills/check-skill-sync.mjs",
     "gen:skill-content": "node scripts/skills/gen-skill-content.mjs",
     "test:skills": "node --test scripts/skills/*.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "typedoc": "typedoc --out typedocs",
     "bumpVersion": "node scripts/bumpVersion.js",
     "changelog": "node scripts/generateChangelog.js",

--- a/packages/angular-20/README.md
+++ b/packages/angular-20/README.md
@@ -49,3 +49,10 @@ it('increments', async () => {
 Interactions settle through `ApplicationRef.whenStable()`, so the same test
 passes whether the application under test runs zone-based or zoneless change
 detection.
+
+## Public API & stability
+
+The stable surface of this package is its `.` barrel exports, frozen under
+SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
+report at [`etc/angular-20.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/angular-20/etc/angular-20.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/angular-21/README.md
+++ b/packages/angular-21/README.md
@@ -49,3 +49,10 @@ it('increments', async () => {
 Interactions settle through `ApplicationRef.whenStable()`, so the same test
 passes whether the application under test runs zone-based or zoneless change
 detection.
+
+## Public API & stability
+
+The stable surface of this package is its `.` barrel exports, frozen under
+SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
+report at [`etc/angular-21.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/angular-21/etc/angular-21.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/angular-22/README.md
+++ b/packages/angular-22/README.md
@@ -49,3 +49,10 @@ it('increments', async () => {
 Interactions settle through `ApplicationRef.whenStable()`, so the same test
 passes whether the application under test runs zone-based or zoneless change
 detection.
+
+## Public API & stability
+
+The stable surface of this package is its `.` barrel exports, frozen under
+SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
+report at [`etc/angular-22.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/angular-22/etc/angular-22.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/packages/angular-core/README.md
+++ b/packages/angular-core/README.md
@@ -33,3 +33,10 @@ rationale.
 See the per-major package READMEs, or the validation fixture in
 `package-tests/angular-20-test` for a runnable example covering both zone.js
 and zoneless configurations.
+
+## Public API & stability
+
+The stable surface of this package is its `.` barrel exports, frozen under
+SemVer and machine-checked by the committed [API Extractor](https://api-extractor.com/)
+report at [`etc/angular-core.api.md`](https://github.com/atomic-testing/atomic-testing/blob/main/packages/angular-core/etc/angular-core.api.md). Exports tagged `@internal` are
+not part of that guarantee. See the [1.0 API freeze & evolution policy](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/adr/006-1.0-api-freeze-and-evolution.md).

--- a/scripts/check-frozen-set.mjs
+++ b/scripts/check-frozen-set.mjs
@@ -36,7 +36,7 @@
 // Dependency-free Node ESM, modelled on scripts/check-dependency-pinning.mjs.
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packagesDir = resolve(repoRoot, 'packages');
@@ -44,138 +44,172 @@ const packagesDir = resolve(repoRoot, 'packages');
 const ADR_PATH = 'agent-docs/adr/006-1.0-api-freeze-and-evolution.md';
 const README_PATH = 'README.md';
 const STABILITY_HEADING = 'Public API & stability';
-
-const errors = [];
+// Anchored to a real ATX heading line, not a substring. A bare `includes()` would
+// be satisfied by the phrase appearing in prose, a link title, or a fenced code
+// block — so renaming the heading while leaving any mention behind would keep the
+// gate green while the promise a consumer actually reads had moved or vanished.
+const STABILITY_HEADING_LINE = /^#{1,6}[ \t]+Public API & stability[ \t]*$/m;
 
 /**
- * The package names inside the `frozen-set` marker block, in document order.
- * Returns null when the block is absent or names nothing — the caller turns that
- * into FROZEN-05 rather than an empty set, because an empty set would agree with
- * nothing and pass every comparison below.
+ * The package names inside a `frozen-set` marker block, in document order, or
+ * null when the block is absent or names nothing. Null rather than an empty set
+ * on purpose: an empty set agrees with everything and would pass every
+ * comparison below, which is the silent-success shape this gate exists to reject.
+ *
+ * Exported so the marker contract can be tested directly.
  */
-function readMarkedSet(relPath) {
-  const text = readFileSync(resolve(repoRoot, relPath), 'utf8');
+export function readMarkedSet(text) {
   const block = /<!--\s*frozen-set:start\s*-->([\s\S]*?)<!--\s*frozen-set:end\s*-->/.exec(text);
-  if (!block) {
-    errors.push(
-      `FROZEN-05: ${relPath} has no <!-- frozen-set:start --> … <!-- frozen-set:end --> block. ` +
-        `The frozen package set is declared between those markers so this check can read it; ` +
-        `restore them around the list rather than removing them.`
-    );
-    return null;
-  }
+  if (!block) return null;
   const names = [...block[1].matchAll(/`([^`]+)`/g)].map(match => match[1]);
-  if (names.length === 0) {
-    errors.push(`FROZEN-05: ${relPath}'s frozen-set block is empty. An empty set silently agrees with everything.`);
-    return null;
-  }
-  return names;
+  return names.length === 0 ? null : names;
 }
 
-const declared = readMarkedSet(ADR_PATH);
-const readmeDeclared = readMarkedSet(README_PATH);
-if (declared == null) {
-  console.error(`[frozen-set] ${errors.length} problem(s):`);
-  for (const error of errors) console.error(`  - ${error}`);
-  process.exit(1);
-}
-
-const declaredSet = new Set(declared);
-const packageDirs = new Set(readdirSync(packagesDir).filter(dir => existsSync(join(packagesDir, dir, 'package.json'))));
-
-for (const name of declared) {
-  if (!packageDirs.has(name)) {
-    errors.push(`FROZEN-05: ${ADR_PATH} declares "${name}" frozen, but packages/${name} does not exist.`);
-  }
-}
-
-/** Observe a fact about the tree, as the set of package directories exhibiting it. */
-function observe(predicate) {
-  return new Set([...packageDirs].filter(predicate));
-}
-
-const hasApiScript = observe(dir => {
-  const manifestPath = join(packagesDir, dir, 'package.json');
-  try {
-    return 'check:api' in (JSON.parse(readFileSync(manifestPath, 'utf8')).scripts ?? {});
-  } catch {
-    return false;
-  }
-});
-
-const hasApiReport = observe(dir => existsSync(join(packagesDir, dir, 'etc', `${dir}.api.md`)));
-
-const hasStabilitySection = observe(dir => {
-  const readmePath = join(packagesDir, dir, 'README.md');
-  return existsSync(readmePath) && readFileSync(readmePath, 'utf8').includes(STABILITY_HEADING);
-});
+/** Does this README carry a real "Public API & stability" heading? */
+export const promisesStability = readme => STABILITY_HEADING_LINE.test(readme);
 
 /**
- * Compare an observed set against the declaration, reporting each direction with
- * its own consequence — "declared but not gated" and "gated but not declared" are
- * different bugs and the second is the one B13 actually found.
+ * Decide the verdict from already-gathered facts, so the rules can be exercised
+ * against hand-built inputs — see check-frozen-set.test.mjs, which reintroduces
+ * each drift direction and asserts the matching rule fires. A gate nothing ever
+ * proves can DETECT is only evidence that it ran.
+ *
+ * @param facts.declared        names in ADR-006 §1's marker block (null if unreadable)
+ * @param facts.readmeDeclared  names in the root README's marker block (null if unreadable)
+ * @param facts.packageDirs     every directory under packages/
+ * @param facts.hasApiScript    dirs whose manifest declares a `check:api` script
+ * @param facts.hasApiReport    dirs with a committed etc/<name>.api.md
+ * @param facts.hasStabilitySection  dirs whose README promises a frozen surface
  */
-function requireAgreement(rule, observed, { missing, extra }) {
-  for (const name of declared) {
-    if (!observed.has(name) && packageDirs.has(name)) errors.push(`${rule}: ${missing(name)}`);
-  }
-  for (const name of [...observed].sort()) {
-    if (!declaredSet.has(name)) errors.push(`${rule}: ${extra(name)}`);
-  }
-}
+export function evaluate(facts) {
+  const { declared, readmeDeclared, packageDirs, hasApiScript, hasApiReport, hasStabilitySection } = facts;
+  const errors = [];
 
-requireAgreement('FROZEN-01', hasApiScript, {
-  missing: name =>
-    `${name} is declared frozen in ${ADR_PATH} but has no "check:api" script, so nothing enforces ` +
-    `its surface — the freeze is a promise no gate keeps. Add the script and commit an API report.`,
-  extra: name =>
-    `packages/${name} runs "check:api" and commits an API report, but ${ADR_PATH} does not declare ` +
-    `it frozen. Either add it to the marked list (and give its README the stability section), or ` +
-    `remove the gate — a defended surface the contract never mentions is exactly the ambiguity ` +
-    `B13 was filed about.`,
-});
-
-requireAgreement('FROZEN-02', hasApiReport, {
-  missing: name =>
-    `${name} is declared frozen but has no packages/${name}/etc/${name}.api.md, so there is no ` +
-    `committed record of the surface being frozen. Generate it with \`api-extractor run --local\`.`,
-  extra: name =>
-    `packages/${name}/etc/${name}.api.md exists but ${name} is not declared frozen. Declare it or ` +
-    `delete the stale report.`,
-});
-
-requireAgreement('FROZEN-03', hasStabilitySection, {
-  missing: name =>
-    `${name} is declared frozen but its README has no "${STABILITY_HEADING}" section. Consumers read ` +
-    `the README that ships to npm, not this repo's ADRs.`,
-  extra: name =>
-    `packages/${name}/README.md promises a stable surface under "${STABILITY_HEADING}", but ${name} ` +
-    `is not declared frozen in ${ADR_PATH}. That README ships to npm, so it is the copy a consumer ` +
-    `will rely on — make it true or remove the claim.`,
-});
-
-// FROZEN-04 — the root README restates the list for readers who never open an
-// ADR, which makes it a fourth place to drift.
-if (readmeDeclared != null) {
-  const onlyInAdr = declared.filter(name => !readmeDeclared.includes(name));
-  const onlyInReadme = readmeDeclared.filter(name => !declaredSet.has(name));
-  if (onlyInAdr.length > 0 || onlyInReadme.length > 0) {
+  if (declared == null) {
     errors.push(
-      `FROZEN-04: ${README_PATH}'s frozen-set list disagrees with ${ADR_PATH}'s` +
-        (onlyInAdr.length > 0 ? ` — missing ${onlyInAdr.join(', ')}` : '') +
-        (onlyInReadme.length > 0 ? ` — extra ${onlyInReadme.join(', ')}` : '') +
-        `. The ADR is the source of truth; update the README to match.`
+      `FROZEN-05: ${ADR_PATH} has no readable <!-- frozen-set:start --> … <!-- frozen-set:end --> block. ` +
+        `The frozen package set is declared between those markers so this check can read it; ` +
+        `restore them around a non-empty list rather than removing them.`
+    );
+    return errors;
+  }
+  if (readmeDeclared == null) {
+    errors.push(
+      `FROZEN-05: ${README_PATH} has no readable <!-- frozen-set:start --> … <!-- frozen-set:end --> block. ` +
+        `The frozen package set is declared between those markers so this check can read it; ` +
+        `restore them around a non-empty list rather than removing them.`
     );
   }
+
+  const declaredSet = new Set(declared);
+
+  for (const name of declared) {
+    if (!packageDirs.has(name)) {
+      errors.push(`FROZEN-05: ${ADR_PATH} declares "${name}" frozen, but packages/${name} does not exist.`);
+    }
+  }
+
+  /**
+   * Compare an observed set against the declaration, reporting each direction with
+   * its own consequence — "declared but not gated" and "gated but not declared" are
+   * different bugs and the second is the one B13 actually found.
+   */
+  function requireAgreement(rule, observed, { missing, extra }) {
+    for (const name of declared) {
+      if (!observed.has(name) && packageDirs.has(name)) errors.push(`${rule}: ${missing(name)}`);
+    }
+    for (const name of [...observed].sort()) {
+      if (!declaredSet.has(name)) errors.push(`${rule}: ${extra(name)}`);
+    }
+  }
+
+  requireAgreement('FROZEN-01', hasApiScript, {
+    missing: name =>
+      `${name} is declared frozen in ${ADR_PATH} but has no "check:api" script, so nothing enforces ` +
+      `its surface — the freeze is a promise no gate keeps. Add the script and commit an API report.`,
+    extra: name =>
+      `packages/${name} runs "check:api" and commits an API report, but ${ADR_PATH} does not declare ` +
+      `it frozen. Either add it to the marked list (and give its README the stability section), or ` +
+      `remove the gate — a defended surface the contract never mentions is exactly the ambiguity ` +
+      `B13 was filed about.`,
+  });
+
+  requireAgreement('FROZEN-02', hasApiReport, {
+    missing: name =>
+      `${name} is declared frozen but has no packages/${name}/etc/${name}.api.md, so there is no ` +
+      `committed record of the surface being frozen. Generate it with \`api-extractor run --local\`.`,
+    extra: name =>
+      `packages/${name}/etc/${name}.api.md exists but ${name} is not declared frozen. Declare it or ` +
+      `delete the stale report.`,
+  });
+
+  requireAgreement('FROZEN-03', hasStabilitySection, {
+    missing: name =>
+      `${name} is declared frozen but its README has no "${STABILITY_HEADING}" section. Consumers read ` +
+      `the README that ships to npm, not this repo's ADRs.`,
+    extra: name =>
+      `packages/${name}/README.md promises a stable surface under "${STABILITY_HEADING}", but ${name} ` +
+      `is not declared frozen in ${ADR_PATH}. That README ships to npm, so it is the copy a consumer ` +
+      `will rely on — make it true or remove the claim.`,
+  });
+
+  // FROZEN-04 — the root README restates the list for readers who never open an
+  // ADR, which makes it a fourth place to drift.
+  if (readmeDeclared != null) {
+    const onlyInAdr = declared.filter(name => !readmeDeclared.includes(name));
+    const onlyInReadme = readmeDeclared.filter(name => !declaredSet.has(name));
+    if (onlyInAdr.length > 0 || onlyInReadme.length > 0) {
+      errors.push(
+        `FROZEN-04: ${README_PATH}'s frozen-set list disagrees with ${ADR_PATH}'s` +
+          (onlyInAdr.length > 0 ? ` — missing ${onlyInAdr.join(', ')}` : '') +
+          (onlyInReadme.length > 0 ? ` — extra ${onlyInReadme.join(', ')}` : '') +
+          `. The ADR is the source of truth; update the README to match.`
+      );
+    }
+  }
+
+  return errors;
 }
 
-if (errors.length > 0) {
-  console.error(`[frozen-set] ${errors.length} problem(s):`);
-  for (const error of errors) console.error(`  - ${error}`);
-  process.exit(1);
+/** Gather every fact `evaluate` needs by reading the working tree. */
+function gatherFacts() {
+  const read = relPath => readFileSync(resolve(repoRoot, relPath), 'utf8');
+  const packageDirs = new Set(
+    readdirSync(packagesDir).filter(dir => existsSync(join(packagesDir, dir, 'package.json')))
+  );
+  const observe = predicate => new Set([...packageDirs].filter(predicate));
+
+  return {
+    declared: readMarkedSet(read(ADR_PATH)),
+    readmeDeclared: readMarkedSet(read(README_PATH)),
+    packageDirs,
+    hasApiScript: observe(dir => {
+      try {
+        return 'check:api' in (JSON.parse(readFileSync(join(packagesDir, dir, 'package.json'), 'utf8')).scripts ?? {});
+      } catch {
+        return false;
+      }
+    }),
+    hasApiReport: observe(dir => existsSync(join(packagesDir, dir, 'etc', `${dir}.api.md`))),
+    hasStabilitySection: observe(dir => {
+      const readmePath = join(packagesDir, dir, 'README.md');
+      return existsSync(readmePath) && promisesStability(readFileSync(readmePath, 'utf8'));
+    }),
+  };
 }
 
-process.stdout.write(
-  `[frozen-set] OK — ${declared.length} package(s) declared frozen in ADR-006 §1; the API gate, the ` +
-    `committed reports, the package READMEs and the root README all name the same set.\n`
-);
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  const facts = gatherFacts();
+  const errors = evaluate(facts);
+
+  if (errors.length > 0) {
+    console.error(`[frozen-set] ${errors.length} problem(s):`);
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `[frozen-set] OK — ${facts.declared.length} package(s) declared frozen in ADR-006 §1; the API gate, ` +
+      `the committed reports, the package READMEs and the root README all name the same set.\n`
+  );
+}

--- a/scripts/check-frozen-set.mjs
+++ b/scripts/check-frozen-set.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Frozen-set agreement gate (FROZEN-*). Fails CI when the packages ADR-006 §1
+// declares frozen, the packages CI actually gates, and the packages whose READMEs
+// promise a frozen surface stop being the same set.
+//
+// The 1.0 readiness audit (#1297, B13) found "the frozen set" defined three
+// different ways at once: ADR-006 §1 and the root README named 9 packages,
+// `check:api` gated 14 (adding angular-20/21/22, angular-core and storybook, each
+// with a committed etc/*.api.md enforced on every PR), and 10 package READMEs
+// promised stability. Nothing was broken — a committed API report is a review
+// artifact, so the asymmetry pointed the safe way — but a consumer could not tell
+// whether `angular-core`'s async `createTestEngine` was covered by SemVer, and at
+// a 1.0 tag an ambiguity resolves itself into a promise nobody decided to make.
+//
+// The failure mode is specifically SILENT drift: each of the three definitions
+// lives somewhere different, all three look authoritative, and nothing ever
+// compared them. ADR-006 §1's marked list is now the single source of truth and
+// the other three are derived facts checked against it.
+//
+// FROZEN-01  the set with a `check:api` script differs from the declared set —
+//            in EITHER direction. A declared package that is not gated is an
+//            unenforced promise; a gated package that is not declared is the
+//            original B13 bug, a surface the repo defends without admitting it
+//            has.
+// FROZEN-02  a declared package has no committed etc/<name>.api.md, so nothing
+//            records what its surface currently is.
+// FROZEN-03  the set whose READMEs carry a "Public API & stability" section
+//            differs from the declared set. A consumer reads the README, not the
+//            ADR — an undeclared package making the promise is the more dangerous
+//            direction, because it is the copy that reaches npm.
+// FROZEN-04  the root README's own list disagrees with the ADR's.
+// FROZEN-05  a marker block is missing, empty, or names a package that does not
+//            exist. Checked explicitly so a reworded document fails loudly rather
+//            than quietly matching nothing and reporting success.
+//
+// Dependency-free Node ESM, modelled on scripts/check-dependency-pinning.mjs.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = resolve(repoRoot, 'packages');
+
+const ADR_PATH = 'agent-docs/adr/006-1.0-api-freeze-and-evolution.md';
+const README_PATH = 'README.md';
+const STABILITY_HEADING = 'Public API & stability';
+
+const errors = [];
+
+/**
+ * The package names inside the `frozen-set` marker block, in document order.
+ * Returns null when the block is absent or names nothing — the caller turns that
+ * into FROZEN-05 rather than an empty set, because an empty set would agree with
+ * nothing and pass every comparison below.
+ */
+function readMarkedSet(relPath) {
+  const text = readFileSync(resolve(repoRoot, relPath), 'utf8');
+  const block = /<!--\s*frozen-set:start\s*-->([\s\S]*?)<!--\s*frozen-set:end\s*-->/.exec(text);
+  if (!block) {
+    errors.push(
+      `FROZEN-05: ${relPath} has no <!-- frozen-set:start --> … <!-- frozen-set:end --> block. ` +
+        `The frozen package set is declared between those markers so this check can read it; ` +
+        `restore them around the list rather than removing them.`
+    );
+    return null;
+  }
+  const names = [...block[1].matchAll(/`([^`]+)`/g)].map(match => match[1]);
+  if (names.length === 0) {
+    errors.push(`FROZEN-05: ${relPath}'s frozen-set block is empty. An empty set silently agrees with everything.`);
+    return null;
+  }
+  return names;
+}
+
+const declared = readMarkedSet(ADR_PATH);
+const readmeDeclared = readMarkedSet(README_PATH);
+if (declared == null) {
+  console.error(`[frozen-set] ${errors.length} problem(s):`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+const declaredSet = new Set(declared);
+const packageDirs = new Set(readdirSync(packagesDir).filter(dir => existsSync(join(packagesDir, dir, 'package.json'))));
+
+for (const name of declared) {
+  if (!packageDirs.has(name)) {
+    errors.push(`FROZEN-05: ${ADR_PATH} declares "${name}" frozen, but packages/${name} does not exist.`);
+  }
+}
+
+/** Observe a fact about the tree, as the set of package directories exhibiting it. */
+function observe(predicate) {
+  return new Set([...packageDirs].filter(predicate));
+}
+
+const hasApiScript = observe(dir => {
+  const manifestPath = join(packagesDir, dir, 'package.json');
+  try {
+    return 'check:api' in (JSON.parse(readFileSync(manifestPath, 'utf8')).scripts ?? {});
+  } catch {
+    return false;
+  }
+});
+
+const hasApiReport = observe(dir => existsSync(join(packagesDir, dir, 'etc', `${dir}.api.md`)));
+
+const hasStabilitySection = observe(dir => {
+  const readmePath = join(packagesDir, dir, 'README.md');
+  return existsSync(readmePath) && readFileSync(readmePath, 'utf8').includes(STABILITY_HEADING);
+});
+
+/**
+ * Compare an observed set against the declaration, reporting each direction with
+ * its own consequence — "declared but not gated" and "gated but not declared" are
+ * different bugs and the second is the one B13 actually found.
+ */
+function requireAgreement(rule, observed, { missing, extra }) {
+  for (const name of declared) {
+    if (!observed.has(name) && packageDirs.has(name)) errors.push(`${rule}: ${missing(name)}`);
+  }
+  for (const name of [...observed].sort()) {
+    if (!declaredSet.has(name)) errors.push(`${rule}: ${extra(name)}`);
+  }
+}
+
+requireAgreement('FROZEN-01', hasApiScript, {
+  missing: name =>
+    `${name} is declared frozen in ${ADR_PATH} but has no "check:api" script, so nothing enforces ` +
+    `its surface — the freeze is a promise no gate keeps. Add the script and commit an API report.`,
+  extra: name =>
+    `packages/${name} runs "check:api" and commits an API report, but ${ADR_PATH} does not declare ` +
+    `it frozen. Either add it to the marked list (and give its README the stability section), or ` +
+    `remove the gate — a defended surface the contract never mentions is exactly the ambiguity ` +
+    `B13 was filed about.`,
+});
+
+requireAgreement('FROZEN-02', hasApiReport, {
+  missing: name =>
+    `${name} is declared frozen but has no packages/${name}/etc/${name}.api.md, so there is no ` +
+    `committed record of the surface being frozen. Generate it with \`api-extractor run --local\`.`,
+  extra: name =>
+    `packages/${name}/etc/${name}.api.md exists but ${name} is not declared frozen. Declare it or ` +
+    `delete the stale report.`,
+});
+
+requireAgreement('FROZEN-03', hasStabilitySection, {
+  missing: name =>
+    `${name} is declared frozen but its README has no "${STABILITY_HEADING}" section. Consumers read ` +
+    `the README that ships to npm, not this repo's ADRs.`,
+  extra: name =>
+    `packages/${name}/README.md promises a stable surface under "${STABILITY_HEADING}", but ${name} ` +
+    `is not declared frozen in ${ADR_PATH}. That README ships to npm, so it is the copy a consumer ` +
+    `will rely on — make it true or remove the claim.`,
+});
+
+// FROZEN-04 — the root README restates the list for readers who never open an
+// ADR, which makes it a fourth place to drift.
+if (readmeDeclared != null) {
+  const onlyInAdr = declared.filter(name => !readmeDeclared.includes(name));
+  const onlyInReadme = readmeDeclared.filter(name => !declaredSet.has(name));
+  if (onlyInAdr.length > 0 || onlyInReadme.length > 0) {
+    errors.push(
+      `FROZEN-04: ${README_PATH}'s frozen-set list disagrees with ${ADR_PATH}'s` +
+        (onlyInAdr.length > 0 ? ` — missing ${onlyInAdr.join(', ')}` : '') +
+        (onlyInReadme.length > 0 ? ` — extra ${onlyInReadme.join(', ')}` : '') +
+        `. The ADR is the source of truth; update the README to match.`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`[frozen-set] ${errors.length} problem(s):`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[frozen-set] OK — ${declared.length} package(s) declared frozen in ADR-006 §1; the API gate, the ` +
+    `committed reports, the package READMEs and the root README all name the same set.\n`
+);

--- a/scripts/check-frozen-set.test.mjs
+++ b/scripts/check-frozen-set.test.mjs
@@ -1,0 +1,126 @@
+// Unit tests for the frozen-set agreement gate. Run with `node --test`.
+//
+// The point of these is DETECTION. B13 existed because three definitions of the
+// frozen set drifted apart while every one of them looked authoritative and
+// nothing compared them; a gate that only ever runs against a reconciled tree
+// repeats that mistake one level up. So each rule gets a fixture reintroducing
+// the drift it was written for, including B13 exactly as filed.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { evaluate, promisesStability, readMarkedSet } from './check-frozen-set.mjs';
+
+const ALL = ['core', 'dom-core', 'angular-core', 'storybook', 'component-driver-radix-v1'];
+const FROZEN = ['core', 'dom-core', 'angular-core', 'storybook'];
+
+/** Facts for a fully reconciled tree, with `overrides` applied on top. */
+function facts(overrides = {}) {
+  return {
+    declared: FROZEN,
+    readmeDeclared: FROZEN,
+    packageDirs: new Set(ALL),
+    hasApiScript: new Set(FROZEN),
+    hasApiReport: new Set(FROZEN),
+    hasStabilitySection: new Set(FROZEN),
+    ...overrides,
+  };
+}
+
+const codesOf = errors => errors.map(error => error.slice(0, 9));
+
+test('a reconciled tree produces no findings', () => {
+  assert.deepEqual(evaluate(facts()), []);
+});
+
+test('B13 as filed: the ADR names fewer packages than the gate defends', () => {
+  // The real shape — check:api gated angular-core and storybook while ADR-006 §1
+  // and the README named neither.
+  const errors = evaluate(facts({ declared: ['core', 'dom-core'], readmeDeclared: ['core', 'dom-core'] }));
+
+  // Every derived fact disagrees, and each says so in its own terms.
+  assert.ok(errors.some(error => error.startsWith('FROZEN-01') && error.includes('angular-core')));
+  assert.ok(errors.some(error => error.startsWith('FROZEN-02') && error.includes('storybook')));
+  assert.ok(errors.some(error => error.startsWith('FROZEN-03') && error.includes('storybook')));
+});
+
+test('FROZEN-01 fires in both directions', () => {
+  // A package quietly acquires a gate without being declared.
+  const undeclared = evaluate(facts({ hasApiScript: new Set([...FROZEN, 'component-driver-radix-v1']) }));
+  assert.equal(undeclared.length, 1);
+  assert.match(undeclared[0], /^FROZEN-01/);
+  assert.match(undeclared[0], /component-driver-radix-v1/);
+
+  // A declared package has no gate at all — an unenforced promise.
+  const ungated = evaluate(facts({ hasApiScript: new Set(['core', 'dom-core', 'angular-core']) }));
+  assert.deepEqual(codesOf(ungated), ['FROZEN-01']);
+  assert.match(ungated[0], /storybook is declared frozen .* no "check:api" script/);
+});
+
+test('FROZEN-02 fires on a declared package with no committed report', () => {
+  const errors = evaluate(facts({ hasApiReport: new Set(['core', 'dom-core', 'storybook']) }));
+
+  assert.deepEqual(codesOf(errors), ['FROZEN-02']);
+  assert.match(errors[0], /angular-core/);
+});
+
+test('FROZEN-03 fires when a declared package README drops its stability section', () => {
+  const errors = evaluate(facts({ hasStabilitySection: new Set(['core', 'dom-core', 'storybook']) }));
+
+  assert.deepEqual(codesOf(errors), ['FROZEN-03']);
+  assert.match(errors[0], /angular-core is declared frozen but its README/);
+});
+
+test('FROZEN-03 fires when an undeclared package README promises stability', () => {
+  // The more dangerous direction: that README is what ships to npm.
+  const errors = evaluate(facts({ hasStabilitySection: new Set([...FROZEN, 'component-driver-radix-v1']) }));
+
+  assert.deepEqual(codesOf(errors), ['FROZEN-03']);
+  assert.match(errors[0], /ships to npm/);
+});
+
+test('FROZEN-04 fires when the root README list falls behind the ADR', () => {
+  const errors = evaluate(facts({ readmeDeclared: ['core', 'dom-core', 'angular-core'] }));
+
+  assert.deepEqual(codesOf(errors), ['FROZEN-04']);
+  assert.match(errors[0], /missing storybook/);
+});
+
+test('FROZEN-05 fires on an unreadable marker block rather than passing', () => {
+  // A null declaration must not be read as "nothing is frozen, so everything
+  // agrees" — that is the silent success the whole gate exists to reject.
+  assert.deepEqual(codesOf(evaluate(facts({ declared: null }))), ['FROZEN-05']);
+  assert.deepEqual(codesOf(evaluate(facts({ readmeDeclared: null }))), ['FROZEN-05']);
+});
+
+test('FROZEN-05 fires when a declared package does not exist', () => {
+  const errors = evaluate(facts({ declared: [...FROZEN, 'react-99'] }));
+
+  assert.ok(errors.some(error => error.startsWith('FROZEN-05') && error.includes('react-99')));
+});
+
+test('readMarkedSet reads the block and rejects a missing or empty one', () => {
+  const document = [
+    'intro',
+    '<!-- frozen-set:start -->',
+    '',
+    '`core`, `dom-core`.',
+    '',
+    '<!-- frozen-set:end -->',
+  ].join('\n');
+  assert.deepEqual(readMarkedSet(document), ['core', 'dom-core']);
+
+  assert.equal(readMarkedSet('`core`, `dom-core` with no markers at all'), null);
+  assert.equal(readMarkedSet('<!-- frozen-set:start -->\n\n<!-- frozen-set:end -->'), null);
+});
+
+test('the stability promise is a heading, not any mention of the phrase', () => {
+  assert.equal(promisesStability('## Public API & stability\n\nFrozen under SemVer.'), true);
+  assert.equal(promisesStability('### Public API & stability'), true);
+
+  // The bug this replaced a substring check to fix: renaming the heading while
+  // leaving the phrase in prose, a link, or a code block used to keep the gate
+  // green even though the section a consumer reads had gone.
+  assert.equal(promisesStability('## API notes\n\nSee the Public API & stability policy in ADR-006.'), false);
+  assert.equal(promisesStability('```\nPublic API & stability\n```'), false);
+  assert.equal(promisesStability('A [Public API & stability](../adr/006.md) link.'), false);
+});


### PR DESCRIPTION
Closes the frozen-set ambiguity from the 1.0 readiness audit — #1297, **B13**.

## Summary

"The frozen set" was defined three different ways at once:

| Definition | Count |
| --- | --- |
| ADR-006 §1 and root `README.md` | **9** |
| packages with a `check:api` script + committed `etc/*.api.md`, enforced by `buildui.yml` | **14** — adding `angular-20/21/22`, `angular-core`, `storybook` |
| package READMEs with a "Public API & stability" section | **10** — the nine plus `storybook` |

Each lived somewhere different, all three read as authoritative, and nothing ever compared them.

Nothing was broken — a committed API report is a review artifact, not a promise, so the asymmetry pointed the safe way. But a consumer could not tell whether `angular-core`'s async `createTestEngine` or `StorybookInteractor` was covered by SemVer, and **at a tag, an ambiguity resolves itself into a promise nobody decided to make**.

## The decision: ratify 14, don't shrink the gate to 9

These five packages ship, carry bounded peer ranges, are documented, and are already gated on every PR — and `storybook`'s README *already* promised a surface "frozen under SemVer" and linked ADR-006. By ADR-006's own Hyrum's-Law premise their surfaces become de-facto contracts at the tag whether or not the list names them, so declaring them costs nothing that wasn't already owed.

The alternative — deleting five working gates so the prose could stay short — would trade real verification for tidiness, and would do it on the newest, least-exercised entry point in the library.

### Stated honestly, not quietly

ADR-006 now records the caveat alongside the addition: `angular-core` ships the only **async** `createTestEngine` (ADR-013) and **no conformance leg exercises any Angular or Storybook interactor**, so what is frozen for those five is a *signature*, not a *behavior*. That is a coverage gap to close, not a reason to leave a shipped surface undeclared.

## The gate

`check:frozen-set` (`scripts/check-frozen-set.mjs`) makes ADR-006 §1's marked list the single source of truth; the other definitions become derived facts checked against it, **in both directions**:

| Rule | Fails when |
| --- | --- |
| **FROZEN-01** | the `check:api` set differs from the declared set. A declared package without a gate is an unenforced promise; a **gated package that isn't declared** is the original B13 bug. |
| **FROZEN-02** | a declared package has no committed `etc/<name>.api.md`. |
| **FROZEN-03** | the set of READMEs carrying a stability section differs. The undeclared-but-promising direction matters more — that README is the copy that reaches npm. |
| **FROZEN-04** | the root README's restatement disagrees with the ADR. |
| **FROZEN-05** | a marker block is missing, empty, or names a nonexistent package — so a reworded document fails loudly instead of matching nothing and reporting success. |

## Changes

- ADR-006 §1: list goes to 14 inside `<!-- frozen-set:start/end -->` markers, plus the rationale and the behavioral caveat above.
- Root `README.md`: same list, same markers.
- `angular-20`, `angular-21`, `angular-22`, `angular-core` READMEs: the "Public API & stability" section the other ten already had.
- `scripts/check-frozen-set.mjs` + `pnpm check:frozen-set` + a `buildui.yml` step.

## Verification

Green on a consistent tree proves nothing about detection, so each drift direction was reintroduced and confirmed to fail:

| Reintroduced drift | Result |
| --- | --- |
| ADR back to 9 packages, gate still at 14 (**B13 exactly as filed**) | 16 problems across FROZEN-01/02/03 |
| `component-driver-radix-v1` silently acquires a `check:api` script | FROZEN-01, the undeclared-gate direction |
| an angular README loses its stability section | FROZEN-03 |
| root README list falls behind the ADR | FROZEN-04, naming `storybook` |
| ADR markers reworded away | FROZEN-05 |

## Checks

- [x] `pnpm run check:type` — 0 errors
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] `pnpm check:frozen-set` / `check:api` / `check:manifests` / `check:deps-pinning` / `check:absence`
- [ ] `pnpm test:dom` / `test:e2e` — no source changes; docs, one new script, and a CI step only

## Breaking change

- [ ] No code change. It does *widen a documented guarantee* — the five newly declared packages were already gated and already treated as stable by the CI that enforces them, so this ratifies existing enforcement rather than adding a new constraint.

## Notes for review

**This conflicts with #1383 (A4)** in `package.json` and `.github/workflows/buildui.yml` — both add a script and a CI step at the same anchor. I merged all three 1.0-readiness branches locally and verified the combination: the resolution is to keep both lines in each file, and every gate, `check:type` and `check:api` pass on the merged result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A)_