### PR TITLE
chore(release): 0.102.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.102.0] - 2026-08-09
+
+### Breaking Changes
+
+- **drivers:** report lookup absence as Optional, not null, across every driver package ([#1381](https://github.com/atomic-testing/atomic-testing/issues/1381))
+- **core:** make list enumeration fail loudly instead of truncating silently ([#1380](https://github.com/atomic-testing/atomic-testing/issues/1380))
+
+### Fixes
+
+- **packaging:** gate the advertised peer ranges instead of declaring them ([#1383](https://github.com/atomic-testing/atomic-testing/issues/1383))
+- **ci:** collapse the dual-Vue instance and gate driver packages on execution ([#1379](https://github.com/atomic-testing/atomic-testing/issues/1379))
+
+### Documentation
+
+- **freeze:** make the frozen package set one answer, and keep it that way ([#1384](https://github.com/atomic-testing/atomic-testing/issues/1384))
+- **quick-start:** answer the existing-tests question instead of promising a guide ([#1385](https://github.com/atomic-testing/atomic-testing/issues/1385))
+
 ## [0.101.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/angular-20/package.json
+++ b/packages/angular-20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-20",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Angular 20 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 20 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-21/package.json
+++ b/packages/angular-21/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-21",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Angular 21 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 21 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-22/package.json
+++ b/packages/angular-22/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-22",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Angular 22 test adapter for Atomic Testing: bootstrap standalone components with Angular's real bootstrap API and test them through the component driver pattern. Thin re-export of @atomic-testing/angular-core pinned to the Angular 22 peer range.",
   "keywords": [
     "angular",

--- a/packages/angular-core/package.json
+++ b/packages/angular-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/angular-core",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Shared Angular adapter core for Atomic Testing: AngularInteractor plus the bootstrapApplication-based createTestEngine. Install the per-major package (@atomic-testing/angular-20/-21/-22) instead of depending on this directly.",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v20/package.json
+++ b/packages/component-driver-angular-material-v20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v20",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Angular Material v20",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v21/package.json
+++ b/packages/component-driver-angular-material-v21/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v21",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Angular Material v21",
   "keywords": [
     "angular",

--- a/packages/component-driver-angular-material-v22/package.json
+++ b/packages/component-driver-angular-material-v22/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-angular-material-v22",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Angular Material v22",
   "keywords": [
     "angular",

--- a/packages/component-driver-astryx/package.json
+++ b/packages/component-driver-astryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-astryx",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Astryx (@astryxdesign/core)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-fluent-v9/package.json
+++ b/packages/component-driver-fluent-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-fluent-v9",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Fluent UI v9 (\"Fluent 2\") React components (@fluentui/react-components)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-html",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "HTML component driver for atomic-testing",
   "keywords": [
     "e2e",

--- a/packages/component-driver-mui-v6/package.json
+++ b/packages/component-driver-mui-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v6",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-v7/package.json
+++ b/packages/component-driver-mui-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v7",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Material-UI v7",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-mui-v9/package.json
+++ b/packages/component-driver-mui-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-v9",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Material-UI v9",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-mui-x-v6/package.json
+++ b/packages/component-driver-mui-x-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v6",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Component driver to help drive Material UI V6 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v7/package.json
+++ b/packages/component-driver-mui-x-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v7",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V7 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v8/package.json
+++ b/packages/component-driver-mui-x-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v8",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V8 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-mui-x-v9/package.json
+++ b/packages/component-driver-mui-x-v9/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-mui-x-v9",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Component driver to help drive Material UI X V9 components",
   "keywords": [
     "integration",

--- a/packages/component-driver-primevue-v4/package.json
+++ b/packages/component-driver-primevue-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-primevue-v4",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for PrimeVue 4 components (Vue 3)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-radix-v1/package.json
+++ b/packages/component-driver-radix-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-radix-v1",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Radix UI primitives (radix-ui v1)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-reka-ui-v2/package.json
+++ b/packages/component-driver-reka-ui-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-reka-ui-v2",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for Reka UI primitives (reka-ui v2, Vue 3)",
   "license": "MIT",
   "repository": {

--- a/packages/component-driver-shadcn-v1/package.json
+++ b/packages/component-driver-shadcn-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/component-driver-shadcn-v1",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Component driver for shadcn/ui (re-export of the Radix UI v1 drivers)",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/core",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Core library for atomic-testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/create-atomic-testing/package.json
+++ b/packages/create-atomic-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-atomic-testing",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Scaffold Atomic Testing into an existing project — detects your framework, runner and package manager and writes a working, green example test.",
   "keywords": [
     "atomic-testing",

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/dom-core",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Core engine for HTML DOM testing",
   "keywords": [],
   "license": "MIT",

--- a/packages/internal-interactor-conformance/package.json
+++ b/packages/internal-interactor-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-interactor-conformance",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Interactor conformance suite (TCK) proving every interactor behaves identically; not for production use",
   "keywords": [],

--- a/packages/internal-mui-x-test-fixture/package.json
+++ b/packages/internal-mui-x-test-fixture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-mui-x-test-fixture",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "license": "MIT",
   "author": "Tianzhen Lin <tangent@usa.net>",

--- a/packages/internal-react-example/package.json
+++ b/packages/internal-react-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-react-example",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Shared example components for package tests",
   "license": "MIT",

--- a/packages/internal-test-runner-jest-adapter/package.json
+++ b/packages/internal-test-runner-jest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-jest-adapter",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Jest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner-playwright-adapter/package.json
+++ b/packages/internal-test-runner-playwright-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-playwright-adapter",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Playwright adapter for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/internal-test-runner-vitest-adapter/package.json
+++ b/packages/internal-test-runner-vitest-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner-vitest-adapter",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Vitest adapter for atomic-testing",
   "keywords": [],

--- a/packages/internal-test-runner/package.json
+++ b/packages/internal-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/internal-test-runner",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "private": true,
   "description": "Experimental test runner library aimed to normalize adapting same test code across different platform for atomic-testing, not for production use",
   "keywords": [],

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/playwright",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Atomic Testing Playwright Adapter",
   "keywords": [],
   "license": "MIT",

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-18",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-19/package.json
+++ b/packages/react-19/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-19",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "",
   "keywords": [
     "integration",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-core",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Shared utilities for Atomic Testing React adapters",
   "keywords": [
     "react",

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/react-legacy",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Adapter for testing React 17 and earlier",
   "keywords": [
     "legacy",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/storybook",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Framework-agnostic Storybook integration for atomic-testing component drivers",
   "keywords": [],
   "license": "MIT",

--- a/packages/vue-3/package.json
+++ b/packages/vue-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomic-testing/vue-3",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "The @atomic-testing/vue-3 package is a Vue 3 test adapter that extends Atomic Testing's component driver pattern to Vue applications. It enables testing Vue components using the same high-level semantic APIs used across React, Playwright, and DOM environments.",
   "keywords": [
     "integration",


### PR DESCRIPTION
## Summary

The release commit for **0.102.0**, missing from the first attempt.

`v0.102.0` was tagged straight on `main` — `005c88c46`, the #1383 merge — without [`RELEASING.md`](https://github.com/atomic-testing/atomic-testing/blob/main/agent-docs/RELEASING.md) steps 2–4 ever running, so no commit carried the version being released. `publish.yml`'s preflight rejected it in **14 seconds** ([run 31287685054](https://github.com/atomic-testing/atomic-testing/actions/runs/31287685054/job/93179382789)):

```
ERROR: packages/angular-20/package.json is at 0.101.0, but this release is 0.102.0.
… all 31 non-private packages …
ERROR: CHANGELOG.md's newest section is '## [0.101.0] - 2026-08-05', expected '## [0.102.0]'.
The release PR for 0.102.0 was not merged, or the tag points at the wrong commit.
```

**Nothing reached npm.** `publish` sits behind `needs: [preflight, e2e-gate, verify]`, so all three downstream jobs recorded `skipped` at the same instant preflight failed; `publish.sh` never ran and every package is still `latest = 0.101.0` on the registry.

Worth recording that the guard behaved better than last time. The identical mistake on the first `v0.101.0` attempt ([run 31005366786](https://github.com/atomic-testing/atomic-testing/actions/runs/31005366786)) failed the *same* assertion from inside the `publish` job — after all 88 e2e-gate and verify jobs and ~25 minutes of matrix. The standalone `preflight` job that caught this one in 14 seconds was created by that recovery, in #1378. This is the first time the hoisted check has spoken.

### What this contains

`pnpm bumpVersion 0.102.0 && pnpm changelog 0.102.0` — nothing hand-edited.

- **38 manifests** to `0.102.0` (31 published + 7 `private` internal packages, bumped in lockstep as before).
- **`CHANGELOG.md`** — a purely additive `## [0.102.0]` section (+17 lines, 0 removals).

The changelog range is `v0.101.0..HEAD`, which is the same six PRs the existing GitHub Release notes credit: #1379, #1380, #1381, #1383, #1384, #1385. Two are breaking (#1380, #1381) and are filed as such.

> Local `v0.101.0` pointed at `f5251fa34d` — the *failed* 0.101.0 tag — because a plain `git fetch` never moves an existing local tag. Left uncorrected, `generateChangelog` would have used it as the baseline and pulled #1375 into this release's notes. Re-synced with `git fetch --tags --force` before generating; the section above is from the corrected baseline.

No `pnpm-lock.yaml` change: workspace packages resolve through `workspace:*`, and the lockfile contains **zero** occurrences of the released version, so `--frozen-lockfile` stays satisfied.

### After merge

Per RELEASING.md step 6, the tag has to name the reviewed commit. The existing `refs/tags/v0.102.0` points at `005c88c46` and Release `367345775` is **published and currently "Latest"**, so GitHub is advertising 0.102.0 while npm's newest is 0.101.0. Both need to be deleted and the Release recreated against this merge commit — RELEASING.md §"If a release fails" prefers exactly this fix-forward shape over re-firing a tag on "whatever main is".

A `workflow_dispatch` run cannot substitute: `INPUT_VERSION` only replaces tag parsing, and the assertion step still reads the checked-out tree.

## Checks

- [x] `pnpm run check:type` — exit 0
- [x] `pnpm run check:lint`
- [x] `pnpm run check:style`
- [x] Preflight simulated locally against the exact `publish.yml` bash — *"Tag, manifests and changelog all agree on 0.102.0."*
- [x] `check:manifests` (31 pkgs) / `check:deps-pinning` / `check:peer-floors` (38 pkgs, 30 shared ranges) / `check:frozen-set` (14 pkgs) / `check:absence` (732 files)
- [x] `pnpm test:scripts` 27/27 · `pnpm test:skills` 21/21
- [ ] `pnpm test:dom` / `test:e2e` — version strings and a generated changelog only, no source changes. Full CI runs here on the exact tree that will publish, which is the point of the release PR.

## Breaking change

- [ ] Not in this PR. The *release* carries two breaking changes (#1380, #1381), already merged and titled with `!`; this commit only records the version.

## Notes for review

- **Step 9 is overdue from the previous release.** `examples/*` and `docs/` still pin `^0.100.0` — the `pnpm bumpVersion X.Y.Z --consumers` follow-up was never done for 0.101.0. Deliberately not folded in here (those install the *published* packages, so floating them before 0.102.0 exists on the registry makes their jobs unresolvable), but it's worth doing as the step-9 PR once this publishes.
- **`pnpm check:style` still reformats markdown**, contradicting CLAUDE.md's "`.md`/`.mdx`/`.css`/`.yaml` left as-is" — running the documented command touched 9 unrelated files here. Reverted all of it, same as in #1383. Still worth either correcting the doc or adding `.md` to `.oxfmtignore`.
- Two releases running have now been tagged on a non-release commit. The guard catches it cheaply every time, so this may just be the cost of a manual ritual — but if it should be impossible rather than merely caught, the enforcement point is release *creation*, not the run that follows it.