### PR TITLE
docs(quick-start): answer the existing-tests question instead of promising a guide

### DIFF
--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -339,4 +339,4 @@ Notice how the test logic is **identical across frameworks**:
 **"This seems like extra setup..."** → See [Why Atomic Testing?](./why-atomic-testing.mdx) for long-term benefits
 **"How do I install without the CLI?"** → See [Manual Installation](./manual-installation.mdx)
 **"How do I test complex forms?"** → Check out the [Step-by-Step Tutorial](./getting-started-tutorial.mdx)
-**"What about my existing tests?"** → We're working on a migration guide!
+**"What about my existing tests?"** → They keep working. Atomic Testing runs alongside your existing suite, so there's nothing to migrate — start with new tests, then convert the ones that break most often during refactors. See [gradual adoption](./why-atomic-testing.mdx#getting-started).

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -339,4 +339,4 @@ Notice how the test logic is **identical across frameworks**:
 **"This seems like extra setup..."** → See [Why Atomic Testing?](./why-atomic-testing.mdx) for long-term benefits
 **"How do I install without the CLI?"** → See [Manual Installation](./manual-installation.mdx)
 **"How do I test complex forms?"** → Check out the [Step-by-Step Tutorial](./getting-started-tutorial.mdx)
-**"What about my existing tests?"** → They keep working. Atomic Testing runs alongside your existing suite, so there's nothing to migrate — start with new tests, then convert the ones that break most often during refactors. See [gradual adoption](./why-atomic-testing.mdx#getting-started).
+**"What about my existing tests?"** → They keep working — nothing to migrate. See [gradual adoption](./why-atomic-testing.mdx#getting-started)


### PR DESCRIPTION
Closes the migration half of the 1.0 readiness audit — #1297, **B12**.

## Summary

The Quick Start FAQ answered *"What about my existing tests?"* with **"We're working on a migration guide!"** — the only consumer-facing mention of the subject anywhere in the repo, and a promise of a document that does not exist and is not planned.

No migration is needed, so the honest answer is the one the docs already give elsewhere: Atomic Testing runs alongside an existing suite. Nothing about adopting it requires converting what is already there — start with new tests, then convert the ones that break most often during refactors, which is exactly what `why-atomic-testing.mdx` says under "Getting started". This replaces a forward reference to vapour with a link to that.

An unfulfilled promise in a Quick Start is worse than no answer: a reader hitting the line concludes their question has a *pending* answer and waits for it, when the real answer is that the question does not arise.

## Scope

Deliberately one line. B12 as filed also proposed hand-writing `MIGRATING-1.0.md` and backfilling a pre-0.94 CHANGELOG section; both are dropped, since "no migration is needed" answers the item rather than deferring it. The audit's eight-item breaking-delta list remains on #961 for anyone who wants it as a record.

A repo-wide sweep confirms nothing else promises a guide. The other `migrat*` hits are all legitimate and untouched — ADR-005's MUI-5 rationale link, the React 17 "supported for gradual migration" note in `framework-guide.mdx`, and `why-atomic-testing.mdx`'s framework-migration benefit.

## Checks

- [x] `cd docs && pnpm build` — **the real gate here.** `onBrokenLinks: 'throw'`, and the new link and its `#getting-started` anchor both resolve; full Docusaurus + TypeDoc build succeeds.
- [x] `pnpm run check:style`
- [ ] `pnpm run check:type` / `check:lint` / `test:dom` / `test:e2e` — a single MDX prose line; no code, config, or type surface touched.

## Breaking change

- [ ] No.

## Notes for review

Independent of the other two 1.0-readiness PRs (#1383 A4, #1384 B13) — no shared files, no conflicts. Verified by merging all three locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xGbUjZw1kSst8VHQLB2A)_